### PR TITLE
Default to remembered/permission-granted location, fix a map crash

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -137,7 +137,9 @@ const MapWrapper = () => {
         const { longitude, latitude } = e.coords
         setSelectedCoordinates([longitude, latitude])
 
-        fetch(`/api/reverse-geocode?longitude=${longitude}&latitude=${latitude}`)
+        fetch(
+          `/api/reverse-geocode?longitude=${longitude}&latitude=${latitude}`
+        )
           .then((res) => res.json())
           .then((data: { features?: GeoJSONFeature[] }) => {
             const placeName = data.features?.[0]?.properties?.full_address
@@ -149,6 +151,31 @@ const MapWrapper = () => {
             console.error("Failed to reverse geocode geolocated position", err)
           })
       })
+
+      // Only auto-center on the user's real location if permission was
+      // already granted in a previous visit — never surprise a first-time
+      // visitor with a location prompt before they've done anything. If
+      // permission is still undecided or denied, the geolocate control
+      // above remains available for the user to trigger explicitly.
+      // Some browsers (and this app's own automated preview environment)
+      // throw synchronously for unsupported permission queries rather
+      // than rejecting the returned promise, so this whole check is
+      // wrapped defensively.
+      try {
+        navigator.permissions
+          ?.query({ name: "geolocation" })
+          .then((status) => {
+            if (status.state === "granted") {
+              geolocate.trigger()
+            }
+          })
+          .catch(() => {
+            // Permission query unsupported/rejected — fall back to
+            // requiring an explicit button click.
+          })
+      } catch {
+        // Permissions API not available at all in this browser.
+      }
     }
 
     // When a click event occurs on a feature in the places layer, open a popup at the
@@ -249,13 +276,29 @@ const MapWrapper = () => {
           }
           dataSource.features.push(feature)
         })
+      })
 
-        if (mapRef.current?.getLayer("events")) {
-          mapRef.current.removeLayer("events")
+      // This effect re-runs on every streamed-in event (it depends on
+      // eventsByDate, which changes per NDJSON line), so for a city with
+      // many results it can fire dozens of times in quick succession —
+      // and can fire before the map's style has finished loading, which
+      // makes Mapbox throw ("Style is not done loading") on addSource.
+      // Kansas-sparse locations rarely hit this race; a dense city like
+      // New York reliably does. Defer to the map's own "load" event when
+      // the style isn't ready yet, and once a source exists, update its
+      // data in place instead of removing/re-adding it every run (which
+      // also separately trips an internal Mapbox GL terrain-update bug
+      // when done rapidly).
+      const applyToMap = () => {
+        const existingSource = mapRef.current?.getSource(
+          "event-data-source"
+        ) as GeoJSONSource | undefined
+
+        if (existingSource) {
+          existingSource.setData(dataSource)
+          return
         }
-        if (mapRef.current?.getSource("event-data-source")) {
-          mapRef.current.removeSource("event-data-source")
-        }
+
         mapRef.current?.addSource("event-data-source", {
           type: "geojson",
           promoteId: "id",
@@ -320,7 +363,13 @@ const MapWrapper = () => {
             "text-halo-width": 2,
           },
         })
-      })
+      }
+
+      if (mapRef.current?.isStyleLoaded()) {
+        applyToMap()
+      } else {
+        mapRef.current?.once("load", applyToMap)
+      }
     }
 
     markEvents()
