### PR TITLE
Style the events drawer and fix latent bugs

### DIFF
--- a/apps/web/src/DateSlider.tsx
+++ b/apps/web/src/DateSlider.tsx
@@ -33,31 +33,37 @@ const DateSlider = ({
   return (
     <div className="flex w-full items-center">
       <ul className="flex h-full w-full snap-x justify-around gap-2 overflow-x-scroll">
-        {groupedDates.map((days) => (
-          <div className="flex w-full flex-[0_0_100%] snap-center items-center gap-2">
-            {days.map((day) => (
-              <li
-                className="box-border cursor-pointer snap-center rounded-xl bg-slate-400 p-2 text-center text-xs leading-none"
-                onClick={() => onSelect(day)}
-                style={{
-                  background:
-                    activeDateId && activeDateId === day
-                      ? "var(--color-green-400)"
-                      : "var(--color-slate-400)",
-                }}
-              >
-                <h4 className="font-semibold text-white">
-                  {dayFormatter.format(
-                    parseDate(day).toDate(getLocalTimeZone())
-                  )}
-                </h4>
-                <span>
-                  {dateFormatter.format(
-                    parseDate(day).toDate(getLocalTimeZone())
-                  )}
-                </span>
-              </li>
-            ))}
+        {groupedDates.map((days, groupIdx) => (
+          <div
+            key={days[0] ?? groupIdx}
+            className="flex w-full flex-[0_0_100%] snap-center items-center gap-2"
+          >
+            {days.map((day) => {
+              const isActive = Boolean(activeDateId && activeDateId === day)
+              return (
+                <li
+                  key={day}
+                  className={
+                    "box-border min-w-14 cursor-pointer snap-center rounded-xl p-2 text-center text-xs leading-none transition " +
+                    (isActive
+                      ? "bg-(--color-ivory-600)"
+                      : "bg-slate-400 hover:bg-slate-500 dark:bg-(--color-surface-dark-400) dark:hover:bg-(--color-surface-dark-300)")
+                  }
+                  onClick={() => onSelect(day)}
+                >
+                  <h4 className="font-semibold text-white">
+                    {dayFormatter.format(
+                      parseDate(day).toDate(getLocalTimeZone())
+                    )}
+                  </h4>
+                  <span className="text-white/90">
+                    {dateFormatter.format(
+                      parseDate(day).toDate(getLocalTimeZone())
+                    )}
+                  </span>
+                </li>
+              )
+            })}
           </div>
         ))}
       </ul>

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -139,6 +139,7 @@ const DrawerWrapper = () => {
         className="z-10 flex h-full w-full flex-col overflow-hidden"
       >
         <DrawerClose
+          aria-label="Close drawer"
           className="absolute top-3 right-3 z-20"
           variant="quiet"
           onClick={() => setIsDrawerOpen(false)}

--- a/apps/web/src/Drawer/EventsDrawer.tsx
+++ b/apps/web/src/Drawer/EventsDrawer.tsx
@@ -18,8 +18,10 @@ export const EventsDrawer = () => {
 
   if (!entries.length && isStreaming) {
     return (
-      <div className="flex h-full w-full items-center justify-center">
-        <p className="text-gray-600">Searching for events…</p>
+      <div className="flex h-full w-full items-center justify-center p-6 text-center">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Searching for events…
+        </p>
       </div>
     )
   }
@@ -27,18 +29,20 @@ export const EventsDrawer = () => {
   return (
     <>
       {entries.length ? (
-        <div ref={eventListRef}>
+        <div ref={eventListRef} className="flex flex-col gap-4">
           {entries.map(([date, events]) => (
             <div key={date}>
               <DateAnchor date={date} ref={registerItem(date)} />
-              <ul className="flex w-full flex-col justify-between gap-4">
+              <ul className="flex w-full flex-col justify-between gap-2.5 pt-2.5">
                 {events.map((event) => (
                   <li className="relative" key={event.id}>
                     <EventCard
                       key={event.id}
                       event={event}
                       date={
-                        <span className="text-gray-600">{event.dates}</span>
+                        <span className="text-gray-600 dark:text-gray-400">
+                          {event.dates}
+                        </span>
                       }
                     />
                   </li>
@@ -48,8 +52,8 @@ export const EventsDrawer = () => {
           ))}
         </div>
       ) : (
-        <div className="flex h-full w-full items-center justify-center">
-          <p className="text-gray-600">
+        <div className="flex h-full w-full items-center justify-center p-6 text-center">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             {radiusExpanded && searchRadius
               ? `No events found within ${searchRadius}mi. Try searching for a different location, or adjusting the calendar date range.`
               : "No events found. Try searching for a different location, or adjusting the calendar date range."}
@@ -87,7 +91,7 @@ export const EventsDrawerHeader = () => {
   return (
     <>
       <div className="mb-2 flex w-full items-center justify-between">
-        <h2 className="text-bold text-xl">Events</h2>
+        <h2 className="text-xl font-bold">Events</h2>
         {radiusExpanded && searchRadius && (
           <span className="text-xs text-gray-500">
             Showing events within {searchRadius}mi
@@ -117,9 +121,11 @@ const DateAnchor = ({
       <div id={`a${date}`} />
       <div
         ref={ref}
-        className="sticky top-0 z-5 flex scroll-smooth border-b border-b-slate-200 bg-(--color-ivory-700) dark:border-b-(--color-border-subtle-dark-200) dark:bg-(--color-bg-dark-700) dark:text-(--color-text-primary-dark-700)"
+        className="sticky top-0 z-5 flex scroll-smooth border-b border-b-slate-200 bg-(--color-ivory-700) px-3 py-1.5 dark:border-b-(--color-border-subtle-dark-200) dark:bg-(--color-bg-dark-700)"
       >
-        <h3>{formattedDate}</h3>
+        <h3 className="text-sm font-semibold text-white dark:text-(--color-text-primary-dark-700)">
+          {formattedDate}
+        </h3>
       </div>
     </>
   )

--- a/apps/web/src/EventCard.tsx
+++ b/apps/web/src/EventCard.tsx
@@ -21,8 +21,16 @@ const EventCard = ({
 
   return (
     <div
-      className="shadow-8 flex overflow-hidden rounded-xl border border-slate-100 bg-white dark:border-(--color-surface-dark-200) dark:bg-(--color-surface-dark-400)"
+      role="button"
+      tabIndex={0}
+      className="relative flex cursor-pointer overflow-hidden rounded-xl border border-slate-100 bg-white shadow-sm transition hover:border-slate-200 hover:shadow-md active:scale-[0.99] dark:border-(--color-surface-dark-200) dark:bg-(--color-surface-dark-400) dark:hover:border-(--color-surface-dark-300)"
       onClick={() => selectEvents([event])}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          selectEvents([event])
+        }
+      }}
     >
       <div className="photo-detail h-auto w-full flex-1 overflow-hidden">
         <ResponsiveImage
@@ -33,18 +41,18 @@ const EventCard = ({
             height: "100%",
             width: "100%",
           }}
-          alt="test"
+          alt={event.name}
         />
       </div>
-      <div className="flex h-auto flex-3 flex-col justify-between p-2">
-        <h3 className="leading-none font-semibold text-black dark:text-(--color-primary-dark-900)">
+      <div className="flex h-auto flex-3 flex-col justify-between gap-2 p-3">
+        <h3 className="leading-tight font-semibold text-black dark:text-(--color-primary-dark-900)">
           {event.name}
         </h3>
-        <div className="">
+        <div className="flex flex-col gap-1">
           <div>{date}</div>
-          <div className="flex items-center text-base/7 leading-none text-indigo-600 dark:text-(--color-secondary-dark-900)">
-            <HouseIcon aria-hidden className="mr-1 h-4 w-4" />
-            <span className="">{event.venue?.name}</span>
+          <div className="flex items-center gap-1 text-sm leading-none text-indigo-600 dark:text-(--color-secondary-dark-900)">
+            <HouseIcon aria-hidden className="h-4 w-4 shrink-0" />
+            <span className="truncate">{event.venue?.name}</span>
           </div>
         </div>
       </div>

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -95,9 +95,10 @@ const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
     <div ref={scrollRef} className="relative overflow-y-scroll">
       {/* sticky compact header inside the pane */}
       {showStickyHeader && (
-        <div className="sticky top-0 z-20 flex items-center justify-between border-b border-slate-800/40 bg-slate-950/90 px-3 py-2 text-xs text-slate-100 backdrop-blur">
+        <div className="sticky top-0 z-20 flex items-center justify-between gap-2 border-b border-slate-800/40 bg-slate-950/90 py-2 pr-14 pl-3 text-xs text-slate-100 backdrop-blur">
           <div className="flex min-w-0 items-center">
             <Button
+              aria-label="Back to events"
               className="z-10 dark:border-(--color-border-subtle-dark-200) dark:bg-(--color-dusty-olive-dark-600)"
               variant="secondary"
               onClick={() => selectEvents([])}
@@ -128,6 +129,7 @@ const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
 
       {/* back + top-right tickets over hero */}
       <Button
+        aria-label="Back to events"
         className="absolute top-2 left-2 z-10 dark:border-(--color-border-subtle-dark-200) dark:bg-(--color-dusty-olive-dark-600)"
         variant="secondary"
         onClick={() => setSelectedEvent(undefined)}
@@ -138,7 +140,7 @@ const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
       {eventData.url && (
         <Link
           variant="button"
-          className="absolute top-2 right-2 z-10 bg-(--color-toasted-almond-600) text-(--color-blush-rose-600) no-underline dark:bg-(--color-toasted-almond-dark-600) dark:text-(--color-text-primary-dark-600)"
+          className="absolute top-2 right-14 z-10 bg-(--color-toasted-almond-600) text-(--color-blush-rose-600) no-underline dark:bg-(--color-toasted-almond-dark-600) dark:text-(--color-text-primary-dark-600)"
           href={eventData.url}
           target="_blank"
         >

--- a/apps/web/src/EventFilter.tsx
+++ b/apps/web/src/EventFilter.tsx
@@ -92,7 +92,11 @@ const EventFilter = () => {
           </Dialog>
         </Popover>
       </DialogTrigger>
-      <p>Current selection: {[...selected].join(", ")}</p>
+      {selected.size > 0 && (
+        <p className="text-xs text-muted-foreground">
+          Filtering by: {[...selected].join(", ")}
+        </p>
+      )}
     </>
   )
 }

--- a/apps/web/src/VenueDetails.tsx
+++ b/apps/web/src/VenueDetails.tsx
@@ -7,33 +7,33 @@ const VenueDetails = ({ events }: { events: EventResponse[] }) => {
   const { selectEvents } = useEventsContext()
   const venue = events[0].venue
   return (
-    <>
+    <div className="p-3">
       <Button
+        aria-label="Back to events"
         className="z-10 dark:border-(--color-border-subtle-dark-200) dark:bg-(--color-dusty-olive-dark-600)"
         variant="secondary"
         onClick={() => selectEvents([])}
       >
         <ArrowLeftIcon aria-hidden className="h-4 w-4" />
       </Button>
-      <h2 className="leading-none font-semibold text-black dark:text-(--color-primary-dark-900)">
+      <h2 className="mt-3 leading-none font-semibold text-black dark:text-(--color-primary-dark-900)">
         {events.length} Events at {venue?.name}
       </h2>
-      <div className="overflow-y-scroll scroll-smooth">
-        <ul className="flex w-full flex-col justify-between gap-4 pt-4">
-          {events.map((event) => (
-            <div key={event.id}>
-              <li className="relative" key={event.id}>
-                <EventCard
-                  key={event.id}
-                  event={event}
-                  date={<span className="text-gray-600">{event.dates}</span>}
-                />
-              </li>
-            </div>
-          ))}
-        </ul>
-      </div>
-    </>
+      <ul className="flex w-full flex-col justify-between gap-2.5 pt-4">
+        {events.map((event) => (
+          <li className="relative" key={event.id}>
+            <EventCard
+              event={event}
+              date={
+                <span className="text-gray-600 dark:text-gray-400">
+                  {event.dates}
+                </span>
+              }
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }
 

--- a/packages/ui/src/components/ui/ResponsiveImage.tsx
+++ b/packages/ui/src/components/ui/ResponsiveImage.tsx
@@ -1,3 +1,5 @@
+import { ImageOff } from "lucide-react"
+
 type Image = {
   ratio?: string
   url: string
@@ -13,7 +15,16 @@ type ResponsiveImageProps = {
 }
 
 export function ResponsiveImage({ sources, alt, style }: ResponsiveImageProps) {
-  if (!sources.length) return null
+  if (!sources.length) {
+    return (
+      <div
+        style={style}
+        className="flex h-full min-h-16 w-full items-center justify-center bg-neutral-100 text-neutral-300 dark:bg-neutral-800 dark:text-neutral-600"
+      >
+        <ImageOff aria-hidden size={20} />
+      </div>
+    )
+  }
 
   // sort by width, just to be safe
   const sorted = [...sources].sort((a, b) => (a.width ?? 0) - (b.width ?? 0))


### PR DESCRIPTION
## Summary
- Fix the persistent drawer close button overlapping the "Tickets" link in event details — a regression from the earlier drawer-nav change (PR #17).
- Add a proper empty-image placeholder to the shared `ResponsiveImage` component instead of rendering nothing, fixing blank thumbnails in `EventCard`, `EventDetails`, and `VenueDetails` at once.
- `DateSlider`: fix missing `key` props (React warned on every render), replace the inline-style-only (light-mode-only) selected/unselected pill colors with themeable Tailwind classes, add a hover state.
- `EventCard`: fix a dead `shadow-8` class that isn't defined anywhere in this project's Tailwind setup (cards had zero elevation), add hover/active affordance and keyboard support for what was a mouse-only clickable `div`.
- `EventFilter`: stop rendering an empty "Current selection:" line above the date pills when no classification filter is active — it read like a mislabeled caption for the date pills below it.
- `EventsDrawerHeader`: fix `text-bold` (not a real Tailwind class) to `font-bold`.
- Add padding to `VenueDetails`, which had none, and spacing/typography polish to the date-section dividers and event list.
- Add accessible labels to icon-only back/close buttons.

## Test plan
- [x] `pnpm --filter web typecheck` — passes
- [x] `pnpm --filter web lint` — passes (2 pre-existing unrelated warnings)
- [x] Manually verified in browser at desktop and mobile widths, light and dark color schemes: event list, event details (including the Tickets/close-button fix), date pills, filter popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)