### PR TITLE
Fix infinite render loop from exhaustive-deps lint fix

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -367,10 +367,14 @@ const MapWrapper = () => {
     }
 
     markEvents()
-    // selectedEvents intentionally omitted: the effect above already patches
-    // icon-image via setLayoutProperty when the selection changes, so
-    // rebuilding the whole layer/source here on every click isn't needed.
-  }, [eventsByDate, selectEvents, selectedEvents])
+    // selectedEvents intentionally omitted: this effect calls selectEvents([])
+    // itself (inside markEvents), so including selectedEvents here would
+    // make the effect re-trigger the state change that re-runs it — an
+    // infinite loop. The effect above already patches icon-image via
+    // setLayoutProperty when the selection changes, so rebuilding the whole
+    // layer/source here on every click isn't needed either.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventsByDate, selectEvents])
 
   useEffect(() => {
     if (!mapRef.current) return


### PR DESCRIPTION
## Summary
- The previous "fix lint errors" PR (#27) added `selectedEvents` to a `useEffect`'s dependency array in `MapWrapper.tsx` to satisfy `react-hooks/exhaustive-deps`.
- That effect calls `selectEvents([])` internally (inside `markEvents`), so depending on `selectedEvents` made the effect re-trigger the very state change that re-runs it — an infinite loop. This crashed the entire app to a blank white page (React's "Maximum update depth exceeded", unhandled since there's no error boundary anywhere in the tree).
- There was already a comment directly above that line explaining why `selectedEvents` must be omitted; the lint fix overrode it without noticing why.
- Reverted to omitting `selectedEvents`, expanded the comment to spell out the infinite-loop risk, and added an explicit `eslint-disable-next-line react-hooks/exhaustive-deps` so this doesn't get "fixed" back into the same footgun by a future lint pass.

## Test plan
- [x] Verified in-browser: app renders (map, markers, events drawer) instead of blank page
- [x] `pnpm lint` — clean, no errors or warnings
- [x] Confirmed no console errors on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)