### PR TITLE
Redesign playlist drawer: clearer Spotify actions, responsive nav, dark mode

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -36,6 +36,42 @@ import AppleMusicLogo from "../assets/Apple_Music_Icon_RGB_lg_073120.svg"
 import { ReactSVG } from "react-svg"
 import { Compass } from "lucide-react"
 
+const destinationTabs = [
+  { id: "explore", label: "Explore" },
+  { id: "spotify", label: "Spotify" },
+  { id: "apple", label: "Apple Music" },
+] as const
+
+const DestinationIcon = ({
+  id,
+  size,
+}: {
+  id: (typeof destinationTabs)[number]["id"]
+  size: number
+}) => {
+  if (id === "explore") return <Compass size={size} />
+  if (id === "spotify")
+    return (
+      <ReactSVG
+        className="shrink-0"
+        style={{ width: size, height: size }}
+        src={SpotifyLogo}
+      />
+    )
+  return (
+    <ReactSVG
+      className="shrink-0"
+      style={{ width: size, height: size }}
+      beforeInjection={(svg) => {
+        svg.setAttribute("width", String(size))
+        svg.setAttribute("height", String(size))
+        svg.setAttribute("viewBox", svg.getAttribute("viewBox") || "0 0 24 24")
+      }}
+      src={AppleMusicLogo}
+    />
+  )
+}
+
 const DrawerWrapper = () => {
   const { eventsByDate, selectedEvents } = useEventsContext()
   const { isDrawerOpen, setIsDrawerOpen } = useDrawerProvider()
@@ -69,55 +105,66 @@ const DrawerWrapper = () => {
 
   return (
     <Tabs
-      orientation="vertical"
+      orientation={isDesktop ? "vertical" : "horizontal"}
       className="h-[40vh] shrink-0 md:h-full md:w-[30rem]"
       selectedKey={activeTab}
       onSelectionChange={(t) => setActiveTab(t)}
     >
-      <TabList
-        aria-label="Tabs"
-        className="border-r border-solid border-l-black"
-      >
-        <Tab id="explore">
-          <Compass size={24} />
-        </Tab>
-        <Tab id="spotify">
-          <ReactSVG className="h-[24px] w-[24px]" src={SpotifyLogo} />
-        </Tab>
-        <Tab id="apple">
-          <ReactSVG
-            beforeInjection={(svg) => {
-              svg.setAttribute("width", "24")
-              svg.setAttribute("height", "24")
-              svg.setAttribute(
-                "viewBox",
-                svg.getAttribute("viewBox") || "0 0 24 24"
-              )
-            }}
-            src={AppleMusicLogo}
-          />
-        </Tab>
-      </TabList>
+      {isDesktop && (
+        <TabList
+          aria-label="Content sections"
+          className="flex-col items-center gap-1 border-r border-black/10 py-2 dark:border-white/10"
+        >
+          {destinationTabs.map(({ id, label }) => (
+            <Tab
+              key={id}
+              id={id}
+              aria-label={label}
+              className="w-16 flex-col gap-1 rounded-lg px-2 py-2"
+            >
+              <DestinationIcon id={id} size={20} />
+              <span className="text-[10px] leading-none font-medium">
+                {label}
+              </span>
+            </Tab>
+          ))}
+        </TabList>
+      )}
 
       <DrawerContent
         isOpen={isDrawerOpen}
         closeDrawer={() => setIsDrawerOpen(false)}
         notch={isDesktop ? false : true}
         side={isDesktop ? "left" : "bottom"}
-        className="z-10 flex h-full w-full flex-col overflow-hidden bg-white"
+        className="z-10 flex h-full w-full flex-col overflow-hidden"
       >
+        <DrawerClose
+          className="absolute top-3 right-3 z-20"
+          variant="quiet"
+          onClick={() => setIsDrawerOpen(false)}
+        >
+          <XIcon />
+        </DrawerClose>
+
+        {!isDesktop && (
+          <TabList
+            aria-label="Content sections"
+            className="flex shrink-0 items-center justify-center gap-1.5 border-b border-black/10 px-3 pt-1 pr-14 pb-2 dark:border-white/10"
+          >
+            {destinationTabs.map(({ id, label }) => (
+              <Tab key={id} id={id} className="gap-1.5 px-3">
+                <DestinationIcon id={id} size={16} />
+                <span className="text-xs font-medium">{label}</span>
+              </Tab>
+            ))}
+          </TabList>
+        )}
+
         <TabPanels>
           <TabPanel id="explore" className="p-0">
-            {!selectedEvents.length && (
-              <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-white">
-                <DrawerClose
-                  className="absolute top-4 right-4 z-10"
-                  variant="quiet"
-                  onClick={() => setIsDrawerOpen(false)}
-                >
-                  <XIcon />
-                </DrawerClose>
-                {entries.length > 0 && <EventsDrawerHeader />}
+            {!selectedEvents.length && entries.length > 0 && (
+              <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-background">
+                <EventsDrawerHeader />
               </DrawerHeader>
             )}
             <DrawerBody className="h-full flex-1 overflow-y-auto scroll-smooth">
@@ -131,10 +178,7 @@ const DrawerWrapper = () => {
             </DrawerBody>
           </TabPanel>
 
-          <TabPanel
-            id="spotify"
-            className="flex flex-col items-center justify-center"
-          >
+          <TabPanel id="spotify" className="flex flex-col">
             <Suspense fallback={null}>
               <PlaylistDrawerHeader />
               <PlaylistsDrawerBody />

--- a/apps/web/src/Drawer/PlaylistsDrawer.tsx
+++ b/apps/web/src/Drawer/PlaylistsDrawer.tsx
@@ -1,6 +1,12 @@
 import { usePlaylistContext } from "@/providers/playlistsProvider"
 import { useSpotifyAuth } from "../hooks/spotify"
-import { CircleCheck } from "lucide-react"
+import {
+  CircleCheck,
+  ListMusic,
+  CirclePlus,
+  Music2,
+  ExternalLink,
+} from "lucide-react"
 
 import { Button } from "@workspace/ui/components/ui/Button"
 import { RadioGroup, Radio } from "@workspace/ui/components/ui/RadioGroup"
@@ -24,7 +30,7 @@ import { DrawerBody, DrawerHeader } from "@workspace/ui/components/ui/Drawer"
 
 export const PlaylistDrawerHeader = () => {
   return (
-    <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-white">
+    <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-background">
       <PlaylistButtons />
     </DrawerHeader>
   )
@@ -32,43 +38,75 @@ export const PlaylistDrawerHeader = () => {
 
 export const PlaylistsDrawerBody = () => {
   const { spotifyPlaylists } = usePlaylistContext()
+  const { status } = useSpotifyAuth()
+  const isConnected = Boolean(status?.spotify_connected)
 
   return (
     <DrawerBody>
       <Tabs>
-        <TabList>
-          <Tab id="playlists">My Playlists</Tab>
-          <Tab id="add-playlist">Create</Tab>
+        <TabList aria-label="Playlist actions" className="mb-2">
+          <Tab id="playlists" className="gap-1.5">
+            <ListMusic size={15} />
+            My Playlists
+          </Tab>
+          <Tab id="add-playlist" className="gap-1.5">
+            <CirclePlus size={15} />
+            Create
+          </Tab>
         </TabList>
         <TabPanels>
           <TabPanel id="playlists">
-            <div className="flex flex-col gap-2">
-              {spotifyPlaylists.length > 0 ? (
-                <div>
-                  <h2>Spotify Playlists</h2>
-                  <ul>
-                    {spotifyPlaylists.map((playlist) => (
-                      <li
-                        key={playlist.id}
-                        className="flex items-center gap-2 rounded-lg border border-gray-300 p-2 hover:bg-gray-100"
-                      >
-                        {playlist.images && playlist.images.length > 0 && (
-                          <img
-                            src={playlist.images[0].url}
-                            alt={playlist.name}
-                            className="h-12 w-12 rounded"
-                          />
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : (
-                <div className="flex flex-col items-center justify-center gap-4 p-4">
-                  <p>Gigeo is not managing any playlists.</p>
-                </div>
-              )}
-            </div>
+            {spotifyPlaylists.length > 0 ? (
+              <ul className="flex flex-col gap-2">
+                {spotifyPlaylists.map((playlist) => (
+                  <li key={playlist.id}>
+                    <a
+                      href={playlist.external_url ?? undefined}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex items-center gap-3 rounded-lg border border-black/10 p-2 transition hover:border-black/20 hover:bg-neutral-50 dark:border-white/10 dark:hover:bg-zinc-800"
+                    >
+                      {playlist.images && playlist.images.length > 0 ? (
+                        <img
+                          src={playlist.images[0].url}
+                          alt=""
+                          className="h-12 w-12 shrink-0 rounded object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded bg-neutral-100 text-muted-foreground dark:bg-neutral-800">
+                          <Music2 size={18} />
+                        </div>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-semibold text-primary">
+                          {playlist.name}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {playlist.track_count} track
+                          {playlist.track_count === 1 ? "" : "s"}
+                          {playlist.city ? ` · ${playlist.city}` : ""}
+                        </p>
+                      </div>
+                      {playlist.external_url && (
+                        <ExternalLink
+                          size={14}
+                          className="shrink-0 text-muted-foreground"
+                        />
+                      )}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
+                <ListMusic size={24} className="text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">
+                  {isConnected
+                    ? "Gigeo isn't managing any playlists yet."
+                    : "Connect Spotify to see the playlists Gigeo manages for you."}
+                </p>
+              </div>
+            )}
           </TabPanel>
           <TabPanel id="add-playlist">
             <CreatePlaylistForm />

--- a/apps/web/src/PlaylistButtons.tsx
+++ b/apps/web/src/PlaylistButtons.tsx
@@ -2,29 +2,66 @@ import { useSpotifyAuth } from "./hooks/spotify"
 import { Button } from "@workspace/ui/components/ui/Button"
 import SpotifyLogo from "./assets/Primary_Logo_Green_CMYK.svg"
 import { ReactSVG } from "react-svg"
+import { CircleCheck, LogOut, TriangleAlert } from "lucide-react"
 
 export function PlaylistButtons() {
   const { status, loading, error, connectSpotify, logout } = useSpotifyAuth()
 
-  if (loading) return <div>Loading auth status…</div>
-  if (error) return <div>Auth error: {error}</div>
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-1 text-sm text-muted-foreground">
+        <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        Checking Spotify connection…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        <TriangleAlert size={16} className="shrink-0" />
+        Couldn't reach Spotify: {error}
+      </div>
+    )
+  }
 
   if (!status?.logged_in || !status.spotify_connected) {
     return (
-      <div>
-        <h2>Connect your Spotify account to manage playlists</h2>
-        <button onClick={connectSpotify}>Connect Spotify</button>
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-black/10 bg-white/80 p-3 dark:border-white/10 dark:bg-zinc-900/70">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-primary">
+            Connect Spotify
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Link your account to create and manage playlists.
+          </p>
+        </div>
+        <Button
+          onClick={connectSpotify}
+          className="shrink-0 gap-2 bg-[#1DB954] text-white hover:bg-[#1ed760]"
+        >
+          <ReactSVG className="h-4 w-4 [&_svg_path]:fill-white" src={SpotifyLogo} />
+          Connect
+        </Button>
       </div>
     )
   }
 
   return (
-    <div className=" ">
-      <Button aria-label="Filters" variant="secondary" className="relative">
-        <ReactSVG className="h-[24px] w-[24px]" src={SpotifyLogo} />
-        Connected
+    <div className="flex items-center justify-between gap-3">
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-[#1DB954]/10 px-2.5 py-1 text-xs font-medium text-[#1a9c48] dark:bg-[#1DB954]/15 dark:text-[#3ddb70]">
+        <CircleCheck size={14} />
+        Spotify connected
+      </span>
+      <Button
+        onClick={logout}
+        variant="quiet"
+        aria-label="Log out of Spotify"
+        className="gap-1.5 text-muted-foreground"
+      >
+        <LogOut size={14} />
+        Logout
       </Button>
-      <Button onClick={logout}>Logout</Button>
     </div>
   )
 }

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -63,7 +63,7 @@ const DrawerContent = ({
       {(props?.isOpen || state?.isOpen) && (
         <DrawerRoot
           className={twJoin(
-            "bg-bg text-fg h-full max-h-full touch-none overflow-hidden align-middle ring ring-input will-change-transform",
+            "bg-background text-foreground h-full max-h-full touch-none overflow-hidden align-middle ring ring-input will-change-transform",
             side === "top" &&
               (isFloat
                 ? "inset-x-2 top-2 rounded-lg"


### PR DESCRIPTION
## Summary
- Restyle `PlaylistButtons` from raw unstyled markup (`<button>`/`<h2>`) into a proper connect/connected card with clear iconography and a status badge for Connect / Logout.
- Fix "My Playlists" to actually show playlist name, track count, and a link to Spotify — it previously rendered only the cover image.
- On mobile, move the Explore/Spotify/Apple Music switcher out of an icon rail that floated over the map (detached from the bottom sheet) into a labeled segmented control docked to the top of the sheet. Desktop rail gains text labels under each icon for clarity.
- Add a persistent close button so the drawer can be dismissed from any tab, not just Explore (previously missing on Spotify/Apple Music tabs).
- Fix dark mode across the drawer: the shared `Drawer` primitive used `bg-bg`/`text-fg` classes with no matching theme tokens (dead classes), so consumers papered over it with hardcoded `bg-white`, which broke text contrast under the `.dark` theme. Switched to the real `bg-background`/`text-foreground` tokens and removed the redundant overrides.

## Test plan
- [x] `pnpm --filter web typecheck` — passes
- [x] `pnpm --filter web lint` — passes (2 pre-existing unrelated warnings)
- [x] Manually verified in browser at desktop and mobile widths, light and dark color schemes: Explore tab, Spotify tab (disconnected state), drawer close button on all tabs, segmented control navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)