### PR TITLE
Fix finicky drawer transition, map resize, and broken scrolling

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -1,5 +1,6 @@
 import { EventDetails } from "../EventDetails"
 import { XIcon } from "lucide-react"
+import { motion } from "motion/react"
 import {
   DrawerBody,
   DrawerContent,
@@ -96,6 +97,11 @@ const DrawerWrapper = () => {
     setIsDrawerOpen(true)
     setActiveTab("explore")
   }, [eventsByDate, setIsDrawerOpen])
+
+  const handleDestinationTab = (tab: Key) => {
+    setIsDrawerOpen(true)
+    setActiveTab(tab)
+  }
   const isDesktop = useMediaQuery("(min-width: 768px)", {
     defaultValue: false,
     initializeWithValue: false,
@@ -103,17 +109,97 @@ const DrawerWrapper = () => {
 
   const entries = Object.entries(eventsByDate).sort()
 
+  // Kept in lockstep with the DrawerContent slide transition in the shared
+  // Drawer component, so the reserved layout width and the visible slide
+  // finish at the same time instead of the map snapping to size afterward.
+  const DRAWER_TRANSITION = { duration: 0.15, ease: "easeInOut" as const }
+  // Must match the literal "w-[26rem]" on DrawerContent below — Tailwind
+  // can't see this value if it's interpolated into a class name, so the
+  // two have to be kept in sync by hand.
+  const desktopDrawerWidth = "26rem"
+
+  const drawerContent = (
+    <DrawerContent
+      isOpen={isDrawerOpen}
+      closeDrawer={() => setIsDrawerOpen(false)}
+      notch={isDesktop ? false : true}
+      side={isDesktop ? "left" : "bottom"}
+      className={
+        isDesktop
+          ? "z-10 flex h-full w-[26rem] flex-col overflow-hidden"
+          : "z-10 flex h-full w-full flex-col overflow-hidden"
+      }
+    >
+      <DrawerClose
+        aria-label="Close drawer"
+        className="absolute top-3 right-3 z-20"
+        variant="quiet"
+        onClick={() => setIsDrawerOpen(false)}
+      >
+        <XIcon />
+      </DrawerClose>
+
+      {!isDesktop && (
+        <TabList
+          aria-label="Content sections"
+          className="flex shrink-0 items-center justify-center gap-1.5 border-b border-black/10 px-3 pt-1 pr-14 pb-2 dark:border-white/10"
+        >
+          {destinationTabs.map(({ id, label }) => (
+            <Tab key={id} id={id} className="gap-1.5 px-3">
+              <DestinationIcon id={id} size={16} />
+              <span className="text-xs font-medium">{label}</span>
+            </Tab>
+          ))}
+        </TabList>
+      )}
+
+      <TabPanels>
+        <TabPanel id="explore" className="p-0">
+          {!selectedEvents.length && entries.length > 0 && (
+            <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-background">
+              <EventsDrawerHeader />
+            </DrawerHeader>
+          )}
+          <DrawerBody className="h-full flex-1 overflow-y-auto scroll-smooth">
+            {selectedEvents.length === 1 ? (
+              <EventDetails eventData={selectedEvents[0]} />
+            ) : selectedEvents.length ? (
+              <VenueDetails events={selectedEvents} />
+            ) : (
+              <EventsDrawer />
+            )}
+          </DrawerBody>
+        </TabPanel>
+
+        <TabPanel id="spotify" className="flex flex-col">
+          <Suspense fallback={null}>
+            <PlaylistDrawerHeader />
+            <PlaylistsDrawerBody />
+          </Suspense>
+        </TabPanel>
+        <TabPanel
+          id="search"
+          className="flex items-center justify-center"
+        ></TabPanel>
+        <TabPanel
+          id="settings"
+          className="flex items-center justify-center"
+        ></TabPanel>
+      </TabPanels>
+    </DrawerContent>
+  )
+
   return (
     <Tabs
       orientation={isDesktop ? "vertical" : "horizontal"}
-      className="h-[40vh] shrink-0 md:h-full md:w-[30rem]"
+      className="h-[40vh] shrink-0 md:h-full"
       selectedKey={activeTab}
-      onSelectionChange={(t) => setActiveTab(t)}
+      onSelectionChange={(t) => handleDestinationTab(t)}
     >
       {isDesktop && (
         <TabList
           aria-label="Content sections"
-          className="flex-col items-center gap-1 border-r border-black/10 py-2 dark:border-white/10"
+          className="h-full flex-col items-center gap-1 border-r border-black/10 py-2 dark:border-white/10"
         >
           {destinationTabs.map(({ id, label }) => (
             <Tab
@@ -131,70 +217,18 @@ const DrawerWrapper = () => {
         </TabList>
       )}
 
-      <DrawerContent
-        isOpen={isDrawerOpen}
-        closeDrawer={() => setIsDrawerOpen(false)}
-        notch={isDesktop ? false : true}
-        side={isDesktop ? "left" : "bottom"}
-        className="z-10 flex h-full w-full flex-col overflow-hidden"
-      >
-        <DrawerClose
-          aria-label="Close drawer"
-          className="absolute top-3 right-3 z-20"
-          variant="quiet"
-          onClick={() => setIsDrawerOpen(false)}
+      {isDesktop ? (
+        <motion.div
+          className="h-full shrink-0 overflow-hidden"
+          initial={false}
+          animate={{ width: isDrawerOpen ? desktopDrawerWidth : "0rem" }}
+          transition={DRAWER_TRANSITION}
         >
-          <XIcon />
-        </DrawerClose>
-
-        {!isDesktop && (
-          <TabList
-            aria-label="Content sections"
-            className="flex shrink-0 items-center justify-center gap-1.5 border-b border-black/10 px-3 pt-1 pr-14 pb-2 dark:border-white/10"
-          >
-            {destinationTabs.map(({ id, label }) => (
-              <Tab key={id} id={id} className="gap-1.5 px-3">
-                <DestinationIcon id={id} size={16} />
-                <span className="text-xs font-medium">{label}</span>
-              </Tab>
-            ))}
-          </TabList>
-        )}
-
-        <TabPanels>
-          <TabPanel id="explore" className="p-0">
-            {!selectedEvents.length && entries.length > 0 && (
-              <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-background">
-                <EventsDrawerHeader />
-              </DrawerHeader>
-            )}
-            <DrawerBody className="h-full flex-1 overflow-y-auto scroll-smooth">
-              {selectedEvents.length === 1 ? (
-                <EventDetails eventData={selectedEvents[0]} />
-              ) : selectedEvents.length ? (
-                <VenueDetails events={selectedEvents} />
-              ) : (
-                <EventsDrawer />
-              )}
-            </DrawerBody>
-          </TabPanel>
-
-          <TabPanel id="spotify" className="flex flex-col">
-            <Suspense fallback={null}>
-              <PlaylistDrawerHeader />
-              <PlaylistsDrawerBody />
-            </Suspense>
-          </TabPanel>
-          <TabPanel
-            id="search"
-            className="flex items-center justify-center"
-          ></TabPanel>
-          <TabPanel
-            id="settings"
-            className="flex items-center justify-center"
-          ></TabPanel>
-        </TabPanels>
-      </DrawerContent>
+          {drawerContent}
+        </motion.div>
+      ) : (
+        drawerContent
+      )}
     </Tabs>
   )
 }

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -94,8 +94,7 @@ const DrawerWrapper = () => {
 
   useEffect(() => {
     if (!eventListRef.current) return
-    setIsDrawerOpen(true)
-    setActiveTab("explore")
+    handleDestinationTab("explore")
   }, [eventsByDate, setIsDrawerOpen])
 
   const handleDestinationTab = (tab: Key) => {

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -70,13 +70,25 @@ const MapWrapper = () => {
   })
 
   useEffect(() => {
+    // Debounced rather than calling resize() on every tick: Mapbox
+    // recalculates its internal camera transform on each resize() call, and
+    // the drawer's open/close transition fires this observer continuously
+    // as its reserved width animates (~150ms). Resizing the GL canvas that
+    // often before it settles produces a visible zoom/scale glitch. Waiting
+    // for the container to go quiet avoids it — the canvas just stretches
+    // via CSS in the meantime, which is cheap and doesn't touch the camera.
+    let settleTimeout: ReturnType<typeof setTimeout> | null = null
     const resizeObserver = new ResizeObserver(() => {
-      mapRef.current?.resize()
+      if (settleTimeout) clearTimeout(settleTimeout)
+      settleTimeout = setTimeout(() => {
+        mapRef.current?.resize()
+      }, 200)
     })
     if (mapContainer.current) {
       resizeObserver.observe(mapContainer.current)
     }
     return () => {
+      if (settleTimeout) clearTimeout(settleTimeout)
       resizeObserver.disconnect()
     }
   }, [])

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -17,7 +17,7 @@ import {
   OverlayTriggerStateContext,
   Text,
 } from "react-aria-components"
-import { twJoin, twMerge } from "tailwind-merge"
+import { twMerge } from "tailwind-merge"
 import { Button, type ButtonProps } from "./Button"
 
 type PassThroughProps = {
@@ -62,7 +62,7 @@ const DrawerContent = ({
     <AnimatePresence>
       {(props?.isOpen || state?.isOpen) && (
         <DrawerRoot
-          className={twJoin(
+          className={twMerge(
             "bg-background text-foreground h-full max-h-full touch-none overflow-hidden align-middle ring ring-input will-change-transform",
             side === "top" &&
               (isFloat
@@ -153,7 +153,7 @@ const DrawerContent = ({
           <Dialog
             aria-label="Drawer"
             role="dialog"
-            className={twJoin(
+            className={twMerge(
               "relative flex h-full flex-col overflow-hidden outline-hidden will-change-auto",
               side === "top" || side === "bottom"
                 ? "mx-auto max-w-lg"

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -160,7 +160,7 @@ const DrawerContent = ({
                 : "h-full"
             )}
           >
-            <div className="relative bottom-0 left-0 z-15 flex flex-col">
+            <div className="relative bottom-0 left-0 z-15 flex h-full min-h-0 flex-col">
               {notch && side === "bottom" && (
                 <div
                   className="notch absolute top-0 left-[50%] z-15 mx-auto my-2 my-2.5 h-1.5 w-10 shrink-0 translate-x-[-50%] touch-pan-y rounded-full bg-gray-400"


### PR DESCRIPTION
## Summary

**Drawer open/close transition** — the desktop drawer's reserved layout width only changed at the very end of its animation (when the sheet unmounted after its exit transition), since its box kept its full layout size the whole time and only its pixels moved via `transform`. That caused the map's width to snap abruptly instead of resizing smoothly, the drawer's width to vary depending on which tab's content was active (no fixed width was ever set), and the sliding content to visibly sweep over the destination tabs rail during the transition.

Kept the drawer as a genuine separate pane rather than switching to an overlay (evaluated and discarded — it fixes the same three symptoms but trades them for a hardcoded pixel offset tying the drawer's position to the rail's width, a z-index contract between rail/drawer/map, and a new bug where the map's `flyTo`/`fitBounds` calls don't know part of the map is covered, so a selected event near the edge could end up hidden behind the panel). Instead, the reserved width is now driven by a `motion.div` that animates its own width in lockstep with the drawer's existing slide transition, so the map genuinely reflows in step with the visible motion instead of snapping afterward, and reserves a fixed width regardless of the active tab.

**Map zoom glitch during the transition** — surfaced by the fix above. Mapbox recalculates its internal camera transform on every `resize()` call, and the `ResizeObserver` watching the map container was calling it on every animation frame of the width tween, producing a visible zoom/scale flicker. Debounced it to fire once the container goes quiet instead — the canvas just stretches via CSS in the meantime, which doesn't touch the camera.

**Drawer content not scrolling** — pre-existing bug in the shared `Drawer` primitive, unrelated to the transition work but found while testing it. The internal wrapper div holding the notch/drag-handle and the drawer's children had no height constraint, which broke the percentage-height chain down to `DrawerBody`'s `h-full flex-1 overflow-y-auto`. With nothing to bound it, the body just grew to fit all of its content instead of clipping and scrolling. Affected both the mobile and desktop drawer.

## Test plan
- [x] `pnpm --filter web typecheck` / `lint` — pass
- [x] Verified map width tracks smoothly frame-by-frame during the transition instead of snapping (measured via computed styles)
- [x] Verified drawer width stays fixed across Explore/Spotify/Apple Music tabs
- [x] Verified no zoom/scale glitch across several open/close cycles
- [x] Verified scrolling works in both the desktop and mobile drawer (`scrollHeight` > `clientHeight`, scroll actually moves content)
- [x] Confirmed mobile bottom sheet is otherwise unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)