### PR TITLE
Fix per-user Spotify token handling and stub playlist list data

### DIFF
--- a/apps/api/.sqlx/query-5a3fd16fc3a38e19096afb644b143898829a9094fe7abeee30f8a92bfae07429.json
+++ b/apps/api/.sqlx/query-5a3fd16fc3a38e19096afb644b143898829a9094fe7abeee30f8a92bfae07429.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        update spotify_account\n        set access_token = $1, refresh_token = $2, expires_at = $3, updated_at = now()\n        where account_id = $4\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5a3fd16fc3a38e19096afb644b143898829a9094fe7abeee30f8a92bfae07429"
+}

--- a/apps/api/.sqlx/query-faca286f2a97ca338a39ee6e2f830802c4d7c1b1f25e1a4f566cd641023b0dd1.json
+++ b/apps/api/.sqlx/query-faca286f2a97ca338a39ee6e2f830802c4d7c1b1f25e1a4f566cd641023b0dd1.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select access_token, refresh_token, expires_at\n        from spotify_account\n        where account_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "access_token",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "refresh_token",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "faca286f2a97ca338a39ee6e2f830802c4d7c1b1f25e1a4f566cd641023b0dd1"
+}

--- a/apps/api/src/auth.rs
+++ b/apps/api/src/auth.rs
@@ -290,6 +290,38 @@ impl UserTokenManager {
         Ok(tok.access_token)
     }
 
+    /// Exchange an arbitrary refresh token for a new access token.
+    ///
+    /// Unlike `get_token`, this doesn't read or write this manager's internal
+    /// single-slot cache — it's used to refresh a *specific* account's token
+    /// (loaded from the database) rather than "the" logged-in user's token.
+    pub async fn refresh_with(&self, refresh_token: &str) -> Result<TokenResponse, AppError> {
+        let body = format!(
+            "grant_type=refresh_token&refresh_token={}",
+            urlencoding(refresh_token),
+        );
+
+        let resp = self
+            .http
+            .post("https://accounts.spotify.com/api/token")
+            .header("Authorization", self.creds.basic_header())
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(AppError::SpotifyApi {
+                status,
+                message: text,
+            });
+        }
+
+        resp.json::<TokenResponse>().await.map_err(AppError::from)
+    }
+
     pub async fn is_authenticated(&self) -> bool {
         self.token.read().await.is_some()
     }

--- a/apps/api/src/spotify/client.rs
+++ b/apps/api/src/spotify/client.rs
@@ -140,6 +140,23 @@ pub struct SnapshotResponse {
     pub snapshot_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct PlaylistTracksInfo {
+    pub total: u32,
+}
+
+/// A subset of the full playlist object, requested via the Web API's
+/// `fields` filter so we don't pull down every track on every list refresh.
+#[derive(Debug, Deserialize)]
+pub struct PlaylistDetails {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub images: Vec<Image>,
+    pub external_urls: ExternalUrls,
+    pub tracks: PlaylistTracksInfo,
+}
+
 // -- Spotify error body -----------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -312,6 +329,18 @@ impl SpotifyClient {
         resp.json::<SnapshotResponse>()
             .await
             .map_err(AppError::from)
+    }
+
+    /// `GET /playlists/{playlist_id}` — non-deprecated.
+    /// Uses `fields` to fetch only what the "My Playlists" list needs.
+    pub async fn get_playlist(
+        &self,
+        token: &str,
+        playlist_id: &str,
+    ) -> Result<PlaylistDetails, AppError> {
+        let url =
+            format!("{BASE}/playlists/{playlist_id}?fields=id,name,images,external_urls,tracks.total");
+        self.get_json(token, &url).await
     }
 
     // -- Internal helpers ---------------------------------------------------

--- a/apps/api/src/spotify/spotify_handlers.rs
+++ b/apps/api/src/spotify/spotify_handlers.rs
@@ -136,10 +136,24 @@ pub struct PlaylistTrack {
     pub uri: String,
 }
 
