### PR TITLE
Fix stale search-radius/zoom leaking across location changes

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -23,7 +23,6 @@ function boundsForRadius(
   center: [number, number],
   radiusMiles: number
 ): [[number, number], [number, number]] {
-  console.log("radius", radiusMiles)
   const [lng, lat] = center
   const latDelta = radiusMiles / MILES_PER_DEGREE_LATITUDE
   const cosLat = Math.max(Math.cos((lat * Math.PI) / 180), 0.01)
@@ -88,7 +87,7 @@ const MapWrapper = () => {
   useEffect(() => {
     const venueLocation = selectedEvents[0]?.venue?.location
     if (selectedEvents.length && venueLocation !== undefined) {
-      // const { latitude, longitude } = venueLocation
+      const { latitude, longitude } = venueLocation
       mapRef.current?.setLayoutProperty("events", "icon-image", [
         "case",
         ["==", ["get", "id"], selectedEvents[0].id],
@@ -102,12 +101,15 @@ const MapWrapper = () => {
         "marker-yellow",
         "marker-red",
       ])
-      // if (latitude && longitude) {
-      //   mapRef.current?.flyTo({
-      //     center: { lat: parseFloat(latitude), lng: parseFloat(longitude) },
-      //     speed: 0.8,
-      //   })
-      // }
+      // Selecting an event from the drawer list doesn't necessarily mean
+      // the map is already showing its venue (unlike clicking a marker
+      // directly, where it's a harmless no-op), so fly there.
+      if (latitude && longitude) {
+        mapRef.current?.flyTo({
+          center: { lat: parseFloat(latitude), lng: parseFloat(longitude) },
+          speed: 0.8,
+        })
+      }
     }
   }, [selectedEvents])
 
@@ -446,7 +448,6 @@ const MapWrapper = () => {
   // zoom out to frame the actual area covered instead of staying zoomed
   // in on a radius that came up empty.
   useEffect(() => {
-    console.log(isStreaming, radiusExpanded, searchRadius)
     if (isStreaming || !radiusExpanded || !searchRadius) return
     mapRef.current?.fitBounds(
       boundsForRadius(selectedCoordinates, searchRadius),
@@ -455,7 +456,6 @@ const MapWrapper = () => {
         duration: 800,
       }
     )
-    console.log("zooming")
   }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates])
 
   return (

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -23,6 +23,7 @@ function boundsForRadius(
   center: [number, number],
   radiusMiles: number
 ): [[number, number], [number, number]] {
+  console.log("radius", radiusMiles)
   const [lng, lat] = center
   const latDelta = radiusMiles / MILES_PER_DEGREE_LATITUDE
   const cosLat = Math.max(Math.cos((lat * Math.PI) / 180), 0.01)
@@ -52,6 +53,7 @@ const MapWrapper = () => {
   const {
     streamEvents,
     cancelStream,
+    resetEvents,
     eventsByDate,
     selectEvents,
     selectedEvents,
@@ -86,7 +88,7 @@ const MapWrapper = () => {
   useEffect(() => {
     const venueLocation = selectedEvents[0]?.venue?.location
     if (selectedEvents.length && venueLocation !== undefined) {
-      const { latitude, longitude } = venueLocation
+      // const { latitude, longitude } = venueLocation
       mapRef.current?.setLayoutProperty("events", "icon-image", [
         "case",
         ["==", ["get", "id"], selectedEvents[0].id],
@@ -100,12 +102,12 @@ const MapWrapper = () => {
         "marker-yellow",
         "marker-red",
       ])
-      if (latitude && longitude) {
-        mapRef.current?.flyTo({
-          center: { lat: parseFloat(latitude), lng: parseFloat(longitude) },
-          speed: 0.8,
-        })
-      }
+      // if (latitude && longitude) {
+      //   mapRef.current?.flyTo({
+      //     center: { lat: parseFloat(latitude), lng: parseFloat(longitude) },
+      //     speed: 0.8,
+      //   })
+      // }
     }
   }, [selectedEvents])
 
@@ -135,6 +137,11 @@ const MapWrapper = () => {
       // when a geolocate event occurs.
       geolocate.on("geolocate", (e) => {
         const { longitude, latitude } = e.coords
+        // Reset the search-radius state in the same commit as the
+        // coordinate change, otherwise the fitBounds effect below can
+        // briefly see the previous location's (possibly much wider)
+        // radius paired with the new coordinates and zoom out to match it.
+        resetEvents()
         setSelectedCoordinates([longitude, latitude])
 
         fetch(
@@ -439,6 +446,7 @@ const MapWrapper = () => {
   // zoom out to frame the actual area covered instead of staying zoomed
   // in on a radius that came up empty.
   useEffect(() => {
+    console.log(isStreaming, radiusExpanded, searchRadius)
     if (isStreaming || !radiusExpanded || !searchRadius) return
     mapRef.current?.fitBounds(
       boundsForRadius(selectedCoordinates, searchRadius),
@@ -447,6 +455,7 @@ const MapWrapper = () => {
         duration: 800,
       }
     )
+    console.log("zooming")
   }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates])
 
   return (

--- a/apps/web/src/Search.tsx
+++ b/apps/web/src/Search.tsx
@@ -4,6 +4,7 @@ import { TextField } from "@workspace/ui/components/ui/TextField"
 import { DateRangePicker } from "@workspace/ui/components/ui/DateRangePicker"
 import { useSearchProvider } from "./providers/searchProvider"
 import { useDrawerProvider } from "./providers/drawerProvider"
+import { useEventsContext } from "./providers/eventsProvider"
 
 const useDebounce = (value: string, delayTime: number) => {
   const [debounceValue, setDebounceValue] = useState(value)
@@ -29,6 +30,7 @@ const Search = () => {
     setInputRef,
   } = useSearchProvider()
   const { setIsDrawerOpen } = useDrawerProvider()
+  const { resetEvents } = useEventsContext()
 
   const [searchTerm, setSearchTerm] = useState("")
   const [places, setPlaces] = useState<GeoJSONFeature[]>([])
@@ -59,6 +61,10 @@ const Search = () => {
     if (place.geometry.type === "GeometryCollection") return
     const coordinates = place.geometry.coordinates as [number, number]
     setPlaces([place])
+    // Reset in the same commit as the coordinate change — see the matching
+    // comment in MapWrapper's geolocate handler for why this must not be
+    // left to streamEvents' own (one-render-late) reset.
+    resetEvents()
     setSelectedCoordinates([coordinates[0], coordinates[1]])
     setSelectedLocation(place.properties?.full_address)
     setIsDrawerOpen(true)

--- a/apps/web/src/providers/searchProvider.tsx
+++ b/apps/web/src/providers/searchProvider.tsx
@@ -101,11 +101,9 @@ export function SearchProvider({ children }: SearchProviderProps) {
   }, [selectedLocation])
 
   const focusSearchInput = () => {
-    console.log("Focusing search input", inputRef.current)
     inputRef.current?.focus()
   }
   const setInputRef = (ref: HTMLInputElement | null) => {
-    console.log("Setting input ref", ref)
     inputRef.current = ref
   }
 


### PR DESCRIPTION
## Summary
- Both the geolocate control and the search bar's place selection called `setSelectedCoordinates` without resetting the events provider's radius state in the same React commit.
- Because that reset previously only happened inside `streamEvents` (fired from a separate effect a render later), the `fitBounds` effect could briefly see the *previous* location's expanded search radius paired with the *new* coordinates, and zoom out to match it.
- Reproducible by starting on a sparse location (e.g. Lebanon, KS) and then jumping to a dense one (e.g. via the geolocate button) — the wide zoom stuck around instead of the map re-centering at the normal zoom.
- Fix: call `resetEvents()` synchronously alongside `setSelectedCoordinates` at both call sites (`MapWrapper`'s geolocate handler, `Search`'s `selectPlace`), so the radius reset lands in the same commit as the coordinate change.

## Test plan
- [x] `lint`, `build`, and full test suite passing
- [x] Verified in-browser: starting from a sparse default location (radius expanded to 150mi) then selecting a dense city (Portland, ME) via the search bar — map immediately zooms to street-level with individual event markers instead of staying zoomed out
- [x] Verified the radius-expansion behavior itself still works correctly for genuinely sparse locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)