### PR TITLE
Add loading and success states to playlist creation

### DIFF
--- a/apps/web/src/Drawer/PlaylistsDrawer.tsx
+++ b/apps/web/src/Drawer/PlaylistsDrawer.tsx
@@ -6,6 +6,7 @@ import {
   useSpotifyAuth,
   parseUpdatePlaylistForm,
   PlaylistUnavailableError,
+  type CreatePlaylistOutput,
 } from "../hooks/spotify"
 import {
   CircleCheck,
@@ -384,13 +385,28 @@ export const CreatePlaylistForm = () => {
   const [isPrivate, setIsPrivate] = useState(false)
   const [selectedFrequency, setSelectedFrequency] = useState("weekly")
   const [selectedBehavior, setSelectedBehavior] = useState("destructive")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<CreatePlaylistOutput | null>(null)
 
   return (
     <div className="flex flex-col items-center justify-center">
       <Form
         className="w-full p-0!"
-        action={(formData) => {
-          createPlaylist(formData)
+        action={async (formData) => {
+          setError(null)
+          setSuccess(null)
+          setIsSubmitting(true)
+          try {
+            const result = await createPlaylist(formData)
+            setSuccess(result)
+          } catch (err) {
+            setError(
+              err instanceof Error ? err.message : "Failed to create playlist"
+            )
+          } finally {
+            setIsSubmitting(false)
+          }
         }}
       >
         <input type="hidden" name="location" value={selectedLocation ?? ""} />
@@ -469,7 +485,30 @@ export const CreatePlaylistForm = () => {
             />
           ))}
         </RadioGroup>
-        <Button type="submit">Create Playlist</Button>
+        {success && (
+          <p className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+            <CircleCheck size={14} className="shrink-0" />
+            "{success.name}" created
+            {success.spotify_url && (
+              <>
+                {" · "}
+                <a
+                  href={success.spotify_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 underline"
+                >
+                  Open in Spotify
+                  <ExternalLink size={12} />
+                </a>
+              </>
+            )}
+          </p>
+        )}
+        {error && <p className="text-xs text-red-500">{error}</p>}
+        <Button type="submit" isPending={isSubmitting} isDisabled={isSubmitting}>
+          Create Playlist
+        </Button>
       </Form>
     </div>
   )


### PR DESCRIPTION
## Summary
- `CreatePlaylistForm`'s submit handler now awaits `createPlaylist` and tracks `isSubmitting`/`error`/`success` state, instead of firing the request and ignoring the result.
- The submit button shows the existing pending spinner and disables while submitting.
- On success, shows a confirmation with the playlist name and an "Open in Spotify" link.
- On failure, shows an inline error, matching the pattern already used in `EditPlaylistForm`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified in browser: Create tab renders, submitting without a Spotify session surfaces the inline error banner as expected
- [ ] Manually verify the success path with a connected Spotify account

🤖 Generated with [Claude Code](https://claude.com/claude-code)