+// ---------------------------------------------------------------------------
+// GET /playlist
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct PlaylistSummary {
+    pub id: String,
+    pub name: String,
+    pub external_url: Option<String>,
+    pub images: Vec<crate::spotify::client::Image>,
+    pub track_count: u32,
+    pub city: String,
+}
+
 pub async fn get_user_playlists(
     State(state): State<AppState>,
     jar: SignedCookieJar,
-) -> Result<Json<Vec<CreatePlaylistResponse>>, AppError> {
+) -> Result<Json<Vec<PlaylistSummary>>, AppError> {
     let cookie = jar.get("spotify_oauth_state").ok_or(AppError::Unauthorized {
         status: StatusCode::UNAUTHORIZED,
         message: "Unauthorized".into(),
@@ -155,7 +169,7 @@ pub async fn get_user_playlists(
             message: "Unauthorized user id".into(),
         });
     };
-    let playlists = get_playlists(&state.db.pool, account_id).await?;
+    let playlists = get_playlists(&state, account_id).await?;
     return Ok(playlists);
 }
 
@@ -187,7 +201,7 @@ pub async fn create_playlist(
             AppError::AuthRequired("Session expired or invalid. Visit /login first.".into())
         })?;
 
-    let user_token = state.user_manager.get_token().await?;
+    let user_token = get_valid_spotify_token(&state, account_id).await?;
     let cc_token = state.cc_manager.get_token().await?;
 
     let per_artist = req.tracks_per_artist.unwrap_or(3).min(10);
