### PR TITLE
Tech-debt: test update_mode branch, dedupe radio-card markup

### DIFF
--- a/apps/api/src/services/playlist_builder.rs
+++ b/apps/api/src/services/playlist_builder.rs
@@ -22,6 +22,19 @@ pub enum PlaylistUpdateMode {
     Destructive,
 }
 
+/// Resolves the requested `destructive` flag on a create-playlist request
+/// into the `PlaylistUpdateMode` stored for periodic updates.
+///
+/// `Some(true)` or `None` (omitted) both mean updates replace the
+/// playlist's tracks; `Some(false)` means updates only add tracks.
+pub fn resolve_update_mode(destructive: Option<bool>) -> PlaylistUpdateMode {
+    if destructive.unwrap_or(true) {
+        PlaylistUpdateMode::Destructive
+    } else {
+        PlaylistUpdateMode::Additive
+    }
+}
+
 pub async fn get_concerts_tm_impl(
     state: &AppState,
     params: &EventsQuery,
@@ -145,5 +158,25 @@ pub async fn search_tracks_for_artists(
     }
 
     Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_update_mode_true_is_destructive() {
+        assert_eq!(resolve_update_mode(Some(true)), PlaylistUpdateMode::Destructive);
+    }
+
+    #[test]
+    fn resolve_update_mode_false_is_additive() {
+        assert_eq!(resolve_update_mode(Some(false)), PlaylistUpdateMode::Additive);
+    }
+
+    #[test]
+    fn resolve_update_mode_none_defaults_to_destructive() {
+        assert_eq!(resolve_update_mode(None), PlaylistUpdateMode::Destructive);
+    }
 }
 

--- a/apps/api/src/spotify/spotify_handlers.rs
+++ b/apps/api/src/spotify/spotify_handlers.rs
@@ -9,7 +9,8 @@ use axum_extra::extract::Query as QueryArray;
 use axum_extra::extract::cookie::SignedCookieJar;
 use serde::{Deserialize, Serialize};
 use crate::services::playlist_builder::{
-    find_artist_names_near, search_tracks_for_artists, PlaylistUpdateMode, PlaylistVisibility,
+    find_artist_names_near, resolve_update_mode, search_tracks_for_artists, PlaylistUpdateMode,
+    PlaylistVisibility,
 };
 use crate::cookie::utils::build_session_cookie;
 use crate::error::AppError;
@@ -263,11 +264,7 @@ pub async fn create_playlist(
         PlaylistVisibility::Public
     };
 
