### PR TITLE
Stop logging DATABASE_URL with embedded credentials

### DIFF
--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -61,7 +61,7 @@ pub async fn build_app() -> Result<Router> {
     let db = AppDatabase::new(&database_url)
         .await
         .expect("Failed to connect to database");
-    println!("connected to database at {database_url}");
+    tracing::info!("connected to database");
     migrate!("./migrations")
         .run(&db.pool)
         .await


### PR DESCRIPTION
## Summary
- Startup logging printed the full `DATABASE_URL` (including the DB password) via `println!`, leaking it into any log aggregator or terminal history.
- Swapped it for `tracing::info!("connected to database")`, matching the structured logging already used elsewhere in `lib.rs`.

Found via a tech-debt audit (`/engineering:tech-debt`) of the repo; this was the highest-priority item (high impact/risk, trivial effort). Other findings (zero test coverage in `packages/ui`, oversized handler files, missing Dockerfile, unversioned Rust toolchain pin) are documented but not addressed in this PR.

## Test plan
- [x] `cargo check -p gigeo_api` — compiles clean, no new warnings introduced
- [ ] Manual verification that the API still connects and logs a message at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)