### PR TITLE
Add playlist edit and delete

### DIFF
--- a/apps/api/.sqlx/query-6668422c6df97b4bb6e1933ff41700f186e6500f035b4453ce43a03b69d4b119.json
+++ b/apps/api/.sqlx/query-6668422c6df97b4bb6e1933ff41700f186e6500f035b4453ce43a03b69d4b119.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT provider_playlist_id, city\n        FROM playlist\n        WHERE account_id = $1\n        ",
+  "query": "\n        select provider_playlist_id, is_active\n        from playlist\n        where id = $1 and account_id = $2 and deleted_at is null\n        ",
   "describe": {
     "columns": [
       {
@@ -10,12 +10,13 @@
       },
       {
         "ordinal": 1,
-        "name": "city",
-        "type_info": "Text"
+        "name": "is_active",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Uuid"
       ]
     },
@@ -24,5 +25,5 @@
       false
     ]
   },
-  "hash": "89fa7369b0f3354217cc02d45662d1f392c0caf30a81f8f047ff5cbf5158e18b"
+  "hash": "6668422c6df97b4bb6e1933ff41700f186e6500f035b4453ce43a03b69d4b119"
 }

--- a/apps/api/.sqlx/query-870e58dd55e61a53bc132c3a048405a43a80c240a7062aafe4eeafd0e0b20027.json
+++ b/apps/api/.sqlx/query-870e58dd55e61a53bc132c3a048405a43a80c240a7062aafe4eeafd0e0b20027.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update playlist set is_active = false where id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "870e58dd55e61a53bc132c3a048405a43a80c240a7062aafe4eeafd0e0b20027"
+}

--- a/apps/api/.sqlx/query-9f2fb9f3e676ab9e39dc5305082a42d9080d4e264d667b44b9ff3c0029f315d8.json
+++ b/apps/api/.sqlx/query-9f2fb9f3e676ab9e39dc5305082a42d9080d4e264d667b44b9ff3c0029f315d8.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "update playlist set deleted_at = now() where id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9f2fb9f3e676ab9e39dc5305082a42d9080d4e264d667b44b9ff3c0029f315d8"
+}

