### PR TITLE
Phase 1 tech debt cleanup: fix input panics, remove debug cruft

### DIFF
--- a/apps/api/src/ticketmaster_stream.rs
+++ b/apps/api/src/ticketmaster_stream.rs
@@ -348,17 +348,15 @@ pub async fn get_concerts_tm_stream(
         },
         6,
     )
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to encode geohash: {e}"),
-        )
-    })
-    .unwrap();
+    .map_err(|e| AppError::TicketmasterApi {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: format!("failed to encode geohash: {e}"),
+    })?;
 
-    let windows = date_windows(&params.start, &params.end)
-        .map_err(|e| (StatusCode::BAD_REQUEST, e))
-        .unwrap();
+    let windows = date_windows(&params.start, &params.end).map_err(|e| AppError::TicketmasterApi {
+        status: StatusCode::BAD_REQUEST,
+        message: e,
+    })?;
 
     let client = state.client.clone();
     let api_key = state.ticketmaster_key.clone();

--- a/apps/web/src/DateSlider.tsx
+++ b/apps/web/src/DateSlider.tsx
@@ -21,18 +21,14 @@ const DateSlider = ({
       if (idx % 7 === 0) {
         acc.push([curr])
       } else if (idx < 7) {
-        console.log(acc, idx, curr)
         acc[(idx % 7) - idx].push(curr)
       } else if (acc[idx % 7]) {
         acc[idx % 7].push(curr)
-      } else {
-        console.log("else", acc, idx, curr)
       }
       return acc
     },
     []
   )
-  console.log(groupedDates)
 
   return (
     <div className="flex w-full items-center">

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -41,7 +41,6 @@ const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
             (attraction) => `name=${encodeURIComponent(attraction.name || "")}`
           )
           .join("&")
-        console.log(artistInfoQuery)
         const res = await fetch(`/api/apple/artist?${artistInfoQuery}`)
         if (!res.ok) throw new Error("Request failed")
         const json = await res.json()
@@ -347,7 +346,6 @@ const ExternalLink = ({ url, label }: { url: string; label: string }) => {
 }
 
 const UpcomingEvents = ({ events }: { events: Event[] }) => {
-  console.log(events)
   return (
     <div className="mt-4">
       <h3 className="text-xs tracking-wide text-slate-400 uppercase">

--- a/apps/web/src/EventFilter.tsx
+++ b/apps/web/src/EventFilter.tsx
@@ -37,7 +37,6 @@ const EventFilter = () => {
       },
       {}
     )
-  console.log(classifications)
   return (
     <>
       <DialogTrigger>

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -268,7 +268,6 @@ const MapWrapper = () => {
             parseFloat(location?.longitude ?? ""),
             parseFloat(location?.latitude ?? ""),
           ]
-          //   coordinates.push([longitude, latitude]);
           const feature: Feature = {
             type: "Feature",
             properties: {

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -120,46 +120,6 @@ export function ThemeProvider({
     }
   }, [theme, applyTheme])
 
-  // React.useEffect(() => {
-  //   const handleKeyDown = (event: KeyboardEvent) => {
-  //     if (event.repeat) {
-  //       return
-  //     }
-
-  //     if (event.metaKey || event.ctrlKey || event.altKey) {
-  //       return
-  //     }
-
-  //     if (isEditableTarget(event.target)) {
-  //       return
-  //     }
-
-  //     if (event.key.toLowerCase() !== "d") {
-  //       return
-  //     }
-
-  //     setThemeState((currentTheme) => {
-  //       const nextTheme =
-  //         currentTheme === "dark"
-  //           ? "light"
-  //           : currentTheme === "light"
-  //             ? "dark"
-  //             : getSystemTheme() === "dark"
-  //               ? "light"
-  //               : "dark"
-
-  //       localStorage.setItem(storageKey, nextTheme)
-  //       return nextTheme
-  //     })
-  //   }
-
-  //   window.addEventListener("keydown", handleKeyDown)
-
-  //   return () => {
-  //     window.removeEventListener("keydown", handleKeyDown)
-  //   }
-  // }, [storageKey])
-
   React.useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
       if (event.storageArea !== localStorage) {


### PR DESCRIPTION
## Summary
Phase 1 of the tech-debt audit — the small, self-contained items.

- **Fix**: `/concerts/stream` panicked (client connection reset) on malformed `start`/`end` query params or an out-of-range `latitude`, instead of returning a proper 400/500. Both were already correctly mapped to an error shape and then discarded via `.unwrap()`. Confirmed live before/after against the running server.
- **Cleanup**: removed leftover `console.log` debug statements in `EventFilter.tsx`, `EventDetails.tsx`, and `DateSlider.tsx`, plus dead commented-out code in `MapWrapper.tsx` (stray line) and `theme-provider.tsx` (an inert ~40-line keyboard-shortcut effect that's been broken/uncallable since the file's initial commit — not a regression).

## Test plan
- [x] `cargo check --bins` / `cargo test --lib` (27 passed) for the API change
- [x] Verified live: `curl` with a malformed date and an out-of-range latitude both now return clean 400/500 JSON errors instead of a connection reset; `/health` stays up throughout
- [x] `lint` (no new errors), `tsc --noEmit`, and `vitest run` (18 passed) for the web changes
- [x] Verified in-browser: DateSlider still groups/renders dates correctly with the debug logs removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)