### PR TITLE
Deduplicate provider logic, add tests, auto-expand radius, geolocate city name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           workspaces: apps/api
       - run: cargo check --bins
+      - run: cargo test --lib
 
   web:
     runs-on: ubuntu-latest
@@ -31,4 +32,5 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm turbo test --filter web
       - run: pnpm turbo build --filter web

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "geojson",
  "hex",
  "jsonwebtoken",
+ "percent-encoding",
  "rand 0.8.6",
  "reqwest",
  "serde",

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -55,4 +55,5 @@ async-stream = "0.3"
 
 futures = "0.3.32"
 unicode-normalization = "0.1.25"
+percent-encoding = "2"
 

--- a/apps/api/src/apple_music/auth.rs
+++ b/apps/api/src/apple_music/auth.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::error::AppError;
+use crate::token_cache::TokenCache;
 
 // ---------------------------------------------------------------------------
 // Config
@@ -63,20 +64,7 @@ pub struct DeveloperTokenManager {
     /// We cache the token for most of its lifetime.
     /// Apple allows up to 6 months; we use 12 hours to keep rotation tight.
     token_lifetime_secs: u64,
-    cached: RwLock<Option<CachedToken>>,
-}
-
-#[derive(Clone)]
-struct CachedToken {
-    token: String,
-    expires_at: std::time::Instant,
-}
-
-impl CachedToken {
-    fn is_expired(&self) -> bool {
-        // Refresh 5 minutes before actual expiry.
-        std::time::Instant::now() >= self.expires_at - std::time::Duration::from_secs(300)
-    }
+    cached: TokenCache<String>,
 }
 
 impl DeveloperTokenManager {
@@ -84,28 +72,15 @@ impl DeveloperTokenManager {
         Arc::new(Self {
             creds,
             token_lifetime_secs: 12 * 60 * 60, // 12 hours
-            cached: RwLock::new(None),
+            // Refresh 5 minutes before actual expiry.
+            cached: TokenCache::new(std::time::Duration::from_secs(300)),
         })
     }
 
     /// Returns a valid developer token, regenerating if expired.
     pub async fn get_token(&self) -> Result<String, AppError> {
-        // Fast path: read lock.
-        {
-            let guard = self.cached.read().await;
-            if let Some(t) = guard.as_ref() {
-                if !t.is_expired() {
-                    return Ok(t.token.clone());
-                }
-            }
-        }
-
-        // Slow path: write lock + generate.
-        let mut guard = self.cached.write().await;
-        if let Some(t) = guard.as_ref() {
-            if !t.is_expired() {
-                return Ok(t.token.clone());
-            }
+        if let Some(token) = self.cached.get().await {
+            return Ok(token);
         }
 
         let now = std::time::SystemTime::now()
@@ -129,11 +104,12 @@ impl DeveloperTokenManager {
         let token = encode(&header, &claims, &key)
             .map_err(|e| AppError::Internal(format!("JWT encoding failed: {e}")))?;
 
-        *guard = Some(CachedToken {
-            token: token.clone(),
-            expires_at: std::time::Instant::now()
-                + std::time::Duration::from_secs(self.token_lifetime_secs),
-        });
+        self.cached
+            .set(
+                token.clone(),
+                std::time::Duration::from_secs(self.token_lifetime_secs),
+            )
+            .await;
 
         tracing::info!(
             "Apple Music developer token generated (expires in {}s)",

--- a/apps/api/src/apple_music/client.rs
+++ b/apps/api/src/apple_music/client.rs
@@ -13,6 +13,7 @@ use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
+use crate::http_utils::{request_with_backoff, url_encode};
 
 const BASE: &str = "https://api.music.apple.com";
 
@@ -170,7 +171,7 @@ impl AppleMusicClient {
         let url = format!(
             "{BASE}/v1/catalog/{storefront}/search?types=artists&term={term}&limit={limit}",
             storefront = self.storefront,
-            term = urlencoding(term),
+            term = url_encode(term),
         );
         let resp: SearchResponse = self.get_json(developer_token, None, &url).await?;
         Ok(resp.results.artists.map(|a| a.data).unwrap_or_default())
@@ -188,7 +189,7 @@ impl AppleMusicClient {
         let url = format!(
             "{BASE}/v1/catalog/{storefront}/search?types=songs&term={term}&limit={limit}",
             storefront = self.storefront,
-            term = urlencoding(term),
+            term = url_encode(term),
         );
         let resp: SearchResponse = self.get_json(developer_token, None, &url).await?;
         Ok(resp.results.songs.map(|s| s.data).unwrap_or_default())
@@ -333,6 +334,21 @@ impl AppleMusicClient {
 
     // -- Internal helpers ---------------------------------------------------
 
+    /// Map a non-2xx Apple Music response body to an `AppError`, extracting
+    /// the structured error message when present.
+    fn map_error(status: StatusCode, text: String) -> AppError {
+        let message = serde_json::from_str::<AppleErrorResponse>(&text)
+            .ok()
+            .and_then(|e| {
+                e.errors
+                    .into_iter()
+                    .next()
+                    .map(|err| err.detail.unwrap_or(err.title))
+            })
+            .unwrap_or(text);
+        AppError::SpotifyApi { status, message }
+    }
+
     /// GET with exponential back-off on 429.
     async fn get_json<T: serde::de::DeserializeOwned>(
         &self,
@@ -340,15 +356,18 @@ impl AppleMusicClient {
         user_token: Option<&str>,
         url: &str,
     ) -> Result<T, AppError> {
-        let resp = self
-            .request_with_backoff(|| {
+        let resp = request_with_backoff(
+            "apple_music",
+            || {
                 let mut req = self.http.get(url).bearer_auth(developer_token);
                 if let Some(ut) = user_token {
                     req = req.header("Music-User-Token", ut);
                 }
                 req
-            })
-            .await?;
+            },
+            Self::map_error,
+        )
+        .await?;
 
         resp.json::<T>().await.map_err(AppError::from)
     }
@@ -361,84 +380,17 @@ impl AppleMusicClient {
         url: &str,
         body: &serde_json::Value,
     ) -> Result<reqwest::Response, AppError> {
-        self.request_with_backoff(|| {
-            let mut req = self.http.post(url).bearer_auth(developer_token).json(body);
-            if let Some(ut) = user_token {
-                req = req.header("Music-User-Token", ut);
-            }
-            req
-        })
+        request_with_backoff(
+            "apple_music",
+            || {
+                let mut req = self.http.post(url).bearer_auth(developer_token).json(body);
+                if let Some(ut) = user_token {
+                    req = req.header("Music-User-Token", ut);
+                }
+                req
+            },
+            Self::map_error,
+        )
         .await
     }
-
-    /// Execute with exponential back-off on 429, respecting `Retry-After`.
-    async fn request_with_backoff(
-        &self,
-        build: impl Fn() -> reqwest::RequestBuilder,
-    ) -> Result<reqwest::Response, AppError> {
-        let max_retries: u32 = 5;
-        let mut attempt = 0u32;
-
-        loop {
-            let resp = build().send().await?;
-
-            if resp.status() == StatusCode::TOO_MANY_REQUESTS {
-                attempt += 1;
-                if attempt > max_retries {
-                    let retry_after = parse_retry_after(&resp);
-                    return Err(AppError::RateLimited {
-                        retry_after_secs: retry_after,
-                    });
-                }
-
-                let server_wait = parse_retry_after(&resp);
-                let backoff = server_wait.max(1) * 2u64.pow(attempt - 1);
-                tracing::warn!(
-                    attempt,
-                    backoff,
-                    "Apple Music rate limited (429), backing off"
-                );
-                tokio::time::sleep(std::time::Duration::from_secs(backoff)).await;
-                continue;
-            }
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let text = resp.text().await.unwrap_or_default();
-
-                let message = serde_json::from_str::<AppleErrorResponse>(&text)
-                    .ok()
-                    .and_then(|e| {
-                        e.errors
-                            .into_iter()
-                            .next()
-                            .map(|err| err.detail.unwrap_or(err.title))
-                    })
-                    .unwrap_or(text);
-
-                return Err(AppError::SpotifyApi { status, message });
-            }
-
-            return Ok(resp);
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn parse_retry_after(resp: &reqwest::Response) -> u64 {
-    resp.headers()
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(1)
-}
-
-fn urlencoding(s: &str) -> String {
-    s.replace(' ', "+")
-        .replace('&', "%26")
-        .replace('=', "%3D")
-        .replace('#', "%23")
 }

--- a/apps/api/src/auth.rs
+++ b/apps/api/src/auth.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::error::AppError;
+use crate::http_utils::url_encode;
+use crate::token_cache::{TokenCache, is_fresh};
 
 // ---------------------------------------------------------------------------
 // Config
@@ -49,7 +51,7 @@ impl SpotifyCredentials {
 // Token types
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TokenResponse {
     pub access_token: String,
     pub token_type: String,
@@ -57,20 +59,6 @@ pub struct TokenResponse {
     /// Only present in Authorization Code flow responses.
     pub refresh_token: Option<String>,
     pub scope: Option<String>,
-}
-
-/// A cached token with its expiry instant.
-#[derive(Clone)]
-struct CachedToken {
-    access_token: String,
-    expires_at: std::time::Instant,
-}
-
-impl CachedToken {
-    fn is_expired(&self) -> bool {
-        // Refresh 60 s before actual expiry to avoid edge-case failures.
-        std::time::Instant::now() >= self.expires_at - std::time::Duration::from_secs(60)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -82,7 +70,7 @@ impl CachedToken {
 pub struct ClientCredentialsManager {
     creds: SpotifyCredentials,
     http: Client,
-    cached: RwLock<Option<TokenResponse>>,
+    cached: TokenCache<TokenResponse>,
 }
 
 impl ClientCredentialsManager {
@@ -90,13 +78,16 @@ impl ClientCredentialsManager {
         Arc::new(Self {
             creds,
             http,
-            cached: RwLock::new(None),
+            // Refresh 60s before actual expiry to avoid edge-case failures.
+            cached: TokenCache::new(std::time::Duration::from_secs(60)),
         })
     }
 
     /// Returns a valid access token, refreshing if necessary.
     pub async fn get_token(&self) -> Result<TokenResponse, AppError> {
-        // Fast path: read lock.
+        if let Some(tok) = self.cached.get().await {
+            return Ok(tok);
+        }
 
         let resp = self
             .http
@@ -117,6 +108,9 @@ impl ClientCredentialsManager {
         }
 
         let tok: TokenResponse = resp.json().await?;
+        self.cached
+            .set(tok.clone(), std::time::Duration::from_secs(tok.expires_in))
+            .await;
 
         tracing::info!(
             "Client Credentials token refreshed (expires in {}s)",
@@ -173,9 +167,9 @@ impl UserTokenManager {
              &redirect_uri={redirect_uri}\
              &state={state}",
             client_id = self.creds.client_id,
-            scopes = urlencoding(scopes),
-            redirect_uri = urlencoding(&self.creds.redirect_uri),
-            state = urlencoding(state),
+            scopes = url_encode(scopes),
+            redirect_uri = url_encode(&self.creds.redirect_uri),
+            state = url_encode(state),
         )
     }
 
@@ -183,8 +177,8 @@ impl UserTokenManager {
     pub async fn exchange_code(&self, code: &str) -> Result<TokenResponse, AppError> {
         let body = format!(
             "grant_type=authorization_code&code={}&redirect_uri={}",
-            urlencoding(code),
-            urlencoding(&self.creds.redirect_uri),
+            url_encode(code),
+            url_encode(&self.creds.redirect_uri),
         );
 
         tracing::info!(
@@ -254,7 +248,7 @@ impl UserTokenManager {
 
         let body = format!(
             "grant_type=refresh_token&refresh_token={}",
-            urlencoding(&current.refresh_token),
+            url_encode(&current.refresh_token),
         );
 
         let resp = self
@@ -298,7 +292,7 @@ impl UserTokenManager {
     pub async fn refresh_with(&self, refresh_token: &str) -> Result<TokenResponse, AppError> {
         let body = format!(
             "grant_type=refresh_token&refresh_token={}",
-            urlencoding(refresh_token),
+            url_encode(refresh_token),
         );
 
         let resp = self
@@ -346,30 +340,9 @@ impl UserTokenManager {
         Ok(resp.json().await?)
     }
 }
-fn token_is_expired(expires_in: u64) -> bool {
-    std::time::Instant::now()
-        >= (std::time::Instant::now() + std::time::Duration::from_secs(expires_in))
-            - std::time::Duration::from_secs(60)
-}
 
 impl UserToken {
     fn is_expired(&self) -> bool {
-        std::time::Instant::now() >= self.expires_at - std::time::Duration::from_secs(60)
+        !is_fresh(self.expires_at, std::time::Duration::from_secs(60))
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Percent-encode a string for use in URL query parameters.
-fn urlencoding(s: &str) -> String {
-    // Simple encoding sufficient for the parameters we use.
-    s.replace(' ', "%20")
-        .replace(':', "%3A")
-        .replace('/', "%2F")
-        .replace('&', "%26")
-        .replace('=', "%3D")
-        .replace('+', "%2B")
-        .replace('@', "%40")
 }

--- a/apps/api/src/http_utils.rs
+++ b/apps/api/src/http_utils.rs
@@ -1,0 +1,91 @@
+//! Shared HTTP helpers for the Spotify and Apple Music API clients:
+//! exponential back-off on rate limiting, and URL-component encoding.
+
+use crate::error::AppError;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::{RequestBuilder, Response, StatusCode};
+
+const QUERY_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// Percent-encode a string for use in a URL query parameter or
+/// `application/x-www-form-urlencoded` body value.
+pub(crate) fn url_encode(s: &str) -> String {
+    utf8_percent_encode(s, QUERY_ENCODE_SET).to_string()
+}
+
+pub(crate) fn parse_retry_after(resp: &Response) -> u64 {
+    resp.headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(1)
+}
+
+/// Execute a request builder with exponential back-off on 429, respecting
+/// the `Retry-After` header. `on_error` maps a non-2xx response body into
+/// the caller's own error, so each provider can keep parsing its own
+/// error body shape.
+pub(crate) async fn request_with_backoff(
+    provider: &'static str,
+    build: impl Fn() -> RequestBuilder,
+    on_error: impl Fn(StatusCode, String) -> AppError,
+) -> Result<Response, AppError> {
+    let max_retries: u32 = 5;
+    let mut attempt = 0u32;
+
+    loop {
+        let resp = build().send().await?;
+
+        if resp.status() == StatusCode::TOO_MANY_REQUESTS {
+            attempt += 1;
+            if attempt > max_retries {
+                let retry_after = parse_retry_after(&resp);
+                return Err(AppError::RateLimited {
+                    retry_after_secs: retry_after,
+                });
+            }
+
+            let server_wait = parse_retry_after(&resp);
+            let backoff = server_wait.max(1) * 2u64.pow(attempt - 1);
+            tracing::warn!(provider, attempt, backoff, "Rate limited (429), backing off");
+            tokio::time::sleep(std::time::Duration::from_secs(backoff)).await;
+            continue;
+        }
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(on_error(status, text));
+        }
+
+        return Ok(resp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_encode_leaves_unreserved_characters_untouched() {
+        assert_eq!(url_encode("abc-XYZ_123.~"), "abc-XYZ_123.~");
+    }
+
+    #[test]
+    fn url_encode_escapes_reserved_and_whitespace() {
+        assert_eq!(url_encode("a b"), "a%20b");
+        assert_eq!(url_encode("a&b=c"), "a%26b%3Dc");
+        assert_eq!(url_encode("100%"), "100%25");
+    }
+
+    #[test]
+    fn url_encode_escapes_unicode() {
+        // Sigur Rós — the ó needs escaping; a hand-rolled ASCII-only
+        // encoder would silently pass it through unescaped.
+        assert_eq!(url_encode("Sigur Rós"), "Sigur%20R%C3%B3s");
+    }
+}

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -130,7 +130,11 @@ pub async fn build_app() -> Result<Router> {
             "/auth/status",
             axum::routing::get(spotify::spotify_handlers::auth_status),
         )
-        .route("/cities", axum::routing::get(mapbox_handlers::get_cities))  
+        .route("/cities", axum::routing::get(mapbox_handlers::get_cities))
+        .route(
+            "/reverse-geocode",
+            axum::routing::get(mapbox_handlers::reverse_geocode),
+        )
         .route(
             "/concerts/stream",
             axum::routing::get(ticketmaster_stream::get_concerts_tm_stream),

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -5,11 +5,13 @@ mod config;
 mod cookie;
 mod db;
 mod error;
+mod http_utils;
 mod mapbox_handlers;
 mod spotify;
 mod state;
 mod ticketmaster_handlers;
 mod ticketmaster_stream;
+mod token_cache;
 mod services;
 use std::sync::Arc;
 

--- a/apps/api/src/mapbox_handlers.rs
+++ b/apps/api/src/mapbox_handlers.rs
@@ -1,3 +1,4 @@
+use crate::http_utils::url_encode;
 use crate::state::AppState;
 use axum::extract::{Query, State};
 use axum::response::IntoResponse;
@@ -10,18 +11,17 @@ pub struct CitiesQuery {
     q: Option<String>,
 }
 
-pub async fn get_cities(
-    State(state): State<AppState>,
-    Query(params): Query<CitiesQuery>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
-    let query = params.q.unwrap_or_default();
+#[derive(Deserialize)]
+pub struct ReverseGeocodeQuery {
+    longitude: f64,
+    latitude: f64,
+}
 
-    let url = format!(
-        "https://api.mapbox.com/search/geocode/v6/forward?q={}&types=place&access_token={}",
-        query, state.mapbox_key
-    );
-
-    let resp = state.client.get(&url).send().await.map_err(|e| {
+async fn fetch_mapbox_features(
+    state: &AppState,
+    url: &str,
+) -> Result<FeatureCollection, (StatusCode, String)> {
+    let resp = state.client.get(url).send().await.map_err(|e| {
         (
             StatusCode::BAD_GATEWAY,
             format!("Failed to fetch from mapbox: {}", e),
@@ -42,12 +42,44 @@ pub async fn get_cities(
         )
     })?;
 
-    let body: FeatureCollection = serde_json::from_str(&text).map_err(|e| {
+    serde_json::from_str(&text).map_err(|e| {
         (
             StatusCode::BAD_GATEWAY,
             format!("Failed to decode mapbox body: {}", e),
         )
-    })?;
+    })
+}
+
+pub async fn get_cities(
+    State(state): State<AppState>,
+    Query(params): Query<CitiesQuery>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let query = params.q.unwrap_or_default();
+
+    let url = format!(
+        "https://api.mapbox.com/search/geocode/v6/forward?q={}&types=place&access_token={}",
+        url_encode(&query),
+        state.mapbox_key
+    );
+
+    let body = fetch_mapbox_features(&state, &url).await?;
+
+    Ok(Json(body))
+}
+
+/// Reverse-geocodes coordinates (e.g. from the map's geolocate control)
+/// into the nearest place name, in the same shape `get_cities` returns so
+/// the frontend can treat a geolocated result identically to a searched one.
+pub async fn reverse_geocode(
+    State(state): State<AppState>,
+    Query(params): Query<ReverseGeocodeQuery>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let url = format!(
+        "https://api.mapbox.com/search/geocode/v6/reverse?longitude={}&latitude={}&types=place&access_token={}",
+        params.longitude, params.latitude, state.mapbox_key
+    );
+
+    let body = fetch_mapbox_features(&state, &url).await?;
 
     Ok(Json(body))
 }

--- a/apps/api/src/services/playlist_builder.rs
+++ b/apps/api/src/services/playlist_builder.rs
@@ -1,9 +1,11 @@
 
 use crate::state::{AppState};
 use crate::error::{AppError};
-use crate::ticketmaster_stream::{EventsQuery, EventResponse, TicketmasterResponse, LocationResponse, VenueResponse};
-use chrono::{DateTime, Local};
+use crate::ticketmaster_stream::{
+    EventsQuery, EventResponse, TicketmasterResponse, dedupe_key, normalize_event,
+};
 use geohash::{encode, Coord};
+use std::collections::HashSet;
 use tracing::info;
 
 pub async fn get_concerts_tm_impl(
@@ -47,79 +49,13 @@ pub async fn get_concerts_tm_impl(
     let body: TicketmasterResponse = serde_json::from_str(&text)
         .map_err(|e| AppError::Internal(format!("Ticketmaster decode error: {e}")))?;
 
-    let events = body
+    let mut seen = HashSet::<String>::new();
+    let events: Vec<EventResponse> = body
         .embedded
         .into_iter()
         .flat_map(|e| e.events)
-        .map(|e| {
-            let dates = e.dates.start.date_time.or_else(|| {
-                match (
-                    e.dates.start.local_date.as_ref(),
-                    e.dates.start.local_time.as_ref(),
-                ) {
-                    (Some(d), Some(t)) => Some(format!("{d}T{t}")),
-                    (Some(d), None) => Some(d.clone()),
-                    _ => None,
-                }
-            });
-
-            let venue = e
-                .embedded
-                .as_ref()
-                .and_then(|emb| emb.venues.as_ref())
-                .and_then(|vs| vs.last().cloned());
-
-            let venue = venue.map(|v| VenueResponse {
-                name: v.name,
-                location: v.location.map(|loc| LocationResponse {
-                    latitude: loc.latitude,
-                    longitude: loc.longitude,
-                }),
-                city: v.city.and_then(|c| c.name),
-            });
-
-            let attractions = e.embedded.and_then(|a| a.attractions);
-
-            let dates_pretty = dates.as_ref().map(|d| {
-                DateTime::parse_from_rfc3339(d)
-                    .map(|dt| dt.with_timezone(&Local).format("%B %d").to_string())
-                    .unwrap_or_else(|_| d.clone())
-            });
-
-            EventResponse {
-                id: e.id,
-                name: e.name,
-                url: e.url,
-                venue,
-                images: e.images,
-                dates,
-                dates_pretty: dates_pretty,
-                classifications: e.classifications,
-                attractions,
-                price_ranges: e.price_ranges,
-            }
-        })
-        .fold(
-            std::collections::HashMap::new(),
-            |mut acc: std::collections::HashMap<String, EventResponse>, event| {
-                let venue_id = event.venue.as_ref().and_then(|v| v.name.clone());
-                let attraction_id = event
-                    .attractions
-                    .as_ref()
-                    .and_then(|attractions| attractions.first().and_then(|a| a.id.clone()));
-
-                let key = format!(
-                    "{}-{}-{}",
-                    event.dates.clone().unwrap_or_default(),
-                    venue_id.unwrap_or_default(),
-                    attraction_id.unwrap_or_default()
-                );
-
-                acc.entry(key).or_insert(event);
-                acc
-            },
-        )
-        .into_values()
+        .map(normalize_event)
+        .filter(|event| seen.insert(dedupe_key(event)))
         .collect();
 
     Ok(events)

--- a/apps/api/src/spotify/client.rs
+++ b/apps/api/src/spotify/client.rs
@@ -6,10 +6,11 @@
 //! All endpoint paths, field names, and response shapes are taken directly
 //! from the spec. Deprecated endpoints are avoided where alternatives exist.
 
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
+use crate::http_utils::{request_with_backoff, url_encode};
 use unicode_normalization::UnicodeNormalization;
 
 fn normalize(s: &str) -> String {
@@ -199,7 +200,7 @@ impl SpotifyClient {
     ) -> Result<Vec<Artist>, AppError> {
         let url = format!(
             "{BASE}/search?q={}&type=artist&limit={limit}",
-            urlencoding(name),
+            url_encode(name),
         );
         self.get_json::<SearchArtistsResponse>(token, &url)
             .await
@@ -217,7 +218,7 @@ impl SpotifyClient {
         let query = format!("{artist_name}");
         let artist_url = format!(
             "{BASE}/search?q={}&type=artist&limit={limit}",
-            urlencoding(&query),
+            url_encode(&query),
         );
         let artist = self
             .get_json::<SearchArtistsResponse>(token, &artist_url)
@@ -231,7 +232,6 @@ impl SpotifyClient {
         let Some(artist) = artist else {
             return Ok(None);
         };
-        println!("{}", artist.name);
         let tracks_url = format!("{BASE}/artists/{}/top-tracks", artist.id);
         self.get_json::<ArtistTracksResponse>(token, &tracks_url)
             .await
@@ -343,15 +343,27 @@ impl SpotifyClient {
 
     // -- Internal helpers ---------------------------------------------------
 
+    /// Map a non-2xx Spotify response body to an `AppError`, extracting the
+    /// structured error message when present.
+    fn map_error(status: reqwest::StatusCode, text: String) -> AppError {
+        let message = serde_json::from_str::<SpotifyErrorWrapper>(&text)
+            .map(|e| e.error.message)
+            .unwrap_or(text);
+        AppError::SpotifyApi { status, message }
+    }
+
     /// GET a URL, parse JSON, with retry on 429.
     async fn get_json<T: serde::de::DeserializeOwned>(
         &self,
         token: &str,
         url: &str,
     ) -> Result<T, AppError> {
-        let resp = self
-            .request_with_backoff(|| self.http.get(url).bearer_auth(token))
-            .await?;
+        let resp = request_with_backoff(
+            "spotify",
+            || self.http.get(url).bearer_auth(token),
+            Self::map_error,
+        )
+        .await?;
         resp.json::<T>().await.map_err(AppError::from)
     }
 
@@ -362,8 +374,12 @@ impl SpotifyClient {
         token: &str,
         body: &serde_json::Value,
     ) -> Result<reqwest::Response, AppError> {
-        self.request_with_backoff(|| self.http.post(url).bearer_auth(token).json(body))
-            .await
+        request_with_backoff(
+            "spotify",
+            || self.http.post(url).bearer_auth(token).json(body),
+            Self::map_error,
+        )
+        .await
     }
 
     /// PUT JSON with retry on 429.
@@ -373,74 +389,11 @@ impl SpotifyClient {
         token: &str,
         body: &serde_json::Value,
     ) -> Result<reqwest::Response, AppError> {
-        self.request_with_backoff(|| self.http.put(url).bearer_auth(token).json(body))
-            .await
+        request_with_backoff(
+            "spotify",
+            || self.http.put(url).bearer_auth(token).json(body),
+            Self::map_error,
+        )
+        .await
     }
-
-    /// Execute a request builder with exponential back-off on 429.
-    /// Respects the `Retry-After` header per Spotify rate-limit guidelines.
-    async fn request_with_backoff(
-        &self,
-        build: impl Fn() -> reqwest::RequestBuilder,
-    ) -> Result<reqwest::Response, AppError> {
-        let max_retries: u32 = 5;
-        let mut attempt = 0u32;
-
-        loop {
-            let resp = build().send().await?;
-
-            if resp.status() == StatusCode::TOO_MANY_REQUESTS {
-                attempt += 1;
-                if attempt > max_retries {
-                    let retry_after = parse_retry_after(&resp);
-                    return Err(AppError::RateLimited {
-                        retry_after_secs: retry_after,
-                    });
-                }
-
-                let server_wait = parse_retry_after(&resp);
-                let backoff = server_wait.max(1) * 2u64.pow(attempt - 1);
-                tracing::warn!(attempt, backoff, "Rate limited (429), backing off");
-                tokio::time::sleep(std::time::Duration::from_secs(backoff)).await;
-                continue;
-            }
-
-            // For non-429 errors, parse the Spotify error body.
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let text = resp.text().await.unwrap_or_default();
-
-                // Try to extract the structured error message.
-                let message = serde_json::from_str::<SpotifyErrorWrapper>(&text)
-                    .map(|e| e.error.message)
-                    .unwrap_or(text);
-
-                return Err(AppError::SpotifyApi { status, message });
-            }
-
-            return Ok(resp);
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Free helpers
-// ---------------------------------------------------------------------------
-
-fn parse_retry_after(resp: &reqwest::Response) -> u64 {
-    resp.headers()
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(1)
-}
-
-fn urlencoding(s: &str) -> String {
-    s.replace(' ', "%20")
-        .replace(':', "%3A")
-        .replace('/', "%2F")
-        .replace('&', "%26")
-        .replace('=', "%3D")
-        .replace('+', "%2B")
-        .replace('@', "%40")
 }

--- a/apps/api/src/ticketmaster_stream.rs
+++ b/apps/api/src/ticketmaster_stream.rs
@@ -183,7 +183,7 @@ pub struct LocationResponse {
     pub longitude: Option<String>,
 }
 
-fn normalize_event(e: TmEvent) -> EventResponse {
+pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
     let dates = e.dates.start.date_time.or_else(|| {
         match (
             e.dates.start.local_date.as_ref(),
@@ -232,7 +232,7 @@ fn normalize_event(e: TmEvent) -> EventResponse {
     }
 }
 
-fn dedupe_key(event: &EventResponse) -> String {
+pub(crate) fn dedupe_key(event: &EventResponse) -> String {
     let venue_name = event.venue.as_ref().and_then(|v| v.name.clone());
     let attraction_id = event
         .attractions
@@ -432,4 +432,217 @@ pub async fn get_concerts_tm_stream(
         .header(header::CACHE_CONTROL, "no-store")
         .body(Body::from_stream(stream))
         .unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tm_event(id: &str, start: TmDateStart) -> TmEvent {
+        TmEvent {
+            id: id.to_string(),
+            url: None,
+            price_ranges: None,
+            name: "Test Event".to_string(),
+            images: vec![],
+            dates: TmDate { start },
+            classifications: None,
+            embedded: None,
+        }
+    }
+
+    #[test]
+    fn normalize_event_prefers_date_time() {
+        let event = tm_event(
+            "1",
+            TmDateStart {
+                date_time: Some("2026-08-01T20:00:00Z".to_string()),
+                local_date: Some("2026-08-01".to_string()),
+                local_time: Some("15:00:00".to_string()),
+            },
+        );
+        let normalized = normalize_event(event);
+        assert_eq!(normalized.dates.as_deref(), Some("2026-08-01T20:00:00Z"));
+    }
+
+    #[test]
+    fn normalize_event_combines_local_date_and_time_when_date_time_missing() {
+        let event = tm_event(
+            "1",
+            TmDateStart {
+                date_time: None,
+                local_date: Some("2026-08-01".to_string()),
+                local_time: Some("15:00:00".to_string()),
+            },
+        );
+        let normalized = normalize_event(event);
+        assert_eq!(
+            normalized.dates.as_deref(),
+            Some("2026-08-01T15:00:00")
+        );
+    }
+
+    #[test]
+    fn normalize_event_falls_back_to_local_date_only() {
+        let event = tm_event(
+            "1",
+            TmDateStart {
+                date_time: None,
+                local_date: Some("2026-08-01".to_string()),
+                local_time: None,
+            },
+        );
+        let normalized = normalize_event(event);
+        assert_eq!(normalized.dates.as_deref(), Some("2026-08-01"));
+    }
+
+    #[test]
+    fn normalize_event_has_no_dates_when_all_fields_missing() {
+        let event = tm_event(
+            "1",
+            TmDateStart {
+                date_time: None,
+                local_date: None,
+                local_time: None,
+            },
+        );
+        let normalized = normalize_event(event);
+        assert_eq!(normalized.dates, None);
+        assert_eq!(normalized.dates_pretty, None);
+    }
+
+    #[test]
+    fn normalize_event_uses_last_venue_when_multiple_present() {
+        let mut event = tm_event(
+            "1",
+            TmDateStart {
+                date_time: Some("2026-08-01T20:00:00Z".to_string()),
+                local_date: None,
+                local_time: None,
+            },
+        );
+        event.embedded = Some(EventEmbedded {
+            venues: Some(vec![
+                TmVenue {
+                    name: Some("First Venue".to_string()),
+                    location: None,
+                    city: None,
+                },
+                TmVenue {
+                    name: Some("Second Venue".to_string()),
+                    location: None,
+                    city: None,
+                },
+            ]),
+            attractions: None,
+        });
+        let normalized = normalize_event(event);
+        assert_eq!(
+            normalized.venue.and_then(|v| v.name),
+            Some("Second Venue".to_string())
+        );
+    }
+
+    #[test]
+    fn dedupe_key_is_stable_for_same_date_venue_and_attraction() {
+        let event = |id: &str| EventResponse {
+            id: id.to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some("The Venue".to_string()),
+                location: None,
+                city: None,
+            }),
+            images: vec![],
+            dates: Some("2026-08-01T20:00:00Z".to_string()),
+            dates_pretty: None,
+            classifications: None,
+            attractions: Some(vec![TmAttraction {
+                name: Some("Artist".to_string()),
+                id: Some("artist-1".to_string()),
+                classifications: None,
+                external_links: None,
+                images: None,
+            }]),
+            url: None,
+            price_ranges: None,
+        };
+
+        // Same date/venue/attraction but a different Ticketmaster event id
+        // should still dedupe to the same key — this is the whole point of
+        // dedupe_key, since Ticketmaster returns the same show multiple
+        // times across overlapping date windows with different ids.
+        assert_eq!(dedupe_key(&event("id-a")), dedupe_key(&event("id-b")));
+    }
+
+    #[test]
+    fn dedupe_key_differs_when_venue_differs() {
+        let base = EventResponse {
+            id: "1".to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some("Venue A".to_string()),
+                location: None,
+                city: None,
+            }),
+            images: vec![],
+            dates: Some("2026-08-01T20:00:00Z".to_string()),
+            dates_pretty: None,
+            classifications: None,
+            attractions: None,
+            url: None,
+            price_ranges: None,
+        };
+        let mut other = EventResponse {
+            venue: Some(VenueResponse {
+                name: Some("Venue B".to_string()),
+                location: None,
+                city: None,
+            }),
+            ..base.clone()
+        };
+        other.id = "2".to_string();
+
+        assert_ne!(dedupe_key(&base), dedupe_key(&other));
+    }
+
+    #[test]
+    fn date_windows_single_day_produces_one_window_clipped_to_input() {
+        let windows =
+            date_windows("2026-08-01T14:00:00Z", "2026-08-01T22:00:00Z").unwrap();
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].0, "2026-08-01T14:00:00Z");
+        assert_eq!(windows[0].1, "2026-08-01T22:00:00Z");
+    }
+
+    #[test]
+    fn date_windows_splits_multi_day_range_by_calendar_day() {
+        let windows =
+            date_windows("2026-08-01T14:00:00Z", "2026-08-03T10:00:00Z").unwrap();
+        assert_eq!(windows.len(), 3);
+
+        // First window starts at the given start time, not midnight.
+        assert_eq!(windows[0].0, "2026-08-01T14:00:00Z");
+        assert_eq!(windows[0].1, "2026-08-02T00:00:00Z");
+
+        // Middle window spans the full calendar day.
+        assert_eq!(windows[1].0, "2026-08-02T00:00:00Z");
+        assert_eq!(windows[1].1, "2026-08-03T00:00:00Z");
+
+        // Last window ends at the given end time, not midnight.
+        assert_eq!(windows[2].0, "2026-08-03T00:00:00Z");
+        assert_eq!(windows[2].1, "2026-08-03T10:00:00Z");
+    }
+
+    #[test]
+    fn date_windows_rejects_end_before_start() {
+        let result = date_windows("2026-08-03T00:00:00Z", "2026-08-01T00:00:00Z");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn date_windows_rejects_malformed_datetime() {
+        let result = date_windows("not-a-date", "2026-08-01T00:00:00Z");
+        assert!(result.is_err());
+    }
 }

--- a/apps/api/src/token_cache.rs
+++ b/apps/api/src/token_cache.rs
@@ -1,0 +1,97 @@
+//! Generic in-memory cache for a single expiring token-like value, shared
+//! by each provider's token/credential manager (Spotify client-credentials
+//! and user tokens, Apple Music developer tokens).
+
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+
+/// Whether an expiring value is still usable, i.e. not within
+/// `refresh_margin` of `expires_at`. Exposed standalone (not just via
+/// `TokenCache`) for managers that need to hold a value past its
+/// freshness window — e.g. to read a refresh token off a stale access
+/// token — without going through the cache's own locking.
+pub(crate) fn is_fresh(expires_at: Instant, refresh_margin: Duration) -> bool {
+    match expires_at.checked_sub(refresh_margin) {
+        Some(effective_expiry) => Instant::now() < effective_expiry,
+        None => false,
+    }
+}
+
+pub(crate) struct TokenCache<T: Clone> {
+    inner: RwLock<Option<(T, Instant)>>,
+    /// How long before actual expiry to treat the cached value as stale,
+    /// so callers have time to refresh before a request would fail.
+    refresh_margin: Duration,
+}
+
+impl<T: Clone> TokenCache<T> {
+    pub fn new(refresh_margin: Duration) -> Self {
+        Self {
+            inner: RwLock::new(None),
+            refresh_margin,
+        }
+    }
+
+    /// Returns the cached value if present and not within `refresh_margin`
+    /// of its expiry.
+    pub async fn get(&self) -> Option<T> {
+        let guard = self.inner.read().await;
+        guard.as_ref().and_then(|(value, expires_at)| {
+            if is_fresh(*expires_at, self.refresh_margin) {
+                Some(value.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub async fn set(&self, value: T, ttl: Duration) {
+        *self.inner.write().await = Some((value, Instant::now() + ttl));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_fresh_true_well_before_expiry() {
+        let expires_at = Instant::now() + Duration::from_secs(3600);
+        assert!(is_fresh(expires_at, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn is_fresh_false_within_refresh_margin() {
+        let expires_at = Instant::now() + Duration::from_secs(30);
+        assert!(!is_fresh(expires_at, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn is_fresh_false_when_margin_exceeds_time_since_epoch() {
+        // expires_at is "now", so subtracting any positive margin
+        // underflows — must not panic, must read as stale.
+        assert!(!is_fresh(Instant::now(), Duration::from_secs(60)));
+    }
+
+    #[tokio::test]
+    async fn empty_cache_returns_none() {
+        let cache: TokenCache<String> = TokenCache::new(Duration::from_secs(60));
+        assert_eq!(cache.get().await, None);
+    }
+
+    #[tokio::test]
+    async fn returns_cached_value_before_expiry() {
+        let cache = TokenCache::new(Duration::from_secs(60));
+        cache.set("token".to_string(), Duration::from_secs(3600)).await;
+        assert_eq!(cache.get().await, Some("token".to_string()));
+    }
+
+    #[tokio::test]
+    async fn treats_value_as_stale_within_refresh_margin() {
+        let cache = TokenCache::new(Duration::from_secs(60));
+        // Expires in 30s, but the refresh margin is 60s, so it should
+        // already read as stale to give callers time to refresh.
+        cache.set("token".to_string(), Duration::from_secs(30)).await;
+        assert_eq!(cache.get().await, None);
+    }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fortawesome/react-fontawesome": "^3.3.0",
@@ -53,6 +54,7 @@
     "globals": "^17.2.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
-    "vite": "^8.1.5"
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/web/src/Drawer/EventsDrawer.tsx
+++ b/apps/web/src/Drawer/EventsDrawer.tsx
@@ -8,12 +8,22 @@ import { formatDate } from "../lib/formats"
 import { EventFilter } from "../EventFilter"
 
 export const EventsDrawer = () => {
-  const { eventsByDate } = useEventsContext()
+  const { eventsByDate, isStreaming, searchRadius, radiusExpanded } =
+    useEventsContext()
   const eventListRef = useRef<HTMLDivElement>(null)
   const { registerItem } = useTopMostVisibleInScrollContainer(eventListRef, {
     offsetTop: 0,
   })
   const entries = Object.entries(eventsByDate).sort()
+
+  if (!entries.length && isStreaming) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <p className="text-gray-600">Searching for events…</p>
+      </div>
+    )
+  }
+
   return (
     <>
       {entries.length ? (
@@ -40,8 +50,9 @@ export const EventsDrawer = () => {
       ) : (
         <div className="flex h-full w-full items-center justify-center">
           <p className="text-gray-600">
-            No events found. Try searching for a different location, or
-            adjusting the calendar date range.
+            {radiusExpanded && searchRadius
+              ? `No events found within ${searchRadius}mi. Try searching for a different location, or adjusting the calendar date range.`
+              : "No events found. Try searching for a different location, or adjusting the calendar date range."}
           </p>
         </div>
       )}
@@ -50,7 +61,7 @@ export const EventsDrawer = () => {
 }
 
 export const EventsDrawerHeader = () => {
-  const { eventsByDate } = useEventsContext()
+  const { eventsByDate, searchRadius, radiusExpanded } = useEventsContext()
   const eventListRef = useRef<HTMLDivElement>(null)
 
   const handleDateChange = (date: string) => {
@@ -75,8 +86,13 @@ export const EventsDrawerHeader = () => {
 
   return (
     <>
-      <div className="mb-2 flex w-full">
+      <div className="mb-2 flex w-full items-center justify-between">
         <h2 className="text-bold text-xl">Events</h2>
+        {radiusExpanded && searchRadius && (
+          <span className="text-xs text-gray-500">
+            Showing events within {searchRadius}mi
+          </span>
+        )}
       </div>
       <EventFilter />
       <DateSlider

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -1,5 +1,9 @@
 import { useRef, useEffect, useState } from "react"
-import mapboxgl, { GeoJSONSource, InteractionEvent } from "mapbox-gl"
+import mapboxgl, {
+  GeoJSONSource,
+  InteractionEvent,
+  type GeoJSONFeature,
+} from "mapbox-gl"
 import { useSearchProvider } from "./providers/searchProvider"
 import { useEventsContext } from "./providers/eventsProvider"
 import { DrawerWrapper } from "./Drawer/DrawerWrapper"
@@ -31,8 +35,12 @@ function boundsForRadius(
 }
 
 const MapWrapper = () => {
-  const { selectedCoordinates, setSelectedCoordinates, dateRange } =
-    useSearchProvider()
+  const {
+    selectedCoordinates,
+    setSelectedCoordinates,
+    setSelectedLocation,
+    dateRange,
+  } = useSearchProvider()
   const [rendered, setRendered] = useState(false)
   useEffect(() => {
     // Marks first-mount completion so later effects can skip their initial
@@ -126,7 +134,20 @@ const MapWrapper = () => {
       // Set an event listener that fires
       // when a geolocate event occurs.
       geolocate.on("geolocate", (e) => {
-        setSelectedCoordinates([e.coords.longitude, e.coords.latitude])
+        const { longitude, latitude } = e.coords
+        setSelectedCoordinates([longitude, latitude])
+
+        fetch(`/api/reverse-geocode?longitude=${longitude}&latitude=${latitude}`)
+          .then((res) => res.json())
+          .then((data: { features?: GeoJSONFeature[] }) => {
+            const placeName = data.features?.[0]?.properties?.full_address
+            if (placeName) {
+              setSelectedLocation(placeName)
+            }
+          })
+          .catch((err) => {
+            console.error("Failed to reverse geocode geolocated position", err)
+          })
       })
     }
 

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -10,6 +10,25 @@ import type { Feature, FeatureCollection } from "geojson"
 import type { EventResponse } from "./hooks/eventsStream"
 
 const INITIAL_ZOOM = 1
+const MILES_PER_DEGREE_LATITUDE = 69
+
+/** Bounding box (west/south, east/north) for a circle of `radiusMiles`
+ * around `center`. Approximate — fine for camera framing, not for
+ * distance math. */
+function boundsForRadius(
+  center: [number, number],
+  radiusMiles: number
+): [[number, number], [number, number]] {
+  const [lng, lat] = center
+  const latDelta = radiusMiles / MILES_PER_DEGREE_LATITUDE
+  const cosLat = Math.max(Math.cos((lat * Math.PI) / 180), 0.01)
+  const lngDelta = radiusMiles / (MILES_PER_DEGREE_LATITUDE * cosLat)
+
+  return [
+    [lng - lngDelta, lat - latDelta],
+    [lng + lngDelta, lat + latDelta],
+  ]
+}
 
 const MapWrapper = () => {
   const { selectedCoordinates, setSelectedCoordinates, dateRange } =
@@ -28,6 +47,9 @@ const MapWrapper = () => {
     eventsByDate,
     selectEvents,
     selectedEvents,
+    isStreaming,
+    searchRadius,
+    radiusExpanded,
   } = useEventsContext()
   const mapRef = useRef<mapboxgl.Map | null>(null)
   const mapContainer = useRef<HTMLDivElement | null>(null)
@@ -148,10 +170,9 @@ const MapWrapper = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const { latitude, longitude, radius, start, end } = {
+  const { latitude, longitude, start, end } = {
     latitude: selectedCoordinates[1],
     longitude: selectedCoordinates[0],
-    radius: 10,
     start: dateRange.start.toString() + "T00:00:00Z",
     end: dateRange.end.toString() + "T23:59:59Z",
   }
@@ -160,16 +181,14 @@ const MapWrapper = () => {
     void streamEvents({
       latitude,
       longitude,
-      radius,
       start,
       end,
     })
-    console.log("streaming", latitude, longitude, radius, start, end)
 
     return () => {
       cancelStream()
     }
-  }, [latitude, longitude, radius, start, end, streamEvents, cancelStream, rendered])
+  }, [latitude, longitude, start, end, streamEvents, cancelStream, rendered])
 
   useEffect(() => {
     const markEvents = () => {
@@ -345,6 +364,17 @@ const MapWrapper = () => {
       speed: 0.8,
     })
   }, [selectedCoordinates, rendered])
+
+  // Once a search had to widen past the base radius to find anything,
+  // zoom out to frame the actual area covered instead of staying zoomed
+  // in on a radius that came up empty.
+  useEffect(() => {
+    if (isStreaming || !radiusExpanded || !searchRadius) return
+    mapRef.current?.fitBounds(boundsForRadius(selectedCoordinates, searchRadius), {
+      padding: 60,
+      duration: 800,
+    })
+  }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates])
 
   return (
     <>

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -15,21 +15,34 @@ import {
 } from "../reducers/events"
 import { type EventResponse } from "@/hooks/eventsStream"
 
-type StreamConcertsParams = {
+// Search radii (miles) tried in order until one returns events. Lets
+// sparsely-served (e.g. rural) locations still find something instead of
+// permanently showing an empty result at the default radius.
+const RADIUS_TIERS = [10, 50, 150] as const
+const BASE_RADIUS = RADIUS_TIERS[0]
+
+type StreamConcertsInput = {
   latitude: number
   longitude: number
-  radius: number
   start: string
   end: string
 }
 
+type StreamConcertsParams = StreamConcertsInput & {
+  radius: number
+}
+
 type EventsContextValue = EventsState & {
-  streamEvents: (params: StreamConcertsParams) => Promise<void>
+  streamEvents: (params: StreamConcertsInput) => Promise<void>
   cancelStream: () => void
   selectEvents: (events: EventResponse[]) => void
   resetEvents: () => void
   selectedEvent: EventResponse | undefined
   setSelectedEvent: (event: EventResponse | undefined) => void
+  /** The radius (miles) the current/last search actually used. */
+  searchRadius: number | null
+  /** Whether searchRadius went beyond the base tier to find results. */
+  radiusExpanded: boolean
 }
 
 function buildConcertStreamUrl(params: StreamConcertsParams) {
@@ -48,6 +61,7 @@ const EventsContext = createContext<EventsContextValue | null>(null)
 export function EventsProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(eventsReducer, initialEventsState)
   const abortRef = useRef<AbortController | null>(null)
+  const [searchRadius, setSearchRadius] = React.useState<number | null>(null)
 
   const cancelStream = useCallback(() => {
     abortRef.current?.abort()
@@ -57,28 +71,23 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
 
   const resetEvents = useCallback(() => {
     dispatch({ type: "RESET_EVENTS" })
+    setSearchRadius(null)
   }, [])
 
   const selectEvents = useCallback((events: EventResponse[]) => {
     dispatch({ type: "SELECT_EVENTS", payload: events })
   }, [])
 
-  const streamEvents = useCallback(async (params: StreamConcertsParams) => {
-    abortRef.current?.abort()
-
-    const controller = new AbortController()
-    abortRef.current = controller
-
-    dispatch({ type: "RESET_EVENTS" })
-    dispatch({ type: "STREAM_STATUS", payload: { isStreaming: true } })
-
-    try {
+  /** Runs one radius tier's request to completion. Returns the number of
+   * events the server sent for this request (pre-dedup). */
+  const runStream = useCallback(
+    async (params: StreamConcertsParams, signal: AbortSignal) => {
       const response = await fetch(buildConcertStreamUrl(params), {
         method: "GET",
         headers: {
           Accept: "application/x-ndjson",
         },
-        signal: controller.signal,
+        signal,
       })
 
       if (!response.ok) {
@@ -93,6 +102,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       const reader = response.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ""
+      let count = 0
 
       try {
         while (true) {
@@ -110,6 +120,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
 
             const event = JSON.parse(trimmed) as EventResponse
             dispatch({ type: "UPSERT_STREAMED_EVENT", payload: event })
+            count++
           }
         }
 
@@ -119,30 +130,67 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
         if (trailing) {
           const event = JSON.parse(trailing) as EventResponse
           dispatch({ type: "UPSERT_STREAMED_EVENT", payload: event })
+          count++
         }
       } finally {
         reader.releaseLock()
       }
 
-      dispatch({ type: "STREAM_STATUS", payload: { isStreaming: false } })
-    } catch (err) {
-      if (controller.signal.aborted) {
-        return
-      }
+      return count
+    },
+    []
+  )
 
-      dispatch({
-        type: "STREAM_ERROR",
-        payload: err instanceof Error ? err.message : "Unknown stream error",
-      })
-    } finally {
-      if (abortRef.current === controller) {
-        abortRef.current = null
+  const streamEvents = useCallback(
+    async (params: StreamConcertsInput) => {
+      abortRef.current?.abort()
+
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      dispatch({ type: "RESET_EVENTS" })
+      dispatch({ type: "STREAM_STATUS", payload: { isStreaming: true } })
+      setSearchRadius(null)
+
+      try {
+        let totalCount = 0
+
+        for (const radius of RADIUS_TIERS) {
+          if (controller.signal.aborted) return
+
+          const tierCount = await runStream(
+            { ...params, radius },
+            controller.signal
+          )
+          totalCount += tierCount
+          setSearchRadius(radius)
+
+          if (totalCount > 0) break
+        }
+
+        dispatch({ type: "STREAM_STATUS", payload: { isStreaming: false } })
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return
+        }
+
+        dispatch({
+          type: "STREAM_ERROR",
+          payload: err instanceof Error ? err.message : "Unknown stream error",
+        })
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null
+        }
       }
-    }
-  }, [])
+    },
+    [runStream]
+  )
   const [selectedEvent, setSelectedEvent] = React.useState<
     EventResponse | undefined
   >(undefined)
+
+  const radiusExpanded = searchRadius !== null && searchRadius > BASE_RADIUS
 
   const value = useMemo(
     () => ({
@@ -153,8 +201,19 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       selectEvents,
       selectedEvent,
       setSelectedEvent,
+      searchRadius,
+      radiusExpanded,
     }),
-    [state, streamEvents, cancelStream, resetEvents, selectEvents, selectedEvent]
+    [
+      state,
+      streamEvents,
+      cancelStream,
+      resetEvents,
+      selectEvents,
+      selectedEvent,
+      searchRadius,
+      radiusExpanded,
+    ]
   )
 
   return (

--- a/apps/web/src/reducers/events.test.ts
+++ b/apps/web/src/reducers/events.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest"
+import {
+  eventDateKey,
+  eventsReducer,
+  initialEventsState,
+  sameEvent,
+  sortEvents,
+  type EventsState,
+} from "./events"
+import type { EventResponse } from "../hooks/eventsStream"
+
+function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
+  return {
+    id: "1",
+    name: "Test Event",
+    images: [],
+    dates: "2026-08-01T20:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("eventDateKey", () => {
+  it("returns the YYYY-MM-DD portion of a valid date", () => {
+    expect(eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }))).toBe(
+      "2026-08-01"
+    )
+  })
+
+  it("returns 'unknown' when dates is missing", () => {
+    expect(eventDateKey(makeEvent({ dates: null }))).toBe("unknown")
+  })
+
+  it("returns 'unknown' when dates is not a parseable date", () => {
+    expect(eventDateKey(makeEvent({ dates: "not-a-date" }))).toBe("unknown")
+  })
+})
+
+describe("sameEvent", () => {
+  it("is true when ids match, regardless of other fields", () => {
+    const a = makeEvent({ id: "1", dates: "2026-08-01T20:00:00Z" })
+    const b = makeEvent({ id: "1", dates: "2026-09-01T20:00:00Z" })
+    expect(sameEvent(a, b)).toBe(true)
+  })
+
+  it("is true for different ids with matching date, venue, and attraction", () => {
+    // Ticketmaster returns the same show under different ids across
+    // overlapping date windows; this is the whole point of sameEvent.
+    const a = makeEvent({
+      id: "tm-1",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "The Venue" },
+      attractions: [{ id: "artist-1" }],
+    })
+    const b = makeEvent({
+      id: "tm-2",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "The Venue" },
+      attractions: [{ id: "artist-1" }],
+    })
+    expect(sameEvent(a, b)).toBe(true)
+  })
+
+  it("is false when the venue differs", () => {
+    const a = makeEvent({
+      id: "tm-1",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "Venue A" },
+    })
+    const b = makeEvent({
+      id: "tm-2",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "Venue B" },
+    })
+    expect(sameEvent(a, b)).toBe(false)
+  })
+
+  it("is false when the date differs", () => {
+    const a = makeEvent({ id: "tm-1", dates: "2026-08-01T20:00:00Z" })
+    const b = makeEvent({ id: "tm-2", dates: "2026-08-02T20:00:00Z" })
+    expect(sameEvent(a, b)).toBe(false)
+  })
+})
+
+describe("sortEvents", () => {
+  it("sorts events by date ascending", () => {
+    const later = makeEvent({ id: "1", name: "Later", dates: "2026-08-02T00:00:00Z" })
+    const earlier = makeEvent({ id: "2", name: "Earlier", dates: "2026-08-01T00:00:00Z" })
+    expect(sortEvents([later, earlier])).toEqual([earlier, later])
+  })
+
+  it("sorts events without a date after dated events", () => {
+    const dated = makeEvent({ id: "1", name: "Dated", dates: "2026-08-01T00:00:00Z" })
+    const undated = makeEvent({ id: "2", name: "Undated", dates: null })
+    expect(sortEvents([undated, dated])).toEqual([dated, undated])
+  })
+
+  it("breaks ties on the same date by name", () => {
+    const b = makeEvent({ id: "1", name: "B Event", dates: "2026-08-01T00:00:00Z" })
+    const a = makeEvent({ id: "2", name: "A Event", dates: "2026-08-01T00:00:00Z" })
+    expect(sortEvents([b, a])).toEqual([a, b])
+  })
+
+  it("does not mutate the input array", () => {
+    const events = [
+      makeEvent({ id: "1", dates: "2026-08-02T00:00:00Z" }),
+      makeEvent({ id: "2", dates: "2026-08-01T00:00:00Z" }),
+    ]
+    const original = [...events]
+    sortEvents(events)
+    expect(events).toEqual(original)
+  })
+})
+
+describe("eventsReducer", () => {
+  it("RESET_EVENTS clears state back to initial", () => {
+    const dirty: EventsState = {
+      eventsByDate: { "2026-08-01": [makeEvent()] },
+      isStreaming: true,
+      selectedEvents: [makeEvent()],
+      error: "boom",
+    }
+    expect(eventsReducer(dirty, { type: "RESET_EVENTS" })).toEqual(
+      initialEventsState
+    )
+  })
+
+  it("STREAM_STATUS updates isStreaming only", () => {
+    const next = eventsReducer(initialEventsState, {
+      type: "STREAM_STATUS",
+      payload: { isStreaming: true },
+    })
+    expect(next.isStreaming).toBe(true)
+    expect(next.eventsByDate).toBe(initialEventsState.eventsByDate)
+  })
+
+  it("STREAM_ERROR sets the error and stops streaming", () => {
+    const streaming: EventsState = { ...initialEventsState, isStreaming: true }
+    const next = eventsReducer(streaming, {
+      type: "STREAM_ERROR",
+      payload: "network error",
+    })
+    expect(next.error).toBe("network error")
+    expect(next.isStreaming).toBe(false)
+  })
+
+  it("UPSERT_STREAMED_EVENT buckets a new event by its date key", () => {
+    const event = makeEvent({ dates: "2026-08-01T20:00:00Z" })
+    const next = eventsReducer(initialEventsState, {
+      type: "UPSERT_STREAMED_EVENT",
+      payload: event,
+    })
+    expect(next.eventsByDate["2026-08-01"]).toEqual([event])
+  })
+
+  it("UPSERT_STREAMED_EVENT does not insert a duplicate of the same event", () => {
+    const event = makeEvent({
+      id: "tm-1",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "The Venue" },
+    })
+    const duplicate = makeEvent({
+      id: "tm-2",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "The Venue" },
+    })
+
+    const afterFirst = eventsReducer(initialEventsState, {
+      type: "UPSERT_STREAMED_EVENT",
+      payload: event,
+    })
+    const afterSecond = eventsReducer(afterFirst, {
+      type: "UPSERT_STREAMED_EVENT",
+      payload: duplicate,
+    })
+
+    expect(afterSecond.eventsByDate["2026-08-01"]).toHaveLength(1)
+    expect(afterSecond).toBe(afterFirst)
+  })
+
+  it("SELECT_EVENTS replaces selectedEvents", () => {
+    const events = [makeEvent({ id: "1" }), makeEvent({ id: "2" })]
+    const next = eventsReducer(initialEventsState, {
+      type: "SELECT_EVENTS",
+      payload: events,
+    })
+    expect(next.selectedEvents).toBe(events)
+  })
+
+  it("returns the same state reference for an unknown action", () => {
+    // @ts-expect-error intentionally testing the default branch
+    expect(eventsReducer(initialEventsState, { type: "NOOP" })).toBe(
+      initialEventsState
+    )
+  })
+})

--- a/apps/web/src/reducers/events.ts
+++ b/apps/web/src/reducers/events.ts
@@ -118,4 +118,11 @@ const initialEventsState: EventsState = {
   error: null,
 }
 
-export { type EventsState, eventsReducer, initialEventsState }
+export {
+  type EventsState,
+  eventsReducer,
+  initialEventsState,
+  eventDateKey,
+  sameEvent,
+  sortEvents,
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import path from "path"
 import { defineConfig } from "vite"
 import tailwindcss from "@tailwindcss/vite"
@@ -27,5 +28,9 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/api/, ""),
       },
     },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.4)(vite@8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0))
 
   packages/ui:
     dependencies:
@@ -1643,6 +1646,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
@@ -1791,6 +1797,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1889,6 +1901,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1947,6 +1988,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -2013,6 +2058,10 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2233,6 +2282,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -2311,6 +2363,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2334,6 +2389,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -3016,6 +3075,10 @@ packages:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3104,6 +3167,9 @@ packages:
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3446,6 +3512,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3464,9 +3533,15 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3554,9 +3629,20 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3722,6 +3808,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3730,6 +3857,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3979,11 +4111,11 @@ snapshots:
       enquirer: 2.4.1
       env-paths: 2.2.1
       execa: 5.1.1
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       ignore: 5.3.2
       object-treeify: 1.1.33
       open: 8.4.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       systeminformation: 5.31.11
       undici: 7.28.0
       which: 4.0.0
@@ -5192,6 +5324,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
@@ -5327,6 +5461,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -5448,6 +5589,47 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0))
       babel-plugin-react-compiler: 1.0.0
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -5496,6 +5678,8 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -5567,6 +5751,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5733,6 +5919,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.1: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -5857,6 +6045,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -5893,6 +6085,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -5952,9 +6146,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   figures@6.1.0:
     dependencies:
@@ -6436,6 +6630,8 @@ snapshots:
 
   object-treeify@1.1.33: {}
 
+  obug@2.1.4: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6532,6 +6728,8 @@ snapshots:
   path-key@4.0.0: {}
 
   path-to-regexp@8.4.2: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -6938,6 +7136,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -6948,7 +7148,11 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -7016,10 +7220,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7141,6 +7351,33 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
+  vitest@4.1.10(@types/node@25.9.4)(vite@8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.4
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -7148,6 +7385,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

Phase 3 of the tech debt follow-up (see #5, #6) — the two remaining duplication items from the original audit and a first pass at test coverage — plus two feature additions requested afterward, added as follow-up commits.

**Ticketmaster normalization dedup**: `services/playlist_builder.rs` reimplemented `ticketmaster_stream.rs`'s `normalize_event`/dedup logic almost verbatim. Both now call the same `pub(crate)` functions.

**Provider HTTP/auth dedup**:
- New `apps/api/src/http_utils.rs`: shared `request_with_backoff` + `parse_retry_after`, replacing two near-identical 40-line 429-retry loops in `spotify/client.rs` and `apple_music/client.rs`.
- Same module also replaces **three** hand-rolled, inconsistent `urlencoding()` implementations with one `url_encode()` backed by the `percent-encoding` crate. This wasn't just style drift — `auth.rs`/`spotify/client.rs` encoded space as `%20`, `apple_music/client.rs` encoded it as `+` and didn't escape most reserved or non-ASCII characters at all. A search term like "Sigur Rós" would have gone out unescaped.
- New `apps/api/src/token_cache.rs`: a generic `TokenCache<T>` used by `apple_music/auth.rs`'s `DeveloperTokenManager` and `auth.rs`'s `ClientCredentialsManager`. The latter turned out to be a real bug, not just duplication — its `cached` field was declared but never read anywhere, so it silently hit Spotify's token endpoint on **every single call** instead of caching. `UserTokenManager` is deliberately left as-is: its refresh flow holds a lock across the network call to avoid a thundering herd on concurrent refreshes, a guarantee the simple cache's `get`/`set` API can't replicate safely.
- Also removed a stray `println!` of an artist name in `spotify/client.rs`, spotted while in there.

**Tests**: first real test coverage in the repo — 20 Rust unit tests (`normalize_event`, `dedupe_key`, `date_windows`, `TokenCache`, `url_encode`) and 18 frontend tests (`eventsReducer` and its helpers, via a newly-added `vitest` setup). CI now runs both suites on every PR.

**Auto-expanding search radius**: rural/sparsely-served locations previously got a permanent empty result at the fixed 10mi search radius. `streamEvents` now tries progressively wider radii (10 → 50 → 150mi) until one returns events. The map reframes via `fitBounds` to show the actual area covered once a search had to expand, the events header shows "Showing events within Xmi" when it did, and the empty state calls out the radius actually searched. `EventsDrawer` also now distinguishes "still searching" from "confirmed empty" (`isStreaming`), since a multi-tier search can take a few seconds. Radius is intentionally not user-configurable — this is a zero-results fallback, not a primary search parameter.

**Geolocate populates the city name**: clicking the map's geolocate control previously only updated `selectedCoordinates`, leaving the search box's city label stale. Added a `/reverse-geocode` endpoint mirroring the existing `/cities` forward-geocode handler (shared fetch/decode logic factored into `fetch_mapbox_features` rather than duplicated a third time), called from the geolocate handler to set `selectedLocation` from the resulting `full_address` — the same field `Search.tsx` already reads for a searched result, so geolocated and searched locations behave identically everywhere else in the app. Also fixed `/cities`' forward query to go through `url_encode`, which it wasn't before.

## Test plan

- [x] `cargo check --bins` passes clean
- [x] `cargo test --lib` — 20/20 passing
- [x] `pnpm turbo build --filter web` passes clean
- [x] `pnpm turbo test --filter web` — 18/18 passing
- [x] `pnpm turbo lint --filter web --filter @workspace/ui` — 0 errors, 1 pre-existing intentional warning
- [x] Radius expansion verified live against the real local API server: all three tiers fire in order, empty state correctly reads "No events found within 150mi", map visibly reframes
- [x] `/reverse-geocode` verified live against the real Mapbox API and through the Vite dev proxy: returns the expected `full_address` shape end-to-end
- [ ] The actual geolocate button click → browser geolocation permission → `full_address` set flow isn't verifiable in this environment (headless browser reports no geolocation support), but every other link in the chain (endpoint, proxy routing, response parsing) is confirmed working
- [ ] Live Spotify/Apple Music OAuth flows (token caching, refresh) not verifiable in this environment — needs real provider credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)