### PR TITLE
Fix hardcoded playlist description + add missing tests

### DIFF
--- a/apps/web/src/hooks/spotify.test.ts
+++ b/apps/web/src/hooks/spotify.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { parseCreatePlaylistForm } from "./spotify"
+
+function makeForm(fields: Record<string, string>): FormData {
+  const form = new FormData()
+  for (const [key, value] of Object.entries(fields)) {
+    form.set(key, value)
+  }
+  return form
+}
+
+const validFields = {
+  playlistName: "Road Trip",
+  location: "Austin, TX",
+  cadence: "weekly",
+}
+
+describe("parseCreatePlaylistForm", () => {
+  it("parses a valid form into a CreatePlaylistInput", () => {
+    expect(parseCreatePlaylistForm(makeForm(validFields))).toEqual({
+      name: "Road Trip",
+      location: "Austin, TX",
+      description: "",
+      privacy: false,
+      cadence: 7,
+      destructive: false,
+      radius: 25,
+    })
+  })
+
+  it("trims whitespace from name and location", () => {
+    const result = parseCreatePlaylistForm(
+      makeForm({ ...validFields, playlistName: "  Road Trip  ", location: "  Austin, TX  " })
+    )
+    expect(result.name).toBe("Road Trip")
+    expect(result.location).toBe("Austin, TX")
+  })
+
+  it("throws when name is missing", () => {
+    const form = makeForm({ ...validFields })
+    form.delete("playlistName")
+    expect(() => parseCreatePlaylistForm(form)).toThrow(
+      "Playlist name is required"
+    )
+  })
+
+  it("throws when name is blank", () => {
+    expect(() =>
+      parseCreatePlaylistForm(makeForm({ ...validFields, playlistName: "   " }))
+    ).toThrow("Playlist name is required")
+  })
+
+  it("throws when location is missing", () => {
+    const form = makeForm({ ...validFields })
+    form.delete("location")
+    expect(() => parseCreatePlaylistForm(form)).toThrow(
+      "Location is required"
+    )
+  })
+
+  it("throws when cadence is missing", () => {
+    const form = makeForm({ ...validFields })
+    form.delete("cadence")
+    expect(() => parseCreatePlaylistForm(form)).toThrow(
+      "Cadence is required"
+    )
+  })
+
+  it.each([
+    ["weekly", 7],
+    ["bimonthly", 60],
+    ["monthly", 30],
+    ["anything-else", 30],
+  ])("maps cadence %s to %i days", (cadence, expected) => {
+    const result = parseCreatePlaylistForm(
+      makeForm({ ...validFields, cadence })
+    )
+    expect(result.cadence).toBe(expected)
+  })
+
+  it("sets privacy true only when privacy field is 'private'", () => {
+    expect(
+      parseCreatePlaylistForm(makeForm({ ...validFields, privacy: "private" }))
+        .privacy
+    ).toBe(true)
+    expect(
+      parseCreatePlaylistForm(makeForm({ ...validFields, privacy: "public" }))
+        .privacy
+    ).toBe(false)
+  })
+
+  it("sets destructive true only when behavior field is 'destructive'", () => {
+    expect(
+      parseCreatePlaylistForm(
+        makeForm({ ...validFields, behavior: "destructive" })
+      ).destructive
+    ).toBe(true)
+    expect(
+      parseCreatePlaylistForm(
+        makeForm({ ...validFields, behavior: "preserve" })
+      ).destructive
+    ).toBe(false)
+  })
+
+  it("never sends a hardcoded placeholder description", () => {
+    expect(parseCreatePlaylistForm(makeForm(validFields)).description).toBe(
+      ""
+    )
+  })
+})

--- a/apps/web/src/hooks/spotify.ts
+++ b/apps/web/src/hooks/spotify.ts
@@ -39,7 +39,9 @@ type UseSpotifyAuthResult = {
   getPlaylists: () => Promise<SpotifyPlaylist[]>
 }
 
-function parseCreatePlaylistForm(formData: FormData): CreatePlaylistInput {
+export function parseCreatePlaylistForm(
+  formData: FormData
+): CreatePlaylistInput {
   const name = formData.get("playlistName")
   const location = formData.get("location")
   const privacy = formData.get("privacy")
@@ -61,7 +63,7 @@ function parseCreatePlaylistForm(formData: FormData): CreatePlaylistInput {
   return {
     name: name.trim(),
     location: location.trim(),
-    description: "test description",
+    description: "",
     privacy: privacy === "private",
     cadence: cadence === "bimonthly" ? 60 : cadence === "weekly" ? 7 : 30,
     destructive: behavior === "destructive",


### PR DESCRIPTION
## Summary
- `parseCreatePlaylistForm` (in `hooks/spotify.ts`) hardcoded `description: "test description"` for every playlist submitted to Spotify's create-playlist API. The UI has no description field, so this looks like leftover dev/placeholder text shipping to production — every playlist a user creates gets that literal description on Spotify. Changed it to `""`, which the backend already treats as the optional default (`Option<String>` → `""`).
- Added unit tests for `parseCreatePlaylistForm`, which had zero coverage despite containing the app's playlist-creation validation logic (required-field checks, cadence-to-days mapping, privacy/destructive flag parsing).

Found while following up on the `/engineering:tech-debt` audit from #19 — inspecting the "untested hooks" finding turned up this bug rather than just a coverage gap.

## Test plan
- [x] `pnpm test` in `apps/web` — 31/31 passing (13 new)
- [x] `pnpm typecheck` in `apps/web` — clean
- [ ] Manual: create a playlist end-to-end and confirm its Spotify description is blank instead of "test description"

🤖 Generated with [Claude Code](https://claude.com/claude-code)