@@ -391,10 +440,13 @@ const MapWrapper = () => {
   // in on a radius that came up empty.
   useEffect(() => {
     if (isStreaming || !radiusExpanded || !searchRadius) return
-    mapRef.current?.fitBounds(boundsForRadius(selectedCoordinates, searchRadius), {
-      padding: 60,
-      duration: 800,
-    })
+    mapRef.current?.fitBounds(
+      boundsForRadius(selectedCoordinates, searchRadius),
+      {
+        padding: 60,
+        duration: 800,
+      }
+    )
   }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates])
 
   return (

--- a/apps/web/src/providers/searchProvider.tsx
+++ b/apps/web/src/providers/searchProvider.tsx
@@ -7,7 +7,41 @@ import {
 } from "@internationalized/date"
 import { type RangeValue } from "react-aria"
 
-const INITIAL_CENTER: [number, number] = [-24, 42]
+// Geographic center of the contiguous US — used only when there's no
+// remembered location and geolocation permission hasn't already been
+// granted. Previously this defaulted to the middle of the Atlantic.
+const DEFAULT_CENTER: [number, number] = [-98.5795, 39.8283]
+
+const COORDINATES_STORAGE_KEY = "gigeo:lastCoordinates"
+const LOCATION_STORAGE_KEY = "gigeo:lastLocation"
+
+function readStoredCoordinates(): [number, number] | undefined {
+  try {
+    const raw = localStorage.getItem(COORDINATES_STORAGE_KEY)
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw)
+    if (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      typeof parsed[0] === "number" &&
+      typeof parsed[1] === "number"
+    ) {
+      return [parsed[0], parsed[1]]
+    }
+  } catch {
+    // localStorage unavailable (e.g. private browsing) or malformed value —
+    // fall through to the default.
+  }
+  return undefined
+}
+
+function readStoredLocation(): string | undefined {
+  try {
+    return localStorage.getItem(LOCATION_STORAGE_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
 
 type SearchProviderState = {
   selectedLocation: string | undefined
@@ -31,14 +65,40 @@ export const SearchProviderContext = React.createContext<
 export function SearchProvider({ children }: SearchProviderProps) {
   const [selectedLocation, setSelectedLocation] = React.useState<
     string | undefined
-  >(undefined)
-  const [selectedCoordinates, setSelectedCoordinates] =
-    React.useState<[number, number]>(INITIAL_CENTER)
+  >(readStoredLocation)
+  const [selectedCoordinates, setSelectedCoordinates] = React.useState<
+    [number, number]
+  >(() => readStoredCoordinates() ?? DEFAULT_CENTER)
   const [dateRange, setDateRange] = React.useState<RangeValue<CalendarDate>>({
     start: today(getLocalTimeZone()),
     end: today(getLocalTimeZone()).add({ weeks: 1 }),
   })
   const inputRef = React.useRef<HTMLInputElement | null>(null)
+
+  // Remember the last selected location so a returning visitor starts
+  // where they left off instead of the static default every time.
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(
+        COORDINATES_STORAGE_KEY,
+        JSON.stringify(selectedCoordinates)
+      )
+    } catch {
+      // Ignore — localStorage may be unavailable (e.g. private browsing).
+    }
+  }, [selectedCoordinates])
+
+  React.useEffect(() => {
+    try {
+      if (selectedLocation) {
+        localStorage.setItem(LOCATION_STORAGE_KEY, selectedLocation)
+      } else {
+        localStorage.removeItem(LOCATION_STORAGE_KEY)
+      }
+    } catch {
+      // Ignore — localStorage may be unavailable (e.g. private browsing).
+    }
+  }, [selectedLocation])
 
   const focusSearchInput = () => {
     console.log("Focusing search input", inputRef.current)


### PR DESCRIPTION
## Summary
- Default map center changes from the middle of the Atlantic Ocean to the geographic center of the contiguous US, used only when there's no remembered location and geolocation hasn't already been granted.
- If the browser reports geolocation permission as already `granted`, silently re-center on the user's location without a new prompt.
- Persist the last selected location/coordinates to `localStorage` so returning visitors start where they left off.
- Fix a real, pre-existing crash in `MapWrapper`'s event-marker rendering: it recreated the Mapbox source/layer on every streamed event update (tripping an internal Mapbox terrain bug) and could run before the map style finished loading. Now uses `GeoJSONSource.setData()` to update in place and defers first-time source/layer creation until `map.isStyleLoaded()`.

## Test plan
- [x] `lint`, `build`, and full test suite passing
- [x] Verified in-browser: first-time visitor (no permission, no stored location) lands on the US default without crashing
- [x] Verified in-browser: returning visitor with stored NYC coordinates re-centers correctly and renders dense event data without crashing
- [x] Verified in-browser: granted-permission path silently re-centers on real location

🤖 Generated with [Claude Code](https://claude.com/claude-code)