@@ -321,11 +335,10 @@ info!("query, {}, {}, {}, {}, {}", &query.end, &query.start, &query.longitude, &
 // GET /playlist
 
 pub async fn get_playlists(
-    db: &sqlx::PgPool,
+    state: &AppState,
     account_id: uuid::Uuid,
-) -> Result<Json<Vec<CreatePlaylistResponse>>, AppError> {
-    // Query the database for playlists associated with the user_id
-    let playlists = sqlx::query!(
+) -> Result<Json<Vec<PlaylistSummary>>, AppError> {
+    let rows = sqlx::query!(
         r#"
         SELECT provider_playlist_id, city
         FROM playlist
@@ -333,23 +346,43 @@ pub async fn get_playlists(
         "#,
         account_id
     )
-    .fetch_all(db)
+    .fetch_all(&state.db.pool)
     .await?;
 
-    let mut playlist_responses = Vec::new();
-
-    for playlist in playlists {
-        // Here you would typically call Spotify API to get more details about the playlist
-        // For simplicity, we will just return the playlist ID for now
-        playlist_responses.push(CreatePlaylistResponse {
-            playlist_id: playlist.provider_playlist_id,
-            playlist_url: None, // You would fetch this from Spotify API
-            track_count: 0,     // You would fetch this from Spotify API
-            tracks: vec![],     // You would fetch this from Spotify API
-        });
+    if rows.is_empty() {
+        return Ok(Json(vec![]));
     }
 
-    Ok(Json(playlist_responses))
+    let token = get_valid_spotify_token(state, account_id).await?;
+
+    let mut summaries = Vec::with_capacity(rows.len());
+    for row in rows {
+        match state
+            .spotify
+            .get_playlist(&token, &row.provider_playlist_id)
+            .await
+        {
+            Ok(details) => summaries.push(PlaylistSummary {
+                id: details.id,
+                name: details.name,
+                external_url: details.external_urls.spotify,
+                images: details.images,
+                track_count: details.tracks.total,
+                city: row.city,
+            }),
+            Err(err) => {
+                // A single playlist that's been deleted/renamed on Spotify's side
+                // (or a transient API error) shouldn't take down the whole list.
+                tracing::warn!(
+                    playlist_id = %row.provider_playlist_id,
+                    error = %err,
+                    "failed to fetch playlist details from Spotify, skipping"
+                );
+            }
+        }
+    }
+
+    Ok(Json(summaries))
 }
 
 // ---------------------------------------------------------------------------
@@ -530,6 +563,63 @@ async fn create_playlist_record(
     .await?;
 
     Ok(row.id)
+}
+
+struct SpotifyTokenRow {
+    access_token: String,
+    refresh_token: String,
+    expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Returns a valid Spotify access token for the given account, refreshing
+/// (and persisting the refresh) if the stored token has expired.
+///
+/// This looks the token up per-account rather than relying on
+/// `state.user_manager`'s single-slot in-memory cache, which only ever holds
+/// whichever user most recently completed the OAuth flow in this process.
+async fn get_valid_spotify_token(
+    state: &AppState,
+    account_id: uuid::Uuid,
+) -> Result<String, AppError> {
+    let row = sqlx::query_as!(
+        SpotifyTokenRow,
+        r#"
+        select access_token, refresh_token, expires_at
+        from spotify_account
+        where account_id = $1
+        "#,
+        account_id
+    )
+    .fetch_optional(&state.db.pool)
+    .await?
+    .ok_or_else(|| AppError::AuthRequired("Spotify not connected for this account.".into()))?;
+
+    if row.expires_at > Utc::now() + Duration::seconds(60) {
+        return Ok(row.access_token);
+    }
+
+    let refreshed = state.user_manager.refresh_with(&row.refresh_token).await?;
+    let new_refresh_token = refreshed
+        .refresh_token
+        .clone()
+        .unwrap_or(row.refresh_token);
+    let new_expires_at = Utc::now() + Duration::seconds(refreshed.expires_in as i64);
+
+    sqlx::query!(
+        r#"
+        update spotify_account
+        set access_token = $1, refresh_token = $2, expires_at = $3, updated_at = now()
+        where account_id = $4
+        "#,
+        refreshed.access_token,
+        new_refresh_token,
+        new_expires_at,
+        account_id
+    )
+    .execute(&state.db.pool)
+    .await?;
+
+    Ok(refreshed.access_token)
 }
 
 async fn resolve_session_account(


### PR DESCRIPTION
## Summary

Follow-up to #1. Two of the immediate improvements identified after that fix landed:

- **Per-user tokens.** `create_playlist` was still calling `state.user_manager.get_token()` — a single global in-memory token that only ever holds whichever account most recently completed OAuth in this process. With two different logged-in users, playlists would get created against whichever account happened to be cached, not the requesting user's own account.
- **Stub playlist list.** `get_user_playlists` only echoed DB rows with hardcoded `playlist_url: None`, `track_count: 0`, `tracks: []` — never actually called Spotify. The frontend's "My Playlists" tab (`PlaylistsDrawer.tsx`) expects `id`/`name`/`images` on each playlist and was rendering nothing useful.

## Changes

- `UserTokenManager::refresh_with()` (`auth.rs`) — refreshes an arbitrary refresh token, independent of the manager's single-slot cache
- `get_valid_spotify_token()` (`spotify_handlers.rs`) — loads a specific account's stored token from `spotify_account`, refreshes it via Spotify if expired, and persists the refreshed token back to that row
- `create_playlist` now uses the resolved account's token instead of the global manager
- `SpotifyClient::get_playlist()` (`client.rs`) — fields-filtered `GET /playlists/{id}` (id, name, images, external_urls, tracks.total)
- `get_playlists` rewritten to fetch real data per playlist and return `id`/`name`/`images`/`external_url`/`track_count`/`city` — matches the frontend's existing expectations, so no frontend changes were needed. A playlist that fails to fetch (deleted on Spotify's side, etc.) is logged and skipped rather than failing the whole list.

## Test plan

- [x] `cargo build` — clean compile; `cargo sqlx prepare` + `SQLX_OFFLINE=true cargo build` both pass
- [x] Verified the refresh-token grant and the fields-filtered `GET /playlists/{id}` call directly against Spotify's API using a real account already in the dev DB — confirmed the response shape matches the new `PlaylistDetails` struct exactly
- [ ] Full "My Playlists" tab check in the browser with a live session (should now show real cover art instead of nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)