### PR TITLE
Fold coordinate-change + radius-reset into one hook

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -6,6 +6,7 @@ import mapboxgl, {
 } from "mapbox-gl"
 import { useSearchProvider } from "./providers/searchProvider"
 import { useEventsContext } from "./providers/eventsProvider"
+import { useNavigateToLocation } from "./hooks/useNavigateToLocation"
 import { DrawerWrapper } from "./Drawer/DrawerWrapper"
 import { useIsMobile } from "./providers/Breakpoint"
 import "mapbox-gl/dist/mapbox-gl.css"
@@ -35,12 +36,9 @@ function boundsForRadius(
 }
 
 const MapWrapper = () => {
-  const {
-    selectedCoordinates,
-    setSelectedCoordinates,
-    setSelectedLocation,
-    dateRange,
-  } = useSearchProvider()
+  const { selectedCoordinates, setSelectedLocation, dateRange } =
+    useSearchProvider()
+  const navigateToLocation = useNavigateToLocation()
   const [rendered, setRendered] = useState(false)
   useEffect(() => {
     // Marks first-mount completion so later effects can skip their initial
@@ -52,7 +50,6 @@ const MapWrapper = () => {
   const {
     streamEvents,
     cancelStream,
-    resetEvents,
     eventsByDate,
     selectEvents,
     selectedEvents,
@@ -139,12 +136,7 @@ const MapWrapper = () => {
       // when a geolocate event occurs.
       geolocate.on("geolocate", (e) => {
         const { longitude, latitude } = e.coords
-        // Reset the search-radius state in the same commit as the
-        // coordinate change, otherwise the fitBounds effect below can
-        // briefly see the previous location's (possibly much wider)
-        // radius paired with the new coordinates and zoom out to match it.
-        resetEvents()
-        setSelectedCoordinates([longitude, latitude])
+        navigateToLocation([longitude, latitude])
 
         fetch(
           `/api/reverse-geocode?longitude=${longitude}&latitude=${latitude}`

--- a/apps/web/src/Search.tsx
+++ b/apps/web/src/Search.tsx
@@ -4,7 +4,7 @@ import { TextField } from "@workspace/ui/components/ui/TextField"
 import { DateRangePicker } from "@workspace/ui/components/ui/DateRangePicker"
 import { useSearchProvider } from "./providers/searchProvider"
 import { useDrawerProvider } from "./providers/drawerProvider"
-import { useEventsContext } from "./providers/eventsProvider"
+import { useNavigateToLocation } from "./hooks/useNavigateToLocation"
 
 const useDebounce = (value: string, delayTime: number) => {
   const [debounceValue, setDebounceValue] = useState(value)
@@ -22,7 +22,6 @@ const useDebounce = (value: string, delayTime: number) => {
 
 const Search = () => {
   const {
-    setSelectedCoordinates,
     dateRange,
     setDateRange,
     selectedLocation,
@@ -30,7 +29,7 @@ const Search = () => {
     setInputRef,
   } = useSearchProvider()
   const { setIsDrawerOpen } = useDrawerProvider()
-  const { resetEvents } = useEventsContext()
+  const navigateToLocation = useNavigateToLocation()
 
   const [searchTerm, setSearchTerm] = useState("")
   const [places, setPlaces] = useState<GeoJSONFeature[]>([])
@@ -61,12 +60,10 @@ const Search = () => {
     if (place.geometry.type === "GeometryCollection") return
     const coordinates = place.geometry.coordinates as [number, number]
     setPlaces([place])
-    // Reset in the same commit as the coordinate change — see the matching
-    // comment in MapWrapper's geolocate handler for why this must not be
-    // left to streamEvents' own (one-render-late) reset.
-    resetEvents()
-    setSelectedCoordinates([coordinates[0], coordinates[1]])
-    setSelectedLocation(place.properties?.full_address)
+    navigateToLocation(
+      [coordinates[0], coordinates[1]],
+      place.properties?.full_address
+    )
     setIsDrawerOpen(true)
   }
 

--- a/apps/web/src/hooks/useNavigateToLocation.ts
+++ b/apps/web/src/hooks/useNavigateToLocation.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react"
+import { useSearchProvider } from "@/providers/searchProvider"
+import { useEventsContext } from "@/providers/eventsProvider"
+
+/**
+ * Changes the selected coordinates (and optionally the location label)
+ * together, resetting the events provider's search-radius state in the
+ * same commit.
+ *
+ * Always use this instead of calling setSelectedCoordinates directly.
+ * The radius reset and the coordinate change must land in the same React
+ * commit — otherwise the fitBounds effect in MapWrapper can briefly see
+ * the *previous* location's expanded search radius paired with the *new*
+ * coordinates and zoom out to match it.
+ */
+export function useNavigateToLocation() {
+  const { setSelectedCoordinates, setSelectedLocation } = useSearchProvider()
+  const { resetEvents } = useEventsContext()
+
+  return useCallback(
+    (coordinates: [number, number], location?: string) => {
+      resetEvents()
+      setSelectedCoordinates(coordinates)
+      if (location !== undefined) {
+        setSelectedLocation(location)
+      }
+    },
+    [resetEvents, setSelectedCoordinates, setSelectedLocation]
+  )
+}


### PR DESCRIPTION
## Summary
Picks up the "coordinate/radius-reset coupling still footgun-prone" item from the tech-debt audit.

`setSelectedCoordinates` (`searchProvider`) and `resetEvents` (`eventsProvider`) had to be called together, by convention, at every call site — nothing enforced it. That's exactly what caused the earlier radius/zoom-leak bug (fixed in #10): a location change landing in a React commit that still carried the *previous* location's search radius, so the map briefly zoomed to match a radius that no longer applied. That fix patched both existing call sites individually; the coupling itself remained, so a third call site (e.g. a future "recent searches" feature) could silently reintroduce the same bug.

Adds `useNavigateToLocation()` ([useNavigateToLocation.ts](apps/web/src/hooks/useNavigateToLocation.ts)), which resets the radius state and changes coordinates (and optionally the location label) together in one call. `MapWrapper`'s geolocate handler and `Search`'s `selectPlace` — the only two places that changed coordinates — now go through it instead of manually pairing `resetEvents()` + `setSelectedCoordinates()`. `setSelectedCoordinates` is no longer called directly anywhere outside the hook.

Providers are otherwise untouched — this doesn't merge `searchProvider`/`eventsProvider`, just centralizes the one invariant that needs to hold when coordinates change.

## Test plan
- [x] `lint` — clean (same 2 pre-existing unrelated warnings)
- [x] `tsc --noEmit` — clean
- [x] `vitest run` — 18 passed
- [x] Verified in-browser: sparse default location (radius expands to 150mi) → search for Portland, ME — map zooms straight to street level with individual event markers, no wide-zoom flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)