### PR TITLE
Fix drawer/playlist regressions from tab-sync and menu cleanup

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -8,9 +8,10 @@ import {
 } from "@workspace/ui/components/ui/Drawer"
 import { useEventsContext } from "../providers/eventsProvider"
 import { useMediaQuery } from "usehooks-ts"
-import { useEffect, useRef, lazy, Suspense } from "react"
+import { useEffect, useRef, useState, lazy, Suspense } from "react"
 import { VenueDetails } from "../VenueDetails"
 import { EventsDrawer, EventsDrawerHeader } from "./EventsDrawer"
+import type { Key } from "react-aria-components/Tabs"
 import { useDrawerProvider } from "@/providers/drawerProvider"
 
 const PlaylistsDrawerBody = lazy(() =>
@@ -38,11 +39,26 @@ import { Compass } from "lucide-react"
 const DrawerWrapper = () => {
   const { eventsByDate, selectedEvents } = useEventsContext()
   const { isDrawerOpen, setIsDrawerOpen } = useDrawerProvider()
+
+  const [activeTab, setActiveTab] = useState<Key>("explore")
   const eventListRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    // Syncs drawer visibility/active tab to event selection, which is owned
+    // by a different provider (eventsProvider) — not derivable at render
+    // time without lifting that state up or touching every selectEvents()
+    // call site (map marker clicks, drawer list clicks, etc.).
+    if (selectedEvents.length) {
+      setIsDrawerOpen(true)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setActiveTab("explore")
+    }
+  }, [selectedEvents, setIsDrawerOpen])
 
   useEffect(() => {
     if (!eventListRef.current) return
     setIsDrawerOpen(true)
+    setActiveTab("explore")
   }, [eventsByDate, setIsDrawerOpen])
   const isDesktop = useMediaQuery("(min-width: 768px)", {
     defaultValue: false,
@@ -55,6 +71,8 @@ const DrawerWrapper = () => {
     <Tabs
       orientation="vertical"
       className="h-[40vh] shrink-0 md:h-full md:w-[30rem]"
+      selectedKey={activeTab}
+      onSelectionChange={(t) => setActiveTab(t)}
     >
       <TabList
         aria-label="Tabs"

--- a/apps/web/src/Drawer/PlaylistsDrawer.tsx
+++ b/apps/web/src/Drawer/PlaylistsDrawer.tsx
@@ -3,11 +3,6 @@ import { useSpotifyAuth } from "../hooks/spotify"
 import { CircleCheck } from "lucide-react"
 
 import { Button } from "@workspace/ui/components/ui/Button"
-import {
-  Disclosure,
-  DisclosureHeader,
-  DisclosurePanel,
-} from "@workspace/ui/components/ui/Disclosure"
 import { RadioGroup, Radio } from "@workspace/ui/components/ui/RadioGroup"
 import {
   Tabs,
@@ -48,12 +43,12 @@ export const PlaylistsDrawerBody = () => {
         <TabPanels>
           <TabPanel id="playlists">
             <div className="flex flex-col gap-2">
-              {spotifyPlaylists.length > 0 && (
-                <Disclosure isDisabled={spotifyPlaylists.length === 0}>
-                  <DisclosureHeader>Spotify Playlists</DisclosureHeader>
-                  <DisclosurePanel>
+              {spotifyPlaylists.length > 0 ? (
+                <div>
+                  <h2>Spotify Playlists</h2>
+                  <ul>
                     {spotifyPlaylists.map((playlist) => (
-                      <div
+                      <li
                         key={playlist.id}
                         className="flex items-center gap-2 rounded-lg border border-gray-300 p-2 hover:bg-gray-100"
                       >
@@ -64,14 +59,15 @@ export const PlaylistsDrawerBody = () => {
                             className="h-12 w-12 rounded"
                           />
                         )}
-                      </div>
+                      </li>
                     ))}
-                  </DisclosurePanel>
-                </Disclosure>
+                  </ul>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center gap-4 p-4">
+                  <p>Gigeo is not managing any playlists.</p>
+                </div>
               )}
-              <div className="flex flex-col items-center justify-center gap-4 p-4">
-                <p>Gigeo is not managing any playlists.</p>
-              </div>
             </div>
           </TabPanel>
           <TabPanel id="add-playlist">

--- a/apps/web/src/PlaylistButtons.tsx
+++ b/apps/web/src/PlaylistButtons.tsx
@@ -3,11 +3,8 @@ import { Button } from "@workspace/ui/components/ui/Button"
 import SpotifyLogo from "./assets/Primary_Logo_Green_CMYK.svg"
 import { ReactSVG } from "react-svg"
 
-import { Menu, MenuTrigger, MenuItem } from "@workspace/ui/components/ui/Menu"
-
 export function PlaylistButtons() {
-  const { status, loading, error, connectSpotify, getPlaylists } =
-    useSpotifyAuth()
+  const { status, loading, error, connectSpotify, logout } = useSpotifyAuth()
 
   if (loading) return <div>Loading auth status…</div>
   if (error) return <div>Auth error: {error}</div>
@@ -23,16 +20,11 @@ export function PlaylistButtons() {
 
   return (
     <div className=" ">
-      <MenuTrigger>
-        <Button aria-label="Filters" variant="secondary" className="relative">
-          <ReactSVG className="h-[24px] w-[24px]" src={SpotifyLogo} />
-          Connected
-        </Button>
-        <Menu>
-          <MenuItem onClick={() => getPlaylists()}>Manage Playlists</MenuItem>
-          <MenuItem>Logout</MenuItem>
-        </Menu>
-      </MenuTrigger>
+      <Button aria-label="Filters" variant="secondary" className="relative">
+        <ReactSVG className="h-[24px] w-[24px]" src={SpotifyLogo} />
+        Connected
+      </Button>
+      <Button onClick={logout}>Logout</Button>
     </div>
   )
 }

--- a/apps/web/src/hooks/spotify.ts
+++ b/apps/web/src/hooks/spotify.ts
@@ -139,6 +139,15 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
     return res
   }, [setSpotifyPlaylists, setPlaylistManagement])
 
+  useEffect(() => {
+    // Fetch the user's playlists once Spotify is connected, so "My
+    // Playlists" has data without requiring a manual trigger.
+    if (status?.spotify_connected) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      void getPlaylists()
+    }
+  }, [status?.spotify_connected, getPlaylists])
+
   const createPlaylist = useCallback(
     async (input: FormData) => {
       setError(null)


### PR DESCRIPTION
## Summary
You asked me to review the changes on this branch to catch anything silly before shipping. Found two real regressions and fixed both:

- **`DrawerWrapper.tsx`**: the new effect that opens the drawer and switches to the "explore" tab when an event gets selected trips `react-hooks/set-state-in-effect` — an **error** in this repo's eslint config, not a warning, so it was failing `pnpm lint`. It's a legitimate cross-provider sync (`selectedEvents` is owned by `eventsProvider`, not something derivable at render time without a bigger refactor across every `selectEvents()` call site — map marker clicks, drawer list clicks, etc.), so it's disabled with the same justification pattern already used for `MapWrapper`'s mount-tracking effect. Also filled in the effect's missing `setIsDrawerOpen` dependency.
- **`PlaylistButtons.tsx`**: removing the "Manage Playlists" menu item dropped the only call site for `getPlaylists()`, which would've silently broken the "My Playlists" tab (`spotifyPlaylists` never populates). Moved the fetch into `useSpotifyAuth` as an effect that runs once `status.spotify_connected` is true, so playlists load automatically instead of needing a manual trigger.

Also picked up further cleanup you'd already made on this branch (the playlist list's empty-state logic, the logout button).

## Test plan
- [x] `eslint` — 0 errors (previously 1 error in `DrawerWrapper.tsx`)
- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)