-    let update_mode = if req.destructive.unwrap_or(true) {
-        PlaylistUpdateMode::Destructive
-    } else {
-        PlaylistUpdateMode::Additive
-    };
+    let update_mode = resolve_update_mode(req.destructive);
 
     create_playlist_record(
         &state.db.pool,

--- a/apps/web/src/Drawer/PlaylistsDrawer.tsx
+++ b/apps/web/src/Drawer/PlaylistsDrawer.tsx
@@ -84,6 +84,56 @@ const updateFrequencyOptions = [
   { value: "monthly", title: "Monthly", description: "Every 30 days" },
   { value: "bimonthly", title: "Bimonthly", description: "Every 60 days" },
 ]
+
+const updateBehaviorOptions = [
+  {
+    value: "destructive",
+    title: "Replace tracks",
+    description:
+      "Rebuild playlist from scratch on each update, keeping playlist light and fresh.",
+  },
+  {
+    value: "additive",
+    title: "Add new tracks",
+    description: "New tracks are added and old ones are preserved.",
+  },
+]
+
+const radioCardClassName =
+  "relative min-h-20 flex-1 cursor-default gap-1 rounded-lg border border-black/10 bg-white/80 p-3 text-left text-slate-700 transition select-none before:hidden before:content-none hover:border-black/20 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-white/10 dark:bg-zinc-900/70 dark:text-slate-200 dark:hover:border-white/20 selected:border-primary selected:bg-primary/5 selected:shadow-md"
+
+const RadioCard = ({
+  value,
+  title,
+  description,
+}: {
+  value: string
+  title: string
+  description: string
+}) => (
+  <Radio value={value} className={radioCardClassName}>
+    {({ isSelected }) => (
+      <>
+        <div className="min-w-0 pr-5">
+          <div className="text-sm font-semibold text-primary">{title}</div>
+          <span slot="description" className="text-xs text-muted-foreground">
+            {description}
+          </span>
+        </div>
+
+        {isSelected && (
+          <span
+            aria-hidden="true"
+            className="absolute top-3 right-3 text-primary"
+          >
+            <CircleCheck size={16} />
+          </span>
+        )}
+      </>
+    )}
+  </Radio>
+)
+
 export const CreatePlaylistForm = () => {
   const { focusSearchInput, selectedLocation } = useSearchProvider()
   const { createPlaylist } = useSpotifyAuth()
@@ -153,36 +203,12 @@ export const CreatePlaylistForm = () => {
           isRequired
         >
           {updateFrequencyOptions.map((option) => (
-            <Radio
+            <RadioCard
               key={option.value}
               value={option.value}
-              className="relative min-h-20 flex-1 cursor-default gap-1 rounded-lg border border-black/10 bg-white/80 p-3 text-left text-slate-700 transition select-none before:hidden before:content-none hover:border-black/20 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-white/10 dark:bg-zinc-900/70 dark:text-slate-200 dark:hover:border-white/20 selected:border-primary selected:bg-primary/5 selected:shadow-md"
-            >
-              {({ isSelected }) => (
-                <>
-                  <div className="min-w-0 pr-5">
-                    <div className="text-sm font-semibold text-primary">
-                      {option.title}
-                    </div>
-                    <span
-                      slot="description"
-                      className="text-xs text-muted-foreground"
-                    >
-                      {option.description}
-                    </span>
-                  </div>
-
-                  {isSelected && (
-                    <span
-                      aria-hidden="true"
-                      className="absolute top-3 right-3 text-primary"
-                    >
-                      <CircleCheck size={16} />
-                    </span>
-                  )}
-                </>
-              )}
-            </Radio>
+              title={option.title}
+              description={option.description}
+            />
           ))}
         </RadioGroup>
         <Label>Update behavior</Label>
@@ -195,67 +221,14 @@ export const CreatePlaylistForm = () => {
           name="behavior"
           isRequired
         >
-          <Radio
-            key="destructive"
-            value="destructive"
-            className="relative min-h-20 flex-1 cursor-default gap-1 rounded-lg border border-black/10 bg-white/80 p-3 text-left text-slate-700 transition select-none before:hidden before:content-none hover:border-black/20 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-white/10 dark:bg-zinc-900/70 dark:text-slate-200 dark:hover:border-white/20 selected:border-primary selected:bg-primary/5 selected:shadow-md"
-          >
-            {({ isSelected }) => (
-              <>
-                <div className="min-w-0 pr-5">
-                  <div className="text-sm font-semibold text-primary">
-                    Replace tracks
-                  </div>
-                  <span
-                    slot="description"
-                    className="text-xs text-muted-foreground"
-                  >
-                    Rebuild playlist from scratch on each update, keeping
-                    playlist light and fresh.
-                  </span>
-                </div>
-
-                {isSelected && (
-                  <span
-                    aria-hidden="true"
-                    className="absolute top-3 right-3 text-primary"
-                  >
-                    <CircleCheck size={16} />
-                  </span>
-                )}
-              </>
-            )}
-          </Radio>
-          <Radio
-            key="additive"
-            value="additive"
-            className="relative min-h-20 flex-1 cursor-default gap-1 rounded-lg border border-black/10 bg-white/80 p-3 text-left text-slate-700 transition select-none before:hidden before:content-none hover:border-black/20 hover:shadow-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-white/10 dark:bg-zinc-900/70 dark:text-slate-200 dark:hover:border-white/20 selected:border-primary selected:bg-primary/5 selected:shadow-md"
-          >
-            {({ isSelected }) => (
-              <>
-                <div className="min-w-0 pr-5">
-                  <div className="text-sm font-semibold text-primary">
-                    Add new tracks
-                  </div>
-                  <span
-                    slot="description"
-                    className="text-xs text-muted-foreground"
-                  >
-                    New tracks are added and old ones are preserved.
-                  </span>
-                </div>
-
-                {isSelected && (
-                  <span
-                    aria-hidden="true"
-                    className="absolute top-3 right-3 text-primary"
-                  >
-                    <CircleCheck size={16} />
-                  </span>
-                )}
-              </>
-            )}
-          </Radio>
+          {updateBehaviorOptions.map((option) => (
+            <RadioCard
+              key={option.value}
+              value={option.value}
+              title={option.title}
+              description={option.description}
+            />
+          ))}
         </RadioGroup>
         <Button type="submit">Create Playlist</Button>
       </Form>


### PR DESCRIPTION
## Summary
Two independent, scoped follow-ups from the additive/destructive playlist-update feature (#12):

- **spotify_handlers.rs**: extracted the `req.destructive` -> `PlaylistUpdateMode` branch (previously untested and controlling whether a periodic update replaces or adds to a user's real Spotify playlist) into a pure `resolve_update_mode` fn in `playlist_builder.rs`, next to where `PlaylistUpdateMode` is defined. Added unit tests for `Some(true)` -> Destructive, `Some(false)` -> Additive, `None` -> Destructive (confirmed the default is still `unwrap_or(true)`).
- **PlaylistsDrawer.tsx**: the cadence and update-behavior radio groups duplicated the same ~15-line className plus title/description/CircleCheck markup three times (once per array-driven cadence option, twice hardcoded for destructive/additive). Extracted a local `RadioCard` component and drove the behavior pair from an array literal the same way cadence already worked, so both are consistent. Kept it local to `PlaylistsDrawer.tsx` rather than promoting to `packages/ui` since it's still single-consumer. Both radio groups remain independently stateful — no shared state reintroduced.

## Test plan
- [x] `cd apps/api && SQLX_OFFLINE=true cargo check --bins` — clean
- [x] `cd apps/api && SQLX_OFFLINE=true cargo test --lib` — 30 passed (27 existing + 3 new)
- [x] `pnpm --filter web lint` — 0 errors, 2 pre-existing unrelated warnings (`MapWrapper.tsx`, `hooks/spotify.ts`)
- [x] `cd apps/web && npx tsc --noEmit` — clean
- [x] `cd apps/web && npx vitest run` — 18 passed
- [x] Diffed the extracted `RadioCard` JSX against the original inline markup to confirm identical className, structure, and copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)