### PR TITLE
Pin Rust toolchain to 1.96.0 instead of floating stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       SQLX_OFFLINE: "true"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- `rust-toolchain.toml` and CI (`dtolnay/rust-toolchain@stable`) both float on the `stable` Rust channel.
- CI gates on `cargo clippy --bins --tests -- -D clippy::all`. A new stable release landing mid-sprint can introduce new clippy lints (or rustc warnings) that immediately fail every open PR, with no local repro until someone updates their toolchain and hits it.
- Pinned both to `1.96.0`, the version currently in use, so upgrades become a deliberate, reviewable change instead of an ambient surprise. Also added `components = ["rustfmt", "clippy"]` to `rust-toolchain.toml` so `rustup` installs those for local dev automatically, matching what CI already installs.

Found via the `/engineering:tech-debt` audit that produced #19 and #20.

## Test plan
- [x] `cargo fmt --check`, `cargo check --bins`, `cargo clippy --bins --tests -- -D clippy::all`, `cargo test --lib` — all pass on the pinned 1.96.0 toolchain (same pre-existing warnings as before, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)