### PR TITLE
Fix broken date bookmarking/scroll-to in events drawer

### DIFF
--- a/apps/web/src/DateSlider.tsx
+++ b/apps/web/src/DateSlider.tsx
@@ -1,5 +1,8 @@
 import { useDateFormatter } from "react-aria"
 import { parseDate, getLocalTimeZone } from "@internationalized/date"
+import { useEffect, useRef } from "react"
+import { groupDatesByWeek } from "./lib/dates"
+
 const DateSlider = ({
   dates,
   onSelect,
@@ -16,19 +19,22 @@ const DateSlider = ({
   const dayFormatter = useDateFormatter({
     weekday: "short",
   })
-  const groupedDates: string[][] = dates.reduce(
-    (acc: string[][], curr: string, idx: number) => {
-      if (idx % 7 === 0) {
-        acc.push([curr])
-      } else if (idx < 7) {
-        acc[(idx % 7) - idx].push(curr)
-      } else if (acc[idx % 7]) {
-        acc[idx % 7].push(curr)
-      }
-      return acc
-    },
-    []
-  )
+  const groupedDates = groupDatesByWeek(dates)
+  const groupRefs = useRef(new Map<number, HTMLDivElement>())
+
+  useEffect(() => {
+    if (!activeDateId) return
+    const groupIndex = groupedDates.findIndex((group) =>
+      group.includes(activeDateId)
+    )
+    if (groupIndex === -1) return
+
+    groupRefs.current.get(groupIndex)?.scrollIntoView({
+      inline: "nearest",
+      block: "nearest",
+      behavior: "smooth",
+    })
+  }, [activeDateId, groupedDates])
 
   return (
     <div className="flex w-full items-center">
@@ -36,31 +42,38 @@ const DateSlider = ({
         {groupedDates.map((days, groupIdx) => (
           <div
             key={days[0] ?? groupIdx}
+            ref={(node) => {
+              if (node) groupRefs.current.set(groupIdx, node)
+              else groupRefs.current.delete(groupIdx)
+            }}
             className="flex w-full flex-[0_0_100%] snap-center items-center gap-2"
           >
             {days.map((day) => {
               const isActive = Boolean(activeDateId && activeDateId === day)
               return (
-                <li
-                  key={day}
-                  className={
-                    "box-border min-w-14 cursor-pointer snap-center rounded-xl p-2 text-center text-xs leading-none transition " +
-                    (isActive
-                      ? "bg-(--color-ivory-600)"
-                      : "bg-slate-400 hover:bg-slate-500 dark:bg-(--color-surface-dark-400) dark:hover:bg-(--color-surface-dark-300)")
-                  }
-                  onClick={() => onSelect(day)}
-                >
-                  <h4 className="font-semibold text-white">
-                    {dayFormatter.format(
-                      parseDate(day).toDate(getLocalTimeZone())
-                    )}
-                  </h4>
-                  <span className="text-white/90">
-                    {dateFormatter.format(
-                      parseDate(day).toDate(getLocalTimeZone())
-                    )}
-                  </span>
+                <li key={day} className="snap-center">
+                  <button
+                    type="button"
+                    aria-current={isActive ? "date" : undefined}
+                    className={
+                      "box-border min-w-14 cursor-pointer rounded-xl p-2 text-center text-xs leading-none transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-(--color-ivory-600) focus-visible:ring-offset-1 " +
+                      (isActive
+                        ? "bg-(--color-ivory-600)"
+                        : "bg-slate-400 hover:bg-slate-500 dark:bg-(--color-surface-dark-400) dark:hover:bg-(--color-surface-dark-300)")
+                    }
+                    onClick={() => onSelect(day)}
+                  >
+                    <span className="block font-semibold text-white">
+                      {dayFormatter.format(
+                        parseDate(day).toDate(getLocalTimeZone())
+                      )}
+                    </span>
+                    <span className="text-white/90">
+                      {dateFormatter.format(
+                        parseDate(day).toDate(getLocalTimeZone())
+                      )}
+                    </span>
+                  </button>
                 </li>
               )
             })}

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -12,6 +12,7 @@ import { useMediaQuery } from "usehooks-ts"
 import { useEffect, useCallback, useRef, useState, lazy, Suspense } from "react"
 import { VenueDetails } from "../VenueDetails"
 import { EventsDrawer, EventsDrawerHeader } from "./EventsDrawer"
+import { useTopMostVisibleInScrollContainer } from "../hooks/listItemObserver"
 import type { Key } from "react-aria-components/Tabs"
 import { useDrawerProvider } from "@/providers/drawerProvider"
 
@@ -78,7 +79,17 @@ const DrawerWrapper = () => {
   const { isDrawerOpen, setIsDrawerOpen } = useDrawerProvider()
 
   const [activeTab, setActiveTab] = useState<Key>("explore")
+  // FIXME: eventListRef is never attached to a DOM node, so the effect below
+  // that guards on `eventListRef.current` never runs — "switch to Explore
+  // tab on new events" is currently dead code, not working behavior. Left
+  // as-is for now; revisit as its own change rather than reviving it as a
+  // side effect of the date-scroll fix.
   const eventListRef = useRef<HTMLDivElement>(null)
+  const eventsScrollRef = useRef<HTMLDivElement>(null)
+  const { topMostId, registerItem } = useTopMostVisibleInScrollContainer(
+    eventsScrollRef,
+    { offsetTop: 0 }
+  )
 
   const handleDestinationTab = useCallback(
     (tab: Key) => {
@@ -87,6 +98,11 @@ const DrawerWrapper = () => {
     },
     [setIsDrawerOpen]
   )
+
+  const scrollToDate = useCallback((date: string) => {
+    const target = eventsScrollRef.current?.querySelector(`#a${date}`)
+    target?.scrollIntoView({ block: "start", behavior: "smooth" })
+  }, [])
 
   useEffect(() => {
     // Syncs drawer visibility/active tab to event selection, which is owned
@@ -160,16 +176,19 @@ const DrawerWrapper = () => {
         <TabPanel id="explore" className="p-0">
           {!selectedEvents.length && entries.length > 0 && (
             <DrawerHeader className="sticky top-0 z-10 my-2 w-full bg-background">
-              <EventsDrawerHeader />
+              <EventsDrawerHeader topMostId={topMostId} onSelect={scrollToDate} />
             </DrawerHeader>
           )}
-          <DrawerBody className="h-full flex-1 overflow-y-auto scroll-smooth">
+          <DrawerBody
+            ref={eventsScrollRef}
+            className="h-full flex-1 overflow-y-auto scroll-smooth"
+          >
             {selectedEvents.length === 1 ? (
               <EventDetails eventData={selectedEvents[0]} />
             ) : selectedEvents.length ? (
               <VenueDetails events={selectedEvents} />
             ) : (
-              <EventsDrawer />
+              <EventsDrawer registerItem={registerItem} />
             )}
           </DrawerBody>
         </TabPanel>

--- a/apps/web/src/Drawer/EventsDrawer.tsx
+++ b/apps/web/src/Drawer/EventsDrawer.tsx
@@ -2,18 +2,19 @@ import { EventCard } from "../EventCard"
 import { DateSlider } from "../DateSlider"
 
 import { useEventsContext } from "../providers/eventsProvider"
-import { useRef, type Ref } from "react"
-import { useTopMostVisibleInScrollContainer } from "../hooks/listItemObserver"
-import { formatDate } from "../lib/formats"
+import type { Ref } from "react"
+import { formatDate } from "../lib/dates"
 import { EventFilter } from "../EventFilter"
 
-export const EventsDrawer = () => {
+type RegisterItem = (id: string) => Ref<HTMLDivElement>
+
+export const EventsDrawer = ({
+  registerItem,
+}: {
+  registerItem: RegisterItem
+}) => {
   const { eventsByDate, isStreaming, searchRadius, radiusExpanded } =
     useEventsContext()
-  const eventListRef = useRef<HTMLDivElement>(null)
-  const { registerItem } = useTopMostVisibleInScrollContainer(eventListRef, {
-    offsetTop: 0,
-  })
   const entries = Object.entries(eventsByDate).sort()
 
   if (!entries.length && isStreaming) {
@@ -29,7 +30,7 @@ export const EventsDrawer = () => {
   return (
     <>
       {entries.length ? (
-        <div ref={eventListRef} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
           {entries.map(([date, events]) => (
             <div key={date}>
               <DateAnchor date={date} ref={registerItem(date)} />
@@ -64,28 +65,14 @@ export const EventsDrawer = () => {
   )
 }
 
-export const EventsDrawerHeader = () => {
+export const EventsDrawerHeader = ({
+  topMostId,
+  onSelect,
+}: {
+  topMostId: string | null
+  onSelect: (date: string) => void
+}) => {
   const { eventsByDate, searchRadius, radiusExpanded } = useEventsContext()
-  const eventListRef = useRef<HTMLDivElement>(null)
-
-  const handleDateChange = (date: string) => {
-    if (eventListRef && eventListRef.current) {
-      const target = eventListRef.current.querySelector(`#a${date}`)
-
-      if (target) {
-        target.scrollIntoView({
-          block: "start",
-          behavior: "instant",
-          // @ts-expect-error - `container` isn't in the standard ScrollIntoViewOptions type
-          container: "nearest",
-        })
-      }
-    }
-  }
-
-  const { topMostId } = useTopMostVisibleInScrollContainer(eventListRef, {
-    offsetTop: 0,
-  })
   const entries = Object.entries(eventsByDate).sort()
 
   return (
@@ -102,7 +89,7 @@ export const EventsDrawerHeader = () => {
       <DateSlider
         dates={entries.map(([key]) => key)}
         activeDateId={topMostId}
-        onSelect={handleDateChange}
+        onSelect={onSelect}
       />
     </>
   )

--- a/apps/web/src/lib/dates.test.ts
+++ b/apps/web/src/lib/dates.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { groupDatesByWeek } from "./dates"
+
+const dates = (count: number) =>
+  Array.from({ length: count }, (_, i) => `d${i}`)
+
+describe("groupDatesByWeek", () => {
+  it("returns an empty array for no dates", () => {
+    expect(groupDatesByWeek([])).toEqual([])
+  })
+
+  it("puts fewer than 7 dates in a single group", () => {
+    expect(groupDatesByWeek(dates(5))).toEqual([dates(5)])
+  })
+
+  it("puts exactly 7 dates in a single group", () => {
+    expect(groupDatesByWeek(dates(7))).toEqual([dates(7)])
+  })
+
+  it("starts a new group after 7 dates", () => {
+    expect(groupDatesByWeek(dates(8))).toEqual([dates(7), ["d7"]])
+  })
+
+  it("keeps every date in its correct week group across 3+ weeks", () => {
+    // Regression test: the previous implementation used `acc[idx % 7]` to
+    // pick the current group, which only lines up with the group index for
+    // the first two weeks. From week 3 onward it silently misfiled dates
+    // into earlier groups instead of the current one.
+    const groups = groupDatesByWeek(dates(17))
+
+    expect(groups).toEqual([
+      ["d0", "d1", "d2", "d3", "d4", "d5", "d6"],
+      ["d7", "d8", "d9", "d10", "d11", "d12", "d13"],
+      ["d14", "d15", "d16"],
+    ])
+  })
+})

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -33,4 +33,14 @@ const formatDate = (dateString: string) => {
   return formatter.format(date)
 }
 
-export { formatDateTime, formatDate }
+const groupDatesByWeek = (dates: string[]): string[][] => {
+  const groups: string[][] = []
+
+  for (let i = 0; i < dates.length; i += 7) {
+    groups.push(dates.slice(i, i + 7))
+  }
+
+  return groups
+}
+
+export { formatDateTime, formatDate, groupDatesByWeek }

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion, useDragControls } from "motion/react"
 import { use, Children, cloneElement } from "react"
+import type { Ref } from "react"
 import type {
   DialogProps,
   DialogTriggerProps,
@@ -221,9 +222,11 @@ const DrawerDescription = ({ className, ...props }: TextProps) => (
 
 const DrawerBody = ({
   className,
+  ref,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: Ref<HTMLDivElement> }) => (
   <div
+    ref={ref}
     slot="body"
     className={twMerge(
       "isolate flex h-full min-h-0 flex-col overflow-auto px-4 py-1 will-change-scroll",


### PR DESCRIPTION
## Summary
- `EventsDrawer` and `EventsDrawerHeader` each held their own disconnected ref, so clicking a date pill silently did nothing and the active pill highlight never updated — the shared ref/scroll-tracking is now lifted into `DrawerWrapper` and attached to `DrawerBody`, the actual scroll viewport
- Fixed `DateSlider`'s week-grouping math, which scrambled dates from the third week onward into the wrong carousel page (extracted to `groupDatesByWeek` in `lib/dates.ts` with a regression test)
- Scroll-to-date now animates smoothly instead of jumping instantly
- The pill carousel auto-scrolls to reveal the active date's week when it changes from list scrolling
- Date pills are now real `<button>` elements with `aria-current="date"` on the active one, for keyboard/screen-reader support
- `lib/formats.ts` renamed to `lib/dates.ts` to hold all date-related helpers going forward

## Test plan
- [x] `npx vitest run` — 48 tests pass, including new `groupDatesByWeek` regression test
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] Manually verified in browser: clicking a date pill scrolls the list and updates the active pill; keyboard Tab reaches pills with visible focus ring; dark mode styling checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)