--- a/apps/api/.sqlx/query-a175ba6878b91dc85a81c45b3e71fa8146769df80b2ffeeb13f183333696f7fa.json
+++ b/apps/api/.sqlx/query-a175ba6878b91dc85a81c45b3e71fa8146769df80b2ffeeb13f183333696f7fa.json
@@ -1,0 +1,78 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, provider_playlist_id, city,\n            visibility as \"visibility: PlaylistVisibility\",\n            update_mode as \"update_mode: PlaylistUpdateMode\",\n            update_cadence_days, is_active\n        FROM playlist\n        WHERE account_id = $1 AND deleted_at IS NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "provider_playlist_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "city",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "visibility: PlaylistVisibility",
+        "type_info": {
+          "Custom": {
+            "name": "playlist_visibility",
+            "kind": {
+              "Enum": [
+                "public",
+                "private"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "update_mode: PlaylistUpdateMode",
+        "type_info": {
+          "Custom": {
+            "name": "playlist_update_mode",
+            "kind": {
+              "Enum": [
+                "additive",
+                "destructive"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "update_cadence_days",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_active",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a175ba6878b91dc85a81c45b3e71fa8146769df80b2ffeeb13f183333696f7fa"
+}

--- a/apps/api/.sqlx/query-b3d98a3906c1222936be4232feecc027c62f8dab21bdb58920222942d558ecf2.json
+++ b/apps/api/.sqlx/query-b3d98a3906c1222936be4232feecc027c62f8dab21bdb58920222942d558ecf2.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        update playlist\n        set name = $2, visibility = $3, update_mode = $4, update_cadence_days = $5\n        where id = $1\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        {
+          "Custom": {
+            "name": "playlist_visibility",
+            "kind": {
+              "Enum": [
+                "public",
+                "private"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "playlist_update_mode",
+            "kind": {
+              "Enum": [
+                "additive",
+                "destructive"
+              ]
+            }
+          }
+        },
+        "Int2"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b3d98a3906c1222936be4232feecc027c62f8dab21bdb58920222942d558ecf2"
+}

--- a/apps/api/.sqlx/query-d4abf01e16ab0bc76ffa6d0a02416adacee2e810d8d229a07b00be0fa0a15040.json
+++ b/apps/api/.sqlx/query-d4abf01e16ab0bc76ffa6d0a02416adacee2e810d8d229a07b00be0fa0a15040.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        update playlist\n        set next_update_at = $1\n        where id = (\n            select id from playlist\n            where is_active\n              and (next_update_at is null or next_update_at <= now())\n            order by next_update_at nulls first\n            limit 1\n            for update skip locked\n        )\n        returning\n            id, account_id, provider_playlist_id, geohash,\n            update_mode as \"update_mode: PlaylistUpdateMode\",\n            update_cadence_days\n        ",
+  "query": "\n        update playlist\n        set next_update_at = $1\n        where id = (\n            select id from playlist\n            where is_active\n              and deleted_at is null\n              and (next_update_at is null or next_update_at <= now())\n            order by next_update_at nulls first\n            limit 1\n            for update skip locked\n        )\n        returning\n            id, account_id, provider_playlist_id, geohash,\n            update_mode as \"update_mode: PlaylistUpdateMode\",\n            update_cadence_days\n        ",
   "describe": {
     "columns": [
       {
@@ -58,5 +58,5 @@
       false
     ]
   },
-  "hash": "3584f85c95bcc631d0e8ec4abb66e791858b411b0a31d363eae5e90c42965377"
+  "hash": "d4abf01e16ab0bc76ffa6d0a02416adacee2e810d8d229a07b00be0fa0a15040"
 }

--- a/apps/api/migrations/003_playlist_edit_delete.sql
+++ b/apps/api/migrations/003_playlist_edit_delete.sql
@@ -1,0 +1,15 @@
+alter table playlist add column deleted_at timestamptz;
+
+-- allow re-adding the same spotify playlist after a soft-delete
+alter table playlist drop constraint playlist_account_id_provider_playlist_id_key;
+create unique index playlist_account_provider_active_idx
+    on playlist (account_id, provider_playlist_id)
+    where deleted_at is null;
+
+-- exclude soft-deleted rows from the background updater's claim query
+drop index playlist_scheduler_idx;
+create index playlist_scheduler_idx
+    on playlist (next_update_at)
+    where is_active and deleted_at is null;
+
+create index playlist_account_active_idx on playlist (account_id) where deleted_at is null;

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -94,9 +94,7 @@ impl IntoResponse for AppError {
             ),
             AppError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             AppError::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
-            AppError::PlaylistNotFound => {
-                (StatusCode::NOT_FOUND, "Playlist not found".to_string())
-            }
+            AppError::PlaylistNotFound => (StatusCode::NOT_FOUND, "Playlist not found".to_string()),
             AppError::PlaylistUnavailable { .. } => unreachable!("handled above"),
         };
 

--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -36,10 +36,30 @@ pub enum AppError {
 
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
+
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Playlist not found")]
+    PlaylistNotFound,
+
+    #[error("Playlist no longer exists on Spotify")]
+    PlaylistUnavailable { playlist_id: uuid::Uuid },
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
+        if let AppError::PlaylistUnavailable { playlist_id } = &self {
+            return (
+                StatusCode::GONE,
+                Json(json!({
+                    "error": "playlist_unavailable",
+                    "playlist_id": playlist_id.to_string(),
+                })),
+            )
+                .into_response();
+        }
+
         let (status, message) = match &self {
             AppError::SpotifyApi { status, message } => {
                 let code = *status;
@@ -73,6 +93,11 @@ impl IntoResponse for AppError {
                 format!("Database error: {e}"),
             ),
             AppError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+            AppError::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::PlaylistNotFound => {
+                (StatusCode::NOT_FOUND, "Playlist not found".to_string())
+            }
+            AppError::PlaylistUnavailable { .. } => unreachable!("handled above"),
         };
 
         let body = json!({ "error": message });

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -158,6 +158,11 @@ pub async fn build_app() -> Result<Router> {
             axum::routing::get(spotify::spotify_handlers::get_user_playlists),
         )
         .route(
+            "/spotify/playlist/{id}",
+            axum::routing::patch(spotify::spotify_handlers::update_playlist)
+                .delete(spotify::spotify_handlers::delete_playlist),
+        )
+        .route(
             "/spotify/login",
             axum::routing::get(spotify::spotify_handlers::login),
         )

--- a/apps/api/src/services/playlist_builder.rs
+++ b/apps/api/src/services/playlist_builder.rs
@@ -5,20 +5,36 @@ use crate::ticketmaster_stream::{
 };
 use chrono::Utc;
 use geohash::{Coord, encode};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-#[derive(sqlx::Type, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(sqlx::Type, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[sqlx(type_name = "playlist_visibility", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum PlaylistVisibility {
     Public,
     Private,
 }
 
-#[derive(sqlx::Type, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(sqlx::Type, Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[sqlx(type_name = "playlist_update_mode", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum PlaylistUpdateMode {
     Additive,
     Destructive,
+}
+
+/// Validates a user-supplied update cadence. Unlike playlist creation
+/// (which silently clamps to the nearest allowed value), editing an
+/// existing playlist should reject an invalid cadence outright rather
+/// than guess at intent.
+pub fn validate_cadence_days(days: i16) -> Result<i16, AppError> {
+    match days {
+        7 | 30 | 60 => Ok(days),
+        other => Err(AppError::InvalidRequest(format!(
+            "update_cadence_days must be 7, 30, or 60 (got {other})"
+        ))),
+    }
 }
 
 /// Resolves the requested `destructive` flag on a create-playlist request
@@ -183,5 +199,19 @@ mod tests {
     #[test]
     fn resolve_update_mode_none_defaults_to_destructive() {
         assert_eq!(resolve_update_mode(None), PlaylistUpdateMode::Destructive);
+    }
+
+    #[test]
+    fn validate_cadence_days_accepts_allowed_values() {
+        assert_eq!(validate_cadence_days(7).unwrap(), 7);
+        assert_eq!(validate_cadence_days(30).unwrap(), 30);
+        assert_eq!(validate_cadence_days(60).unwrap(), 60);
+    }
+
+    #[test]
+    fn validate_cadence_days_rejects_other_values() {
+        assert!(validate_cadence_days(14).is_err());
+        assert!(validate_cadence_days(0).is_err());
+        assert!(validate_cadence_days(-7).is_err());
     }
 }

--- a/apps/api/src/services/playlist_updater.rs
+++ b/apps/api/src/services/playlist_updater.rs
@@ -104,6 +104,7 @@ async fn claim_due_playlist(
         where id = (
             select id from playlist
             where is_active
+              and deleted_at is null
               and (next_update_at is null or next_update_at <= now())
             order by next_update_at nulls first
             limit 1

--- a/apps/api/src/spotify/client.rs
+++ b/apps/api/src/spotify/client.rs
@@ -356,8 +356,12 @@ impl SpotifyClient {
             return Ok(());
         }
 
-        self.put_with_backoff(&format!("{BASE}/playlists/{playlist_id}"), user_token, &body)
-            .await?;
+        self.put_with_backoff(
+            &format!("{BASE}/playlists/{playlist_id}"),
+            user_token,
+            &body,
+        )
+        .await?;
 
         Ok(())
     }
@@ -383,8 +387,11 @@ impl SpotifyClient {
         user_token: &str,
         playlist_id: &str,
     ) -> Result<(), AppError> {
-        self.delete_with_backoff(&format!("{BASE}/playlists/{playlist_id}/followers"), user_token)
-            .await?;
+        self.delete_with_backoff(
+            &format!("{BASE}/playlists/{playlist_id}/followers"),
+            user_token,
+        )
+        .await?;
         Ok(())
     }
 
@@ -568,6 +575,9 @@ mod tests {
     #[test]
     fn build_update_details_body_includes_both() {
         let body = SpotifyClient::build_update_details_body(Some("New Name"), Some(false));
-        assert_eq!(body, serde_json::json!({ "name": "New Name", "public": false }));
+        assert_eq!(
+            body,
+            serde_json::json!({ "name": "New Name", "public": false })
+        );
     }
 }

--- a/apps/api/src/spotify/client.rs
+++ b/apps/api/src/spotify/client.rs
@@ -340,6 +340,54 @@ impl SpotifyClient {
             .map_err(AppError::from)
     }
 
+    /// `PUT /playlists/{playlist_id}`
+    /// Updates a playlist's name and/or public visibility. No-ops (without
+    /// making a request) if both `name` and `public` are `None`.
+    /// Scopes: `playlist-modify-public`, `playlist-modify-private`
+    pub async fn update_playlist_details(
+        &self,
+        user_token: &str,
+        playlist_id: &str,
+        name: Option<&str>,
+        public: Option<bool>,
+    ) -> Result<(), AppError> {
+        let body = Self::build_update_details_body(name, public);
+        if body.as_object().is_some_and(|m| m.is_empty()) {
+            return Ok(());
+        }
+
+        self.put_with_backoff(&format!("{BASE}/playlists/{playlist_id}"), user_token, &body)
+            .await?;
+
+        Ok(())
+    }
+
+    fn build_update_details_body(name: Option<&str>, public: Option<bool>) -> serde_json::Value {
+        let mut body = serde_json::Map::new();
+        if let Some(n) = name {
+            body.insert("name".into(), serde_json::json!(n));
+        }
+        if let Some(p) = public {
+            body.insert("public".into(), serde_json::json!(p));
+        }
+        serde_json::Value::Object(body)
+    }
+
+    /// `DELETE /playlists/{playlist_id}/followers`
+    /// Spotify's Web API has no true "delete playlist" endpoint — unfollowing
+    /// is the closest primitive, and for the owner it removes the playlist
+    /// from their library.
+    /// Scopes: `playlist-modify-public`, `playlist-modify-private`
+    pub async fn unfollow_playlist(
+        &self,
+        user_token: &str,
+        playlist_id: &str,
+    ) -> Result<(), AppError> {
+        self.delete_with_backoff(&format!("{BASE}/playlists/{playlist_id}/followers"), user_token)
+            .await?;
+        Ok(())
+    }
+
     /// `GET /playlists/{playlist_id}` — non-deprecated.
     /// Uses `fields` to fetch only what the "My Playlists" list needs.
     pub async fn get_playlist(
@@ -440,6 +488,20 @@ impl SpotifyClient {
         )
         .await
     }
+
+    /// DELETE with retry on 429, no body.
+    async fn delete_with_backoff(
+        &self,
+        url: &str,
+        token: &str,
+    ) -> Result<reqwest::Response, AppError> {
+        request_with_backoff(
+            "spotify",
+            || self.http.delete(url).bearer_auth(token),
+            Self::map_error,
+        )
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -483,5 +545,29 @@ mod tests {
         let page: Paging<PlaylistTrackItem> = serde_json::from_str(json).unwrap();
         assert!(page.next.is_none());
         assert!(page.items.is_empty());
+    }
+
+    #[test]
+    fn build_update_details_body_empty_when_nothing_provided() {
+        let body = SpotifyClient::build_update_details_body(None, None);
+        assert_eq!(body, serde_json::json!({}));
+    }
+
+    #[test]
+    fn build_update_details_body_includes_only_name() {
+        let body = SpotifyClient::build_update_details_body(Some("New Name"), None);
+        assert_eq!(body, serde_json::json!({ "name": "New Name" }));
+    }
+
+    #[test]
+    fn build_update_details_body_includes_only_public() {
+        let body = SpotifyClient::build_update_details_body(None, Some(true));
+        assert_eq!(body, serde_json::json!({ "public": true }));
+    }
+
+    #[test]
+    fn build_update_details_body_includes_both() {
+        let body = SpotifyClient::build_update_details_body(Some("New Name"), Some(false));
+        assert_eq!(body, serde_json::json!({ "name": "New Name", "public": false }));
     }
 }

--- a/apps/api/src/spotify/spotify_handlers/db.rs
+++ b/apps/api/src/spotify/spotify_handlers/db.rs
@@ -164,6 +164,97 @@ pub(super) struct SpotifyAccountRow {
     pub expires_at: chrono::DateTime<chrono::Utc>,
 }
 
+pub(super) struct PlaylistRow {
+    pub provider_playlist_id: String,
+    pub is_active: bool,
+}
+
+/// Fetches a playlist scoped to the owning account, excluding soft-deleted
+/// rows. `None` covers both "wrong account" and "already deleted" — both
+/// should look like "not found" to the caller.
+pub(super) async fn get_playlist_for_account(
+    db: &sqlx::PgPool,
+    playlist_id: uuid::Uuid,
+    account_id: uuid::Uuid,
+) -> Result<Option<PlaylistRow>, sqlx::Error> {
+    sqlx::query_as!(
+        PlaylistRow,
+        r#"
+        select provider_playlist_id, is_active
+        from playlist
+        where id = $1 and account_id = $2 and deleted_at is null
+        "#,
+        playlist_id,
+        account_id
+    )
+    .fetch_optional(db)
+    .await
+}
+
+pub(super) struct UpdatePlaylistParams<'a> {
+    pub name: &'a str,
+    pub visibility: PlaylistVisibility,
+    pub update_mode: PlaylistUpdateMode,
+    pub update_cadence_days: i16,
+}
+
+/// Persists edited config fields only. Deliberately does not touch
+/// `next_update_at` — cadence/mode changes take effect on the playlist's
+/// already-scheduled next run, not immediately.
+pub(super) async fn update_playlist_config(
+    db: &sqlx::PgPool,
+    playlist_id: uuid::Uuid,
+    params: UpdatePlaylistParams<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        update playlist
+        set name = $2, visibility = $3, update_mode = $4, update_cadence_days = $5
+        where id = $1
+        "#,
+        playlist_id,
+        params.name,
+        params.visibility as _,
+        params.update_mode as _,
+        params.update_cadence_days,
+    )
+    .execute(db)
+    .await
+    .map(|_| ())
+}
+
+/// Marks a playlist inactive after Spotify confirms it's gone (404).
+/// Used by the list-fetch and edit/delete 404 paths — the background
+/// updater's own `finalize_playlist_failure` handles this separately
+/// since it also manages retry scheduling.
+pub(super) async fn deactivate_playlist(
+    db: &sqlx::PgPool,
+    playlist_id: uuid::Uuid,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        "update playlist set is_active = false where id = $1",
+        playlist_id
+    )
+    .execute(db)
+    .await
+    .map(|_| ())
+}
+
+/// Soft-delete: preserves the row (and its playlist_update_run history)
+/// while excluding it from all future list/claim queries.
+pub(super) async fn soft_delete_playlist(
+    db: &sqlx::PgPool,
+    playlist_id: uuid::Uuid,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        "update playlist set deleted_at = now() where id = $1",
+        playlist_id
+    )
+    .execute(db)
+    .await
+    .map(|_| ())
+}
+
 pub(super) async fn get_spotify_account(
     db: &sqlx::PgPool,
     account_id: uuid::Uuid,

--- a/apps/api/src/spotify/spotify_handlers/mod.rs
+++ b/apps/api/src/spotify/spotify_handlers/mod.rs
@@ -1,7 +1,7 @@
 //! HTTP handlers for Spotify-related routes, split by concern:
 //! - `artist`: artist lookup (client-credentials auth)
 //! - `auth`: OAuth login/callback/status
-//! - `playlists`: playlist creation and retrieval
+//! - `playlists`: playlist creation, retrieval, edit, and delete
 //! - `db`: persistence for sessions, accounts, and playlists
 
 mod artist;

--- a/apps/api/src/spotify/spotify_handlers/playlists.rs
+++ b/apps/api/src/spotify/spotify_handlers/playlists.rs
@@ -382,7 +382,12 @@ pub async fn update_playlist(
 
     match state
         .spotify
-        .update_playlist_details(&token, &row.provider_playlist_id, Some(&req.name), Some(!req.privacy))
+        .update_playlist_details(
+            &token,
+            &row.provider_playlist_id,
+            Some(&req.name),
+            Some(!req.privacy),
+        )
         .await
     {
         Ok(()) => {

--- a/apps/api/src/spotify/spotify_handlers/playlists.rs
+++ b/apps/api/src/spotify/spotify_handlers/playlists.rs
@@ -1,12 +1,47 @@
-use super::db::{CreatePlaylistParams, create_playlist_record, resolve_session_account};
+use super::db::{
+    CreatePlaylistParams, UpdatePlaylistParams, create_playlist_record, deactivate_playlist,
+    get_playlist_for_account, resolve_session_account, soft_delete_playlist,
+    update_playlist_config,
+};
 use crate::error::AppError;
 use crate::services::playlist_builder::{
-    PlaylistVisibility, find_artist_names_near, resolve_update_mode, search_tracks_for_artists,
+    PlaylistUpdateMode, PlaylistVisibility, find_artist_names_near, resolve_update_mode,
+    search_tracks_for_artists, validate_cadence_days,
 };
 use crate::state::AppState;
-use axum::{Json, extract::State, http::StatusCode};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
 use axum_extra::extract::cookie::SignedCookieJar;
 use serde::{Deserialize, Serialize};
+
+/// Resolves the account tied to the session cookie. Shared by every
+/// handler that requires an authenticated user.
+async fn resolve_account_from_cookie(
+    state: &AppState,
+    jar: &SignedCookieJar,
+) -> Result<uuid::Uuid, AppError> {
+    let cookie = jar
+        .get("spotify_oauth_state")
+        .ok_or_else(|| AppError::AuthRequired("No session cookie. Visit /login first.".into()))?;
+    let session_id = uuid::Uuid::parse_str(cookie.value()).map_err(|_| AppError::Unauthorized {
+        status: StatusCode::UNAUTHORIZED,
+        message: "Invalid session cookie".into(),
+    })?;
+    resolve_session_account(&state.db.pool, session_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::AuthRequired("Session expired or invalid. Visit /login first.".into())
+        })
+}
+
+/// Returns `true` if a Spotify API error indicates the resource no longer
+/// exists upstream (as opposed to a transient failure).
+fn is_gone_from_spotify(err: &AppError) -> bool {
+    matches!(err, AppError::SpotifyApi { status, .. } if status.as_u16() == 404)
+}
 
 // ---------------------------------------------------------------------------
 // POST /playlist
@@ -55,35 +90,24 @@ pub struct PlaylistTrack {
 
 #[derive(Serialize)]
 pub struct PlaylistSummary {
+    pub playlist_id: String,
     pub id: String,
     pub name: String,
     pub external_url: Option<String>,
     pub images: Vec<crate::spotify::client::Image>,
     pub track_count: u32,
     pub city: String,
+    pub visibility: PlaylistVisibility,
+    pub update_mode: PlaylistUpdateMode,
+    pub update_cadence_days: i16,
+    pub is_active: bool,
 }
 
 pub async fn get_user_playlists(
     State(state): State<AppState>,
     jar: SignedCookieJar,
 ) -> Result<Json<Vec<PlaylistSummary>>, AppError> {
-    let cookie = jar
-        .get("spotify_oauth_state")
-        .ok_or(AppError::Unauthorized {
-            status: StatusCode::UNAUTHORIZED,
-            message: "Unauthorized".into(),
-        })?;
-    let session_id = uuid::Uuid::parse_str(cookie.value()).map_err(|_| AppError::Unauthorized {
-        status: StatusCode::UNAUTHORIZED,
-        message: "Unauthorized session id".into(),
-    })?;
-
-    let Some(account_id) = resolve_session_account(&state.db.pool, session_id).await? else {
-        return Err(AppError::Unauthorized {
-            status: StatusCode::UNAUTHORIZED,
-            message: "Unauthorized user id".into(),
-        });
-    };
+    let account_id = resolve_account_from_cookie(&state, &jar).await?;
     let playlists = get_playlists(&state, account_id).await?;
     Ok(playlists)
 }
@@ -102,18 +126,7 @@ pub async fn create_playlist(
     jar: SignedCookieJar,
     Json(req): Json<CreatePlaylistRequest>,
 ) -> Result<(StatusCode, Json<CreatePlaylistResponse>), AppError> {
-    let cookie = jar
-        .get("spotify_oauth_state")
-        .ok_or_else(|| AppError::AuthRequired("No session cookie. Visit /login first.".into()))?;
-    let session_id = uuid::Uuid::parse_str(cookie.value()).map_err(|_| AppError::Unauthorized {
-        status: StatusCode::UNAUTHORIZED,
-        message: "Invalid session cookie".into(),
-    })?;
-    let account_id = resolve_session_account(&state.db.pool, session_id)
-        .await?
-        .ok_or_else(|| {
-            AppError::AuthRequired("Session expired or invalid. Visit /login first.".into())
-        })?;
+    let account_id = resolve_account_from_cookie(&state, &jar).await?;
 
     let user_token = crate::spotify::token::get_valid_spotify_token(&state, account_id).await?;
     let cc_token = state.cc_manager.get_token().await?;
@@ -225,9 +238,13 @@ pub async fn get_playlists(
 ) -> Result<Json<Vec<PlaylistSummary>>, AppError> {
     let rows = sqlx::query!(
         r#"
-        SELECT provider_playlist_id, city
+        SELECT
+            id, provider_playlist_id, city,
+            visibility as "visibility: PlaylistVisibility",
+            update_mode as "update_mode: PlaylistUpdateMode",
+            update_cadence_days, is_active
         FROM playlist
-        WHERE account_id = $1
+        WHERE account_id = $1 AND deleted_at IS NULL
         "#,
         account_id
     )
@@ -242,22 +259,63 @@ pub async fn get_playlists(
 
     let mut summaries = Vec::with_capacity(rows.len());
     for row in rows {
+        if !row.is_active {
+            // Already known to be gone from Spotify — no point re-fetching.
+            summaries.push(PlaylistSummary {
+                playlist_id: row.id.to_string(),
+                id: row.provider_playlist_id,
+                name: String::new(),
+                external_url: None,
+                images: vec![],
+                track_count: 0,
+                city: row.city,
+                visibility: row.visibility,
+                update_mode: row.update_mode,
+                update_cadence_days: row.update_cadence_days,
+                is_active: false,
+            });
+            continue;
+        }
+
         match state
             .spotify
             .get_playlist(&token, &row.provider_playlist_id)
             .await
         {
             Ok(details) => summaries.push(PlaylistSummary {
+                playlist_id: row.id.to_string(),
                 id: details.id,
                 name: details.name,
                 external_url: details.external_urls.spotify,
                 images: details.images,
                 track_count: details.tracks.total,
                 city: row.city,
+                visibility: row.visibility,
+                update_mode: row.update_mode,
+                update_cadence_days: row.update_cadence_days,
+                is_active: true,
             }),
+            Err(err) if is_gone_from_spotify(&err) => {
+                if let Err(e) = deactivate_playlist(&state.db.pool, row.id).await {
+                    tracing::warn!(playlist_id = %row.id, error = %e, "failed to persist is_active=false");
+                }
+                summaries.push(PlaylistSummary {
+                    playlist_id: row.id.to_string(),
+                    id: row.provider_playlist_id,
+                    name: String::new(),
+                    external_url: None,
+                    images: vec![],
+                    track_count: 0,
+                    city: row.city,
+                    visibility: row.visibility,
+                    update_mode: row.update_mode,
+                    update_cadence_days: row.update_cadence_days,
+                    is_active: false,
+                });
+            }
             Err(err) => {
-                // A single playlist that's been deleted/renamed on Spotify's side
-                // (or a transient API error) shouldn't take down the whole list.
+                // A transient API error shouldn't take down the whole list,
+                // and shouldn't flip is_active (it may well still exist).
                 tracing::warn!(
                     playlist_id = %row.provider_playlist_id,
                     error = %err,
@@ -268,4 +326,135 @@ pub async fn get_playlists(
     }
 
     Ok(Json(summaries))
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /playlist/{id}
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+pub struct UpdatePlaylistRequest {
+    pub name: String,
+    pub privacy: bool,
+    pub cadence: i16,
+    pub destructive: bool,
+}
+
+#[derive(Serialize)]
+pub struct UpdatePlaylistResponse {
+    pub playlist_id: String,
+    pub name: String,
+    pub visibility: PlaylistVisibility,
+    pub update_mode: PlaylistUpdateMode,
+    pub update_cadence_days: i16,
+}
+
+pub async fn update_playlist(
+    State(state): State<AppState>,
+    jar: SignedCookieJar,
+    Path(playlist_id): Path<uuid::Uuid>,
+    Json(req): Json<UpdatePlaylistRequest>,
+) -> Result<Json<UpdatePlaylistResponse>, AppError> {
+    let account_id = resolve_account_from_cookie(&state, &jar).await?;
+    let cadence = validate_cadence_days(req.cadence)?;
+
+    let row = get_playlist_for_account(&state.db.pool, playlist_id, account_id)
+        .await?
+        .ok_or(AppError::PlaylistNotFound)?;
+
+    if !row.is_active {
+        // Nothing on Spotify's side left to apply an edit to.
+        return Err(AppError::PlaylistNotFound);
+    }
+
+    let token = crate::spotify::token::get_valid_spotify_token(&state, account_id).await?;
+
+    let visibility = if req.privacy {
+        PlaylistVisibility::Private
+    } else {
+        PlaylistVisibility::Public
+    };
+    let update_mode = if req.destructive {
+        PlaylistUpdateMode::Destructive
+    } else {
+        PlaylistUpdateMode::Additive
+    };
+
+    match state
+        .spotify
+        .update_playlist_details(&token, &row.provider_playlist_id, Some(&req.name), Some(!req.privacy))
+        .await
+    {
+        Ok(()) => {
+            update_playlist_config(
+                &state.db.pool,
+                playlist_id,
+                UpdatePlaylistParams {
+                    name: &req.name,
+                    visibility,
+                    update_mode,
+                    update_cadence_days: cadence,
+                },
+            )
+            .await?;
+
+            Ok(Json(UpdatePlaylistResponse {
+                playlist_id: playlist_id.to_string(),
+                name: req.name,
+                visibility,
+                update_mode,
+                update_cadence_days: cadence,
+            }))
+        }
+        Err(err) if is_gone_from_spotify(&err) => {
+            deactivate_playlist(&state.db.pool, playlist_id).await?;
+            Err(AppError::PlaylistUnavailable { playlist_id })
+        }
+        // Spotify is the source of truth: reject the whole edit, persist nothing.
+        Err(err) => Err(err),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /playlist/{id}
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+pub struct DeletePlaylistResponse {
+    pub playlist_id: String,
+}
+
+pub async fn delete_playlist(
+    State(state): State<AppState>,
+    jar: SignedCookieJar,
+    Path(playlist_id): Path<uuid::Uuid>,
+) -> Result<Json<DeletePlaylistResponse>, AppError> {
+    let account_id = resolve_account_from_cookie(&state, &jar).await?;
+
+    let row = get_playlist_for_account(&state.db.pool, playlist_id, account_id)
+        .await?
+        .ok_or(AppError::PlaylistNotFound)?;
+
+    if row.is_active {
+        let token = crate::spotify::token::get_valid_spotify_token(&state, account_id).await?;
+        match state
+            .spotify
+            .unfollow_playlist(&token, &row.provider_playlist_id)
+            .await
+        {
+            Ok(()) => {}
+            Err(err) if is_gone_from_spotify(&err) => {
+                // Already gone — treat as success and proceed to soft-delete.
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    // If already inactive, there's nothing left to unfollow — skip straight
+    // to soft-delete.
+
+    soft_delete_playlist(&state.db.pool, playlist_id).await?;
+
+    Ok(Json(DeletePlaylistResponse {
+        playlist_id: playlist_id.to_string(),
+    }))
 }

--- a/apps/web/src/Drawer/PlaylistsDrawer.tsx
+++ b/apps/web/src/Drawer/PlaylistsDrawer.tsx
@@ -1,11 +1,20 @@
-import { usePlaylistContext } from "@/providers/playlistsProvider"
-import { useSpotifyAuth } from "../hooks/spotify"
+import {
+  usePlaylistContext,
+  type SpotifyPlaylist,
+} from "@/providers/playlistsProvider"
+import {
+  useSpotifyAuth,
+  parseUpdatePlaylistForm,
+  PlaylistUnavailableError,
+} from "../hooks/spotify"
 import {
   CircleCheck,
   ListMusic,
   CirclePlus,
   Music2,
   ExternalLink,
+  MoreVertical,
+  TriangleAlert,
 } from "lucide-react"
 
 import { Button } from "@workspace/ui/components/ui/Button"
@@ -28,6 +37,14 @@ import { PlaylistButtons } from "../PlaylistButtons"
 import { getRandomPlaylistName } from "@/lib/playlistNames"
 
 import { DrawerBody, DrawerHeader } from "@workspace/ui/components/ui/Drawer"
+import { Modal } from "@workspace/ui/components/ui/Modal"
+import { Dialog } from "@workspace/ui/components/ui/Dialog"
+import { AlertDialog } from "@workspace/ui/components/ui/AlertDialog"
+import {
+  MenuTrigger,
+  Menu,
+  MenuItem,
+} from "@workspace/ui/components/ui/Menu"
 
 export const PlaylistDrawerHeader = () => {
   return (
@@ -60,42 +77,7 @@ export const PlaylistsDrawerBody = () => {
             {spotifyPlaylists.length > 0 ? (
               <ul className="flex flex-col gap-2">
                 {spotifyPlaylists.map((playlist) => (
-                  <li key={playlist.id}>
-                    <a
-                      href={playlist.external_url ?? undefined}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="flex items-center gap-3 rounded-lg border border-black/10 p-2 transition hover:border-black/20 hover:bg-neutral-50 dark:border-white/10 dark:hover:bg-zinc-800"
-                    >
-                      {playlist.images && playlist.images.length > 0 ? (
-                        <img
-                          src={playlist.images[0].url}
-                          alt=""
-                          className="h-12 w-12 shrink-0 rounded object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded bg-neutral-100 text-muted-foreground dark:bg-neutral-800">
-                          <Music2 size={18} />
-                        </div>
-                      )}
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-semibold text-primary">
-                          {playlist.name}
-                        </p>
-                        <p className="truncate text-xs text-muted-foreground">
-                          {playlist.track_count} track
-                          {playlist.track_count === 1 ? "" : "s"}
-                          {playlist.city ? ` · ${playlist.city}` : ""}
-                        </p>
-                      </div>
-                      {playlist.external_url && (
-                        <ExternalLink
-                          size={14}
-                          className="shrink-0 text-muted-foreground"
-                        />
-                      )}
-                    </a>
-                  </li>
+                  <PlaylistListItem key={playlist.playlist_id} playlist={playlist} />
                 ))}
               </ul>
             ) : (
@@ -115,6 +97,224 @@ export const PlaylistsDrawerBody = () => {
         </TabPanels>
       </Tabs>
     </DrawerBody>
+  )
+}
+
+const cadenceToFrequencyValue = (cadence: 7 | 30 | 60) =>
+  cadence === 60 ? "bimonthly" : cadence === 7 ? "weekly" : "monthly"
+
+const PlaylistListItem = ({ playlist }: { playlist: SpotifyPlaylist }) => {
+  const { deletePlaylist } = useSpotifyAuth()
+  const [isEditOpen, setIsEditOpen] = useState(false)
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false)
+  const isUnavailable = !playlist.is_active
+
+  return (
+    <li>
+      <div
+        className={`flex items-center gap-3 rounded-lg border border-black/10 p-2 dark:border-white/10 ${
+          isUnavailable ? "opacity-50" : "hover:border-black/20 hover:bg-neutral-50 dark:hover:bg-zinc-800"
+        }`}
+      >
+        <a
+          href={isUnavailable ? undefined : (playlist.external_url ?? undefined)}
+          target="_blank"
+          rel="noreferrer"
+          aria-disabled={isUnavailable}
+          className={`flex min-w-0 flex-1 items-center gap-3 ${isUnavailable ? "pointer-events-none" : ""}`}
+        >
+          {playlist.images && playlist.images.length > 0 ? (
+            <img
+              src={playlist.images[0].url}
+              alt=""
+              className="h-12 w-12 shrink-0 rounded object-cover"
+            />
+          ) : (
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded bg-neutral-100 text-muted-foreground dark:bg-neutral-800">
+              <Music2 size={18} />
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold text-primary">
+              {playlist.name || playlist.city}
+            </p>
+            {isUnavailable ? (
+              <p className="truncate text-xs text-red-500">
+                Unavailable — removed on Spotify
+              </p>
+            ) : (
+              <p className="truncate text-xs text-muted-foreground">
+                {playlist.track_count} track
+                {playlist.track_count === 1 ? "" : "s"}
+                {playlist.city ? ` · ${playlist.city}` : ""}
+              </p>
+            )}
+          </div>
+          {!isUnavailable && playlist.external_url && (
+            <ExternalLink size={14} className="shrink-0 text-muted-foreground" />
+          )}
+        </a>
+
+        <MenuTrigger>
+          <Button
+            variant="secondary"
+            aria-label={`Actions for ${playlist.name || "playlist"}`}
+            className="shrink-0 p-1.5!"
+          >
+            <MoreVertical size={16} />
+          </Button>
+          <Menu
+            onAction={(key) => {
+              if (key === "edit") setIsEditOpen(true)
+              if (key === "delete") setIsDeleteOpen(true)
+            }}
+          >
+            {!isUnavailable && <MenuItem id="edit">Edit</MenuItem>}
+            <MenuItem id="delete">
+              {isUnavailable ? "Remove from Gigeo" : "Delete"}
+            </MenuItem>
+          </Menu>
+        </MenuTrigger>
+      </div>
+
+      <Modal isOpen={isEditOpen} onOpenChange={setIsEditOpen} isDismissable>
+        <Dialog>
+          {({ close }) => (
+            <EditPlaylistForm playlist={playlist} onDone={close} />
+          )}
+        </Dialog>
+      </Modal>
+
+      <Modal isOpen={isDeleteOpen} onOpenChange={setIsDeleteOpen} isDismissable>
+        <AlertDialog
+          title={isUnavailable ? "Remove from Gigeo?" : "Delete playlist?"}
+          variant="destructive"
+          actionLabel={isUnavailable ? "Remove" : "Delete"}
+          onAction={() => {
+            void deletePlaylist(playlist.playlist_id)
+          }}
+        >
+          {isUnavailable
+            ? "This playlist was already removed on Spotify. This just cleans up Gigeo's record of it."
+            : "This unfollows the playlist on Spotify and removes it from Gigeo. This can't be undone."}
+        </AlertDialog>
+      </Modal>
+    </li>
+  )
+}
+
+const EditPlaylistForm = ({
+  playlist,
+  onDone,
+}: {
+  playlist: SpotifyPlaylist
+  onDone: () => void
+}) => {
+  const { updatePlaylist } = useSpotifyAuth()
+  const [isPrivate, setIsPrivate] = useState(playlist.visibility === "private")
+  const [selectedFrequency, setSelectedFrequency] = useState(
+    cadenceToFrequencyValue(playlist.update_cadence_days)
+  )
+  const [selectedBehavior, setSelectedBehavior] = useState(playlist.update_mode)
+  const [error, setError] = useState<string | null>(null)
+
+  const showDestructiveWarning =
+    selectedBehavior === "destructive" && playlist.update_mode === "additive"
+
+  return (
+    <Form
+      className="w-full p-0!"
+      action={async (formData) => {
+        setError(null)
+        try {
+          await updatePlaylist(
+            playlist.playlist_id,
+            parseUpdatePlaylistForm(formData)
+          )
+          onDone()
+        } catch (err) {
+          setError(
+            err instanceof PlaylistUnavailableError
+              ? "This playlist was just removed on Spotify, so it can no longer be edited."
+              : err instanceof Error
+                ? err.message
+                : "Failed to update playlist"
+          )
+        }
+      }}
+    >
+      <input
+        type="hidden"
+        name="privacy"
+        value={isPrivate ? "private" : "public"}
+      />
+      <TextField
+        label="Playlist Name"
+        isRequired
+        name="playlistName"
+        defaultValue={playlist.name}
+      />
+      <Label>Playlist privacy</Label>
+      <ToggleButton
+        aria-label="Make playlist private"
+        isSelected={isPrivate}
+        onChange={setIsPrivate}
+      >
+        {isPrivate ? <Lock size={18} /> : <Unlock size={18} />}
+      </ToggleButton>
+      <p>{isPrivate ? "Private" : "Public"}</p>
+
+      <Label>Update frequency</Label>
+      <RadioGroup
+        aria-label="Playlist update frequency"
+        value={selectedFrequency}
+        onChange={setSelectedFrequency}
+        orientation="horizontal"
+        className="flex w-full gap-2.5"
+        name="cadence"
+        isRequired
+      >
+        {updateFrequencyOptions.map((option) => (
+          <RadioCard
+            key={option.value}
+            value={option.value}
+            title={option.title}
+            description={option.description}
+          />
+        ))}
+      </RadioGroup>
+      <Label>Update behavior</Label>
+      <RadioGroup
+        aria-label="Playlist update behavior"
+        value={selectedBehavior}
+        onChange={(value) =>
+          setSelectedBehavior(value as "additive" | "destructive")
+        }
+        orientation="horizontal"
+        className="flex w-full gap-2.5"
+        name="behavior"
+        isRequired
+      >
+        {updateBehaviorOptions.map((option) => (
+          <RadioCard
+            key={option.value}
+            value={option.value}
+            title={option.title}
+            description={option.description}
+          />
+        ))}
+      </RadioGroup>
+      {showDestructiveWarning && (
+        <p className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+          <TriangleAlert size={14} className="mt-0.5 shrink-0" />
+          Switching to "Replace tracks" may remove tracks you've kept.
+          Changes apply on the playlist's next scheduled update, not
+          immediately.
+        </p>
+      )}
+      {error && <p className="text-xs text-red-500">{error}</p>}
+      <Button type="submit">Save changes</Button>
+    </Form>
   )
 }
 

--- a/apps/web/src/hooks/spotify.test.ts
+++ b/apps/web/src/hooks/spotify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { parseCreatePlaylistForm } from "./spotify"
+import { parseCreatePlaylistForm, parseUpdatePlaylistForm } from "./spotify"
 
 function makeForm(fields: Record<string, string>): FormData {
   const form = new FormData()
@@ -106,5 +106,90 @@ describe("parseCreatePlaylistForm", () => {
     expect(parseCreatePlaylistForm(makeForm(validFields)).description).toBe(
       ""
     )
+  })
+})
+
+const validUpdateFields = {
+  playlistName: "Road Trip",
+  cadence: "weekly",
+}
+
+describe("parseUpdatePlaylistForm", () => {
+  it("parses a valid form into an UpdatePlaylistInput", () => {
+    expect(parseUpdatePlaylistForm(makeForm(validUpdateFields))).toEqual({
+      name: "Road Trip",
+      privacy: false,
+      cadence: 7,
+      destructive: false,
+    })
+  })
+
+  it("trims whitespace from name", () => {
+    const result = parseUpdatePlaylistForm(
+      makeForm({ ...validUpdateFields, playlistName: "  Road Trip  " })
+    )
+    expect(result.name).toBe("Road Trip")
+  })
+
+  it("throws when name is missing", () => {
+    const form = makeForm({ ...validUpdateFields })
+    form.delete("playlistName")
+    expect(() => parseUpdatePlaylistForm(form)).toThrow(
+      "Playlist name is required"
+    )
+  })
+
+  it("throws when name is blank", () => {
+    expect(() =>
+      parseUpdatePlaylistForm(
+        makeForm({ ...validUpdateFields, playlistName: "   " })
+      )
+    ).toThrow("Playlist name is required")
+  })
+
+  it("throws when cadence is missing", () => {
+    const form = makeForm({ ...validUpdateFields })
+    form.delete("cadence")
+    expect(() => parseUpdatePlaylistForm(form)).toThrow(
+      "Cadence is required"
+    )
+  })
+
+  it.each([
+    ["weekly", 7],
+    ["bimonthly", 60],
+    ["monthly", 30],
+    ["anything-else", 30],
+  ])("maps cadence %s to %i days", (cadence, expected) => {
+    const result = parseUpdatePlaylistForm(
+      makeForm({ ...validUpdateFields, cadence })
+    )
+    expect(result.cadence).toBe(expected)
+  })
+
+  it("sets privacy true only when privacy field is 'private'", () => {
+    expect(
+      parseUpdatePlaylistForm(
+        makeForm({ ...validUpdateFields, privacy: "private" })
+      ).privacy
+    ).toBe(true)
+    expect(
+      parseUpdatePlaylistForm(
+        makeForm({ ...validUpdateFields, privacy: "public" })
+      ).privacy
+    ).toBe(false)
+  })
+
+  it("sets destructive true only when behavior field is 'destructive'", () => {
+    expect(
+      parseUpdatePlaylistForm(
+        makeForm({ ...validUpdateFields, behavior: "destructive" })
+      ).destructive
+    ).toBe(true)
+    expect(
+      parseUpdatePlaylistForm(
+        makeForm({ ...validUpdateFields, behavior: "preserve" })
+      ).destructive
+    ).toBe(false)
   })
 })

--- a/apps/web/src/hooks/spotify.ts
+++ b/apps/web/src/hooks/spotify.ts
@@ -28,6 +28,21 @@ export type CreatePlaylistOutput = {
   spotify_url?: string | null
 }
 
+export type UpdatePlaylistInput = {
+  name: string
+  privacy: boolean
+  cadence: number
+  destructive: boolean
+}
+
+/** Thrown when the server confirms a playlist is no longer on Spotify (410). */
+export class PlaylistUnavailableError extends Error {
+  constructor() {
+    super("Playlist is no longer available on Spotify")
+    this.name = "PlaylistUnavailableError"
+  }
+}
+
 type UseSpotifyAuthResult = {
   status: AuthStatus | null
   loading: boolean
@@ -37,6 +52,11 @@ type UseSpotifyAuthResult = {
   logout: () => Promise<void>
   createPlaylist: (input: FormData) => Promise<CreatePlaylistOutput>
   getPlaylists: () => Promise<SpotifyPlaylist[]>
+  updatePlaylist: (
+    playlistId: string,
+    input: UpdatePlaylistInput
+  ) => Promise<void>
+  deletePlaylist: (playlistId: string) => Promise<void>
 }
 
 export function parseCreatePlaylistForm(
@@ -68,6 +88,28 @@ export function parseCreatePlaylistForm(
     cadence: cadence === "bimonthly" ? 60 : cadence === "weekly" ? 7 : 30,
     destructive: behavior === "destructive",
     radius: 25,
+  }
+}
+
+export function parseUpdatePlaylistForm(formData: FormData): UpdatePlaylistInput {
+  const name = formData.get("playlistName")
+  const privacy = formData.get("privacy")
+  const cadence = formData.get("cadence")
+  const behavior = formData.get("behavior")
+
+  if (typeof name !== "string" || !name.trim()) {
+    throw new Error("Playlist name is required")
+  }
+
+  if (typeof cadence !== "string" || !cadence) {
+    throw new Error("Cadence is required")
+  }
+
+  return {
+    name: name.trim(),
+    privacy: privacy === "private",
+    cadence: cadence === "bimonthly" ? 60 : cadence === "weekly" ? 7 : 30,
+    destructive: behavior === "destructive",
   }
 }
 
@@ -180,6 +222,56 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
     [refresh, latitude, longitude]
   )
 
+  const updatePlaylist = useCallback(
+    async (playlistId: string, input: UpdatePlaylistInput) => {
+      setError(null)
+
+      const res = await fetch(`api/spotify/playlist/${playlistId}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(input),
+      })
+
+      if (res.status === 410) {
+        // Confirmed gone on Spotify's side — refresh so the row flips to
+        // "unavailable", then let the caller distinguish this from a
+        // generic failure.
+        await getPlaylists()
+        throw new PlaylistUnavailableError()
+      }
+
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(text || `update playlist failed: ${res.status}`)
+      }
+
+      await getPlaylists()
+    },
+    [getPlaylists]
+  )
+
+  const deletePlaylist = useCallback(
+    async (playlistId: string) => {
+      setError(null)
+
+      const res = await fetch(`api/spotify/playlist/${playlistId}`, {
+        method: "DELETE",
+        credentials: "include",
+      })
+
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(text || `delete playlist failed: ${res.status}`)
+      }
+
+      await getPlaylists()
+    },
+    [getPlaylists]
+  )
+
   return useMemo(
     () => ({
       status,
@@ -190,6 +282,8 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
       logout,
       createPlaylist,
       getPlaylists,
+      updatePlaylist,
+      deletePlaylist,
     }),
     [
       status,
@@ -200,6 +294,8 @@ export function useSpotifyAuth(): UseSpotifyAuthResult {
       logout,
       createPlaylist,
       getPlaylists,
+      updatePlaylist,
+      deletePlaylist,
     ]
   )
 }

--- a/apps/web/src/providers/playlistsProvider.tsx
+++ b/apps/web/src/providers/playlistsProvider.tsx
@@ -8,12 +8,17 @@ export type SpotifyPlaylistImage = {
 }
 
 export type SpotifyPlaylist = {
+  playlist_id: string
   id: string
   name: string
   external_url?: string | null
   images: SpotifyPlaylistImage[]
   track_count: number
   city: string
+  visibility: "public" | "private"
+  update_mode: "additive" | "destructive"
+  update_cadence_days: 7 | 30 | 60
+  is_active: boolean
 }
 
 type PlaylistProviderState = {

--- a/packages/ui/src/components/ui/AlertDialog.tsx
+++ b/packages/ui/src/components/ui/AlertDialog.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { AlertCircleIcon, InfoIcon } from "lucide-react";
-import React, { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { chain } from "react-aria";
-import { DialogProps, Heading } from "react-aria-components";
+import { Heading, type DialogProps } from "react-aria-components";
 import { Button } from '@workspace/ui/components/ui/Button';
 import { Dialog } from '@workspace/ui/components/ui/Dialog';
 

--- a/packages/ui/src/components/ui/AlertDialog.tsx
+++ b/packages/ui/src/components/ui/AlertDialog.tsx
@@ -3,7 +3,7 @@ import { AlertCircleIcon, InfoIcon } from "lucide-react";
 import React, { ReactNode } from "react";
 import { chain } from "react-aria";
 import { DialogProps, Heading } from "react-aria-components";
-import { Button } from '@workspace/ui/components/Button';
+import { Button } from '@workspace/ui/components/ui/Button';
 import { Dialog } from '@workspace/ui/components/ui/Dialog';
 
 interface AlertDialogProps extends Omit<DialogProps, 'children'> {

--- a/packages/ui/src/components/ui/Modal.tsx
+++ b/packages/ui/src/components/ui/Modal.tsx
@@ -1,6 +1,5 @@
 'use client';
-import React from 'react';
-import { ModalOverlay, ModalOverlayProps, Modal as RACModal } from 'react-aria-components';
+import { ModalOverlay, Modal as RACModal, type ModalOverlayProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
 const overlayStyles = tv({


### PR DESCRIPTION
## Summary
- Adds edit (name, privacy, update cadence, update mode) and delete for existing playlists, propagating both to Spotify. `city`/`geohash` remain permanently locked.
- Delete is a soft-delete (new `deleted_at` column), preserving `playlist_update_run` audit history; Spotify's unfollow endpoint is called first, treating a 404 there as already-gone success.
- Detects playlists removed directly on Spotify (both at list-time and via the existing background updater) and surfaces them in the UI as a distinct "Unavailable — removed on Spotify" state instead of silently dropping them, with only a "Remove from Gigeo" action available.
- Fixes a pre-existing bug in `packages/ui`'s `AlertDialog.tsx` (wrong `Button` import path), invisible until this PR made it the first real consumer.

## Test plan
- [x] `cargo test` (36/36 passing) and `cargo clippy` (no new warnings)
- [x] `pnpm test` (unit tests for `parseUpdatePlaylistForm` and existing suite), `pnpm typecheck`, `pnpm lint`
- [x] Migration applied to dev DB; manually loaded the app, opened the Playlists drawer, confirmed not-connected state renders correctly
- [x] Smoke-tested `PATCH`/`DELETE /spotify/playlist/{id}` directly — correctly 401 without auth
- [ ] Full authenticated edit/delete/unavailable-detection flow against a real Spotify account (needs manual pass with real OAuth login)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>