### PR TITLE
Fix map resizing/refreshing and page growth from the events drawer

### DIFF
--- a/apps/web/src/AppWrapper.tsx
+++ b/apps/web/src/AppWrapper.tsx
@@ -9,11 +9,10 @@ const AppWrapper = () => {
       <AppHeader>
         <Search />
       </AppHeader>
-      <div className="h-full">
+      <div className="flex min-h-0 flex-1 flex-col">
         <MapWrapper />
+        {useIsMobile() && <DrawerWrapper />}
       </div>
-
-      {useIsMobile() && <DrawerWrapper />}
     </div>
   )
 }

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -46,7 +46,7 @@ const DrawerWrapper = () => {
     <>
       <Tabs
         orientation="vertical"
-        className={isDesktop ? "h-full w-[30rem] shrink-0" : "h-[40vh] shrink-0"}
+        className="h-[40vh] shrink-0 md:h-full md:w-[30rem]"
       >
         <TabList
           aria-label="Tabs"

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -44,7 +44,10 @@ const DrawerWrapper = () => {
 
   return (
     <>
-      <Tabs orientation="vertical">
+      <Tabs
+        orientation="vertical"
+        className={isDesktop ? "h-full w-[30rem] shrink-0" : "h-[40vh] shrink-0"}
+      >
         <TabList
           aria-label="Tabs"
           className="border-r border-solid border-l-black"
@@ -77,7 +80,7 @@ const DrawerWrapper = () => {
               isBlurred={false}
               notch={isDesktop ? false : true}
               side={isDesktop ? "left" : "bottom"}
-              className="z-10 flex h-full w-full max-w-md flex-col overflow-hidden bg-white"
+              className="z-10 flex h-full w-full flex-col overflow-hidden bg-white"
             >
               {!selectedEvents.length && (
                 <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-white">

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -331,7 +331,7 @@ const MapWrapper = () => {
 
   return (
     <>
-      <div className="relative flex h-full flex-1">
+      <div className="relative flex min-h-0 flex-1">
         {!useIsMobile() && <DrawerWrapper />}
         <div ref={mapContainer} id="map-container" className="h-full w-full" />
       </div>

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -228,7 +228,7 @@ const DrawerBody = ({
   <div
     slot="body"
     className={twMerge(
-      "isolate flex h-full max-h-[calc(var(--visual-viewport-height)-var(--visual-viewport-vertical-padding))] flex-col overflow-auto px-4 py-1 will-change-scroll",
+      "isolate flex h-full min-h-0 flex-col overflow-auto px-4 py-1 will-change-scroll",
       className
     )}
     {...props}

--- a/packages/ui/src/components/ui/Tabs.tsx
+++ b/packages/ui/src/components/ui/Tabs.tsx
@@ -94,7 +94,7 @@ export function TabPanels<T extends object>(props: TabPanelsProps<T>) {
     <RACTabPanels
       {...props}
       className={twMerge(
-        "relative h-(--tab-panel-height) overflow-clip motion-safe:transition-[height]",
+        "flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-clip",
         props.className
       )}
     />
@@ -103,7 +103,7 @@ export function TabPanels<T extends object>(props: TabPanelsProps<T>) {
 
 const tabPanelStyles = tv({
   extend: focusRing,
-  base: "flex-1 box-border p-4 text-sm text-neutral-900 dark:text-neutral-100 transition entering:opacity-0 exiting:opacity-0 exiting:absolute exiting:top-0 exiting:left-0 exiting:w-full",
+  base: "flex-1 min-h-0 box-border p-4 text-sm text-neutral-900 dark:text-neutral-100 transition entering:opacity-0 exiting:opacity-0 exiting:absolute exiting:top-0 exiting:left-0 exiting:w-full",
 })
 
 export function TabPanel(props: TabPanelProps) {


### PR DESCRIPTION
## Summary

Interacting with the events drawer (switching tabs, or populating it with search results) was causing the map to visually resize/refresh, and the page height to grow.

**Root cause:** `TabPanels`' height was driven by a CSS custom property (`--tab-panel-height`) that's referenced in the shared UI package but never actually set anywhere — no JS writer, no other CSS declaration. With the variable permanently unset, the browser computed a runaway height (measured at 100,000+px during testing) instead of falling back sensibly. `DrawerBody` had the same dead-variable pattern via `--visual-viewport-height`. Since the drawer sits as a flex sibling of the map, that garbage height starved the map down to 0px, and because the garbage value differed per active tab, every tab switch resized the map's container and triggered a Mapbox redraw.

I initially tried making the drawer an absolute-positioned overlay over the map, but the intent was always for the drawer and map to be genuinely separate, non-overlapping containers (so the drawer never covers events plotted on the map) — this PR keeps that design, just with a real bounded size instead of the broken unbounded auto-height.

## Changes

- `TabPanels`/`TabPanel` (`packages/ui/src/components/ui/Tabs.tsx`) get a real flex column (`h-full`, `min-h-0`, `flex-1`) instead of the dead `--tab-panel-height` variable
- `DrawerBody` (`packages/ui/src/components/ui/Drawer.tsx`) drops the equally-dead `--visual-viewport-height` calc
- The drawer keeps a bounded, non-overlapping footprint instead of unbounded content-driven height:
  - Mobile: fixed `40vh` reservation at the bottom, map gets the `flex-1` remainder
  - Desktop: fixed `30rem` sidebar width, so the map's size no longer shifts when different tab panels (each with differently-sized content — e.g. the Spotify tab renders an entirely separate `PlaylistsDrawer` component) become active
- Fixed the drawer's `max-w-md` cap being applied on mobile too, which squeezed the tab icon strip (explore/spotify/apple) down to a few px, making it look like the tabs had disappeared

## Test plan

- [x] `tsc --noEmit` — clean
- [x] Verified via direct DOM measurement (not just visual) on mobile (375×812) and desktop (1280×800): the map's bounding rect is now byte-for-byte identical across all three tab switches
- [x] Populated the drawer with a full list of NYC events — `document.documentElement.scrollHeight` stays pinned to the viewport height; the drawer scrolls its own content internally instead of growing the page
- [x] Confirmed all three tab icons are visible and topmost (not hidden) on both breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)