### PR TITLE
Personalized discovery: match Spotify top artists on the concert stream

### DIFF
--- a/apps/api/.sqlx/query-7497899905fbaa05ee80011313d49254e83ce264fbe5b67c507ae6755801b77b.json
+++ b/apps/api/.sqlx/query-7497899905fbaa05ee80011313d49254e83ce264fbe5b67c507ae6755801b77b.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select normalized_names, fetched_at\n        from spotify_top_artist_cache\n        where account_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "normalized_names",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 1,
+        "name": "fetched_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "7497899905fbaa05ee80011313d49254e83ce264fbe5b67c507ae6755801b77b"
+}

--- a/apps/api/.sqlx/query-ae8934a15198b754ecbc4c9c8c5d33410aa4124fb5940a2929b0fb861de52cc4.json
+++ b/apps/api/.sqlx/query-ae8934a15198b754ecbc4c9c8c5d33410aa4124fb5940a2929b0fb861de52cc4.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        insert into spotify_top_artist_cache (account_id, normalized_names, fetched_at)\n        values ($1, $2, now())\n        on conflict (account_id) do update set\n            normalized_names = excluded.normalized_names,\n            fetched_at = excluded.fetched_at\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ae8934a15198b754ecbc4c9c8c5d33410aa4124fb5940a2929b0fb861de52cc4"
+}

--- a/apps/api/migrations/004_spotify_top_artist_cache.sql
+++ b/apps/api/migrations/004_spotify_top_artist_cache.sql
@@ -1,0 +1,10 @@
+-- Caches each account's exact-normalized Spotify top-artist names, used to
+-- match against Ticketmaster attractions for personalized discovery.
+-- Spotify's top-artists list reflects listening history that changes slowly,
+-- so it's refreshed on a TTL rather than re-fetched on every
+-- /concerts/stream request (which fires on every map pan/zoom).
+create table spotify_top_artist_cache (
+    account_id uuid primary key references account(id) on delete cascade,
+    normalized_names text[] not null,
+    fetched_at timestamptz not null default now()
+);

--- a/apps/api/src/auth.rs
+++ b/apps/api/src/auth.rs
@@ -158,7 +158,8 @@ impl UserTokenManager {
 
     /// Build the Spotify authorization URL the user should visit.
     pub fn authorize_url(&self, state: &str) -> String {
-        let scopes = "playlist-modify-public playlist-modify-private user-read-private";
+        let scopes =
+            "playlist-modify-public playlist-modify-private user-read-private user-top-read";
         format!(
             "https://accounts.spotify.com/authorize?response_type=code&show_dialog=true\
              &client_id={client_id}\

--- a/apps/api/src/spotify/client.rs
+++ b/apps/api/src/spotify/client.rs
@@ -13,7 +13,11 @@ use crate::error::AppError;
 use crate::http_utils::{request_with_backoff, url_encode};
 use unicode_normalization::UnicodeNormalization;
 
-fn normalize(s: &str) -> String {
+/// Lowercases, strips accents (NFD), and drops non-alphanumeric characters —
+/// used both to match a searched artist name against Spotify search results
+/// and, exact-normalized, to match a Spotify top artist against a
+/// Ticketmaster attraction name for personalized discovery.
+pub(crate) fn normalize_artist_name(s: &str) -> String {
     s.to_lowercase()
         .nfd()
         .filter(|c| c.is_alphanumeric() && !c.is_whitespace())
@@ -55,6 +59,28 @@ pub struct Artist {
 pub struct SimplifiedArtist {
     pub id: String,
     pub name: String,
+}
+
+/// Window over which Spotify computes "top artists" — passed as the
+/// `time_range` query param on `GET /me/top/artists`.
+#[derive(Debug, Clone, Copy)]
+pub enum TopArtistsTimeRange {
+    /// ~4 weeks
+    Short,
+    /// ~6 months
+    Medium,
+    /// Several years, calculated periodically
+    Long,
+}
+
+impl TopArtistsTimeRange {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Short => "short_term",
+            Self::Medium => "medium_term",
+            Self::Long => "long_term",
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -239,7 +265,7 @@ impl SpotifyClient {
             .artists
             .items
             .into_iter()
-            .find(|a| normalize(&a.name) == normalize(artist_name));
+            .find(|a| normalize_artist_name(&a.name) == normalize_artist_name(artist_name));
         let Some(artist) = artist else {
             return Ok(None);
         };
@@ -261,6 +287,23 @@ impl SpotifyClient {
     pub async fn get_artist_by_href(&self, token: &str, href: &str) -> Result<Artist, AppError> {
         let url = href.to_string();
         self.get_json(token, &url).await
+    }
+
+    /// `GET /me/top/artists?time_range={time_range}&limit={limit}`
+    /// Scopes: `user-top-read`
+    pub async fn get_top_artists(
+        &self,
+        user_token: &str,
+        time_range: TopArtistsTimeRange,
+        limit: u8,
+    ) -> Result<Vec<Artist>, AppError> {
+        let url = format!(
+            "{BASE}/me/top/artists?time_range={}&limit={limit}",
+            time_range.as_str(),
+        );
+        self.get_json::<Paging<Artist>>(user_token, &url)
+            .await
+            .map(|p| p.items)
     }
 
     // -- Playlists (require user-scoped token) ------------------------------

--- a/apps/api/src/spotify/mod.rs
+++ b/apps/api/src/spotify/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
 pub mod spotify_handlers;
 pub(crate) mod token;
+pub(crate) mod top_artists;

--- a/apps/api/src/spotify/spotify_handlers/db.rs
+++ b/apps/api/src/spotify/spotify_handlers/db.rs
@@ -1,5 +1,39 @@
 use crate::auth::TokenResponse;
+use crate::error::AppError;
 use crate::services::playlist_builder::{PlaylistUpdateMode, PlaylistVisibility};
+use crate::state::AppState;
+use axum::http::StatusCode;
+use axum_extra::extract::cookie::SignedCookieJar;
+
+/// Resolves the account tied to the session cookie. Shared by every
+/// handler that requires an authenticated user.
+pub(super) async fn resolve_account_from_cookie(
+    state: &AppState,
+    jar: &SignedCookieJar,
+) -> Result<uuid::Uuid, AppError> {
+    let cookie = jar
+        .get("spotify_oauth_state")
+        .ok_or_else(|| AppError::AuthRequired("No session cookie. Visit /login first.".into()))?;
+    let session_id = uuid::Uuid::parse_str(cookie.value()).map_err(|_| AppError::Unauthorized {
+        status: StatusCode::UNAUTHORIZED,
+        message: "Invalid session cookie".into(),
+    })?;
+    resolve_session_account(&state.db.pool, session_id)
+        .await?
+        .ok_or_else(|| {
+            AppError::AuthRequired("Session expired or invalid. Visit /login first.".into())
+        })
+}
+
+/// Lenient variant of `resolve_account_from_cookie`, for endpoints where a
+/// missing or invalid session should silently disable a feature (e.g.
+/// personalized discovery) rather than fail the whole request.
+pub(crate) async fn resolve_account_from_cookie_lenient(
+    state: &AppState,
+    jar: &SignedCookieJar,
+) -> Option<uuid::Uuid> {
+    resolve_account_from_cookie(state, jar).await.ok()
+}
 
 pub(super) async fn create_session(
     db: &sqlx::PgPool,

--- a/apps/api/src/spotify/spotify_handlers/mod.rs
+++ b/apps/api/src/spotify/spotify_handlers/mod.rs
@@ -3,6 +3,11 @@
 //! - `auth`: OAuth login/callback/status
 //! - `playlists`: playlist creation, retrieval, edit, and delete
 //! - `db`: persistence for sessions, accounts, and playlists
+//!
+//! `resolve_account_from_cookie_lenient` is re-exported at `pub(crate)` for
+//! endpoints outside this module (e.g. the concerts stream) where a
+//! missing/invalid session should silently disable a feature rather than
+//! fail the request.
 
 mod artist;
 mod auth;
@@ -12,3 +17,4 @@ mod playlists;
 pub use artist::*;
 pub use auth::*;
 pub use playlists::*;
+pub(crate) use db::resolve_account_from_cookie_lenient;

--- a/apps/api/src/spotify/spotify_handlers/mod.rs
+++ b/apps/api/src/spotify/spotify_handlers/mod.rs
@@ -16,5 +16,5 @@ mod playlists;
 
 pub use artist::*;
 pub use auth::*;
-pub use playlists::*;
 pub(crate) use db::resolve_account_from_cookie_lenient;
+pub use playlists::*;

--- a/apps/api/src/spotify/spotify_handlers/playlists.rs
+++ b/apps/api/src/spotify/spotify_handlers/playlists.rs
@@ -1,6 +1,6 @@
 use super::db::{
     CreatePlaylistParams, UpdatePlaylistParams, create_playlist_record, deactivate_playlist,
-    get_playlist_for_account, resolve_session_account, soft_delete_playlist,
+    get_playlist_for_account, resolve_account_from_cookie, soft_delete_playlist,
     update_playlist_config,
 };
 use crate::error::AppError;
@@ -16,26 +16,6 @@ use axum::{
 };
 use axum_extra::extract::cookie::SignedCookieJar;
 use serde::{Deserialize, Serialize};
-
-/// Resolves the account tied to the session cookie. Shared by every
-/// handler that requires an authenticated user.
-async fn resolve_account_from_cookie(
-    state: &AppState,
-    jar: &SignedCookieJar,
-) -> Result<uuid::Uuid, AppError> {
-    let cookie = jar
-        .get("spotify_oauth_state")
-        .ok_or_else(|| AppError::AuthRequired("No session cookie. Visit /login first.".into()))?;
-    let session_id = uuid::Uuid::parse_str(cookie.value()).map_err(|_| AppError::Unauthorized {
-        status: StatusCode::UNAUTHORIZED,
-        message: "Invalid session cookie".into(),
-    })?;
-    resolve_session_account(&state.db.pool, session_id)
-        .await?
-        .ok_or_else(|| {
-            AppError::AuthRequired("Session expired or invalid. Visit /login first.".into())
-        })
-}
 
 /// Returns `true` if a Spotify API error indicates the resource no longer
 /// exists upstream (as opposed to a transient failure).

--- a/apps/api/src/spotify/top_artists.rs
+++ b/apps/api/src/spotify/top_artists.rs
@@ -1,0 +1,81 @@
+//! Per-account cache of exact-normalized Spotify top-artist names, used to
+//! power the personalized discovery match against nearby Ticketmaster events
+//! (see `ticketmaster_stream`). Fetching `/me/top/artists` on every
+//! `/concerts/stream` request would be wasteful — that endpoint fires on
+//! every map pan/zoom — so results are cached per account on a TTL instead.
+
+use std::collections::HashSet;
+
+use chrono::{Duration, Utc};
+
+use crate::error::AppError;
+use crate::spotify::client::{TopArtistsTimeRange, normalize_artist_name};
+use crate::state::AppState;
+
+const CACHE_TTL: Duration = Duration::hours(24);
+
+struct CacheRow {
+    normalized_names: Vec<String>,
+    fetched_at: chrono::DateTime<Utc>,
+}
+
+/// Returns the exact-normalized top-artist names for `account_id` (~6 month
+/// window), refreshing from Spotify if the cache is missing or stale.
+///
+/// Returns an empty set — never an error — if the account has no Spotify
+/// connection, since callers use this to gate an optional feature
+/// (personalization) that must never break the underlying event stream.
+pub(crate) async fn get_top_artist_names(
+    state: &AppState,
+    account_id: uuid::Uuid,
+) -> Result<HashSet<String>, AppError> {
+    let cached = sqlx::query_as!(
+        CacheRow,
+        r#"
+        select normalized_names, fetched_at
+        from spotify_top_artist_cache
+        where account_id = $1
+        "#,
+        account_id
+    )
+    .fetch_optional(&state.db.pool)
+    .await?;
+
+    if let Some(row) = &cached
+        && row.fetched_at > Utc::now() - CACHE_TTL
+    {
+        return Ok(row.normalized_names.iter().cloned().collect());
+    }
+
+    let user_token = match super::token::get_valid_spotify_token(state, account_id).await {
+        Ok(token) => token,
+        Err(AppError::AuthRequired(_)) => return Ok(HashSet::new()),
+        Err(err) => return Err(err),
+    };
+
+    let artists = state
+        .spotify
+        .get_top_artists(&user_token, TopArtistsTimeRange::Medium, 50)
+        .await?;
+
+    let normalized_names: Vec<String> = artists
+        .iter()
+        .map(|a| normalize_artist_name(&a.name))
+        .collect();
+
+    sqlx::query!(
+        r#"
+        insert into spotify_top_artist_cache (account_id, normalized_names, fetched_at)
+        values ($1, $2, now())
+        on conflict (account_id) do update set
+            normalized_names = excluded.normalized_names,
+            fetched_at = excluded.fetched_at
+        "#,
+        account_id,
+        &normalized_names,
+    )
+    .execute(&state.db.pool)
+    .await?;
+
+    Ok(normalized_names.into_iter().collect())
+}

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -16,9 +16,10 @@ mod types;
 
 pub use types::*;
 
-pub(crate) use normalize::{dedupe_key, normalize_event};
+pub(crate) use normalize::{apply_personalization, dedupe_key, normalize_event};
 
 use crate::error::AppError;
+use crate::spotify::spotify_handlers::resolve_account_from_cookie_lenient;
 use crate::state::AppState;
 use axum::{
     body::Body,
@@ -26,6 +27,7 @@ use axum::{
     http::{StatusCode, header},
     response::Response,
 };
+use axum_extra::extract::cookie::SignedCookieJar;
 use bytes::Bytes;
 use client::fetch_tm_page;
 use dates::date_windows;
@@ -35,8 +37,27 @@ use std::collections::HashSet;
 
 pub async fn get_concerts_tm_stream(
     State(state): State<AppState>,
+    jar: SignedCookieJar,
     Query(params): Query<EventsQuery>,
 ) -> Result<Response, AppError> {
+    // Personalized discovery is best-effort: no session, no Spotify
+    // connection, or a failed fetch should silently disable it rather than
+    // break event browsing for everyone.
+    let top_artist_names = match resolve_account_from_cookie_lenient(&state, &jar).await {
+        Some(account_id) => {
+            crate::spotify::top_artists::get_top_artist_names(&state, account_id)
+                .await
+                .unwrap_or_else(|err| {
+                    tracing::warn!(
+                        error = %err,
+                        "failed to fetch top artists for personalized discovery, skipping"
+                    );
+                    HashSet::new()
+                })
+        }
+        None => HashSet::new(),
+    };
+
     let geo_hash = encode(
         Coord {
             x: params.longitude,
@@ -96,7 +117,8 @@ pub async fn get_concerts_tm_stream(
                     .unwrap_or_default();
 
                 for raw in events {
-                    let event = normalize_event(raw);
+                    let mut event = normalize_event(raw);
+                    apply_personalization(&mut event, &top_artist_names);
                     let key = dedupe_key(&event);
 
                     if seen.insert(key) {

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -44,17 +44,15 @@ pub async fn get_concerts_tm_stream(
     // connection, or a failed fetch should silently disable it rather than
     // break event browsing for everyone.
     let top_artist_names = match resolve_account_from_cookie_lenient(&state, &jar).await {
-        Some(account_id) => {
-            crate::spotify::top_artists::get_top_artist_names(&state, account_id)
-                .await
-                .unwrap_or_else(|err| {
-                    tracing::warn!(
-                        error = %err,
-                        "failed to fetch top artists for personalized discovery, skipping"
-                    );
-                    HashSet::new()
-                })
-        }
+        Some(account_id) => crate::spotify::top_artists::get_top_artist_names(&state, account_id)
+            .await
+            .unwrap_or_else(|err| {
+                tracing::warn!(
+                    error = %err,
+                    "failed to fetch top artists for personalized discovery, skipping"
+                );
+                HashSet::new()
+            }),
         None => HashSet::new(),
     };
 

--- a/apps/api/src/ticketmaster_stream/normalize.rs
+++ b/apps/api/src/ticketmaster_stream/normalize.rs
@@ -62,10 +62,7 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
 /// `top_artist_names` must already be exact-normalized (see
 /// `spotify::top_artists::get_top_artist_names`). A no-op when the caller
 /// has no personalization set (not connected, no session, or fetch failed).
-pub(crate) fn apply_personalization(
-    event: &mut EventResponse,
-    top_artist_names: &HashSet<String>,
-) {
+pub(crate) fn apply_personalization(event: &mut EventResponse, top_artist_names: &HashSet<String>) {
     if top_artist_names.is_empty() {
         return;
     }

--- a/apps/api/src/ticketmaster_stream/normalize.rs
+++ b/apps/api/src/ticketmaster_stream/normalize.rs
@@ -2,8 +2,10 @@
 //! and deriving a stable key for deduplicating events seen across
 //! overlapping date windows.
 
-use super::types::{EventResponse, LocationResponse, TmEvent, VenueResponse};
+use super::types::{EventResponse, LocationResponse, TmAttraction, TmEvent, VenueResponse};
+use crate::spotify::client::normalize_artist_name;
 use chrono::{DateTime, Local};
+use std::collections::HashSet;
 
 pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
     let dates = e.dates.start.date_time.or_else(|| {
@@ -51,7 +53,38 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
         classifications: e.classifications,
         attractions,
         price_ranges: e.price_ranges,
+        matched_artist: None,
     }
+}
+
+/// Sets `matched_artist` on `event` if any of its Ticketmaster attractions
+/// exact-normalize-matches one of the caller's Spotify top artists.
+/// `top_artist_names` must already be exact-normalized (see
+/// `spotify::top_artists::get_top_artist_names`). A no-op when the caller
+/// has no personalization set (not connected, no session, or fetch failed).
+pub(crate) fn apply_personalization(
+    event: &mut EventResponse,
+    top_artist_names: &HashSet<String>,
+) {
+    if top_artist_names.is_empty() {
+        return;
+    }
+    event.matched_artist = event
+        .attractions
+        .as_ref()
+        .and_then(|attractions| find_matching_attraction(attractions, top_artist_names));
+}
+
+fn find_matching_attraction(
+    attractions: &[TmAttraction],
+    top_artist_names: &HashSet<String>,
+) -> Option<String> {
+    attractions.iter().find_map(|a| {
+        let name = a.name.as_ref()?;
+        top_artist_names
+            .contains(&normalize_artist_name(name))
+            .then(|| name.clone())
+    })
 }
 
 pub(crate) fn dedupe_key(event: &EventResponse) -> String {
@@ -202,6 +235,7 @@ mod tests {
             }]),
             url: None,
             price_ranges: None,
+            matched_artist: None,
         };
 
         // Same date/venue/attraction but a different Ticketmaster event id
@@ -228,6 +262,7 @@ mod tests {
             attractions: None,
             url: None,
             price_ranges: None,
+            matched_artist: None,
         };
         let mut other = EventResponse {
             venue: Some(VenueResponse {
@@ -240,5 +275,66 @@ mod tests {
         other.id = "2".to_string();
 
         assert_ne!(dedupe_key(&base), dedupe_key(&other));
+    }
+
+    fn event_with_attraction(name: &str) -> EventResponse {
+        EventResponse {
+            id: "1".to_string(),
+            name: "Event".to_string(),
+            venue: None,
+            images: vec![],
+            dates: None,
+            dates_pretty: None,
+            classifications: None,
+            attractions: Some(vec![TmAttraction {
+                name: Some(name.to_string()),
+                id: Some("artist-1".to_string()),
+                classifications: None,
+                external_links: None,
+                images: None,
+            }]),
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+        }
+    }
+
+    #[test]
+    fn apply_personalization_matches_exact_normalized_name() {
+        let mut event = event_with_attraction("Tyler, The Creator");
+        let top_artists = HashSet::from([normalize_artist_name("Tyler, The Creator")]);
+
+        apply_personalization(&mut event, &top_artists);
+
+        assert_eq!(event.matched_artist.as_deref(), Some("Tyler, The Creator"));
+    }
+
+    #[test]
+    fn apply_personalization_is_case_and_punctuation_insensitive() {
+        let mut event = event_with_attraction("Tyler, The Creator");
+        let top_artists = HashSet::from([normalize_artist_name("tyler the creator")]);
+
+        apply_personalization(&mut event, &top_artists);
+
+        assert_eq!(event.matched_artist.as_deref(), Some("Tyler, The Creator"));
+    }
+
+    #[test]
+    fn apply_personalization_leaves_none_when_no_match() {
+        let mut event = event_with_attraction("Some Other Artist");
+        let top_artists = HashSet::from([normalize_artist_name("Tyler, The Creator")]);
+
+        apply_personalization(&mut event, &top_artists);
+
+        assert_eq!(event.matched_artist, None);
+    }
+
+    #[test]
+    fn apply_personalization_is_a_noop_with_no_top_artists() {
+        let mut event = event_with_attraction("Tyler, The Creator");
+
+        apply_personalization(&mut event, &HashSet::new());
+
+        assert_eq!(event.matched_artist, None);
     }
 }

--- a/apps/api/src/ticketmaster_stream/types.rs
+++ b/apps/api/src/ticketmaster_stream/types.rs
@@ -157,6 +157,11 @@ pub struct EventResponse {
     pub url: Option<String>,
     #[serde(rename = "priceRanges")]
     pub price_ranges: Option<Vec<TmPriceRange>>,
+    /// Name of the attraction that matched one of the caller's Spotify top
+    /// artists, for personalized discovery. `None` when the caller isn't
+    /// connected, has no personalization data, or no attraction matched.
+    #[serde(rename = "matchedArtist")]
+    pub matched_artist: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/apps/web/src/hooks/eventsStream.ts
+++ b/apps/web/src/hooks/eventsStream.ts
@@ -33,5 +33,8 @@ export type EventResponse = {
     min: number
     max: number
   }> | null
+  /** Name of the artist that matched one of the caller's Spotify top
+   * artists, for personalized discovery. Absent/null when not applicable. */
+  matchedArtist?: string | null
 }
 


### PR DESCRIPTION
## Summary

First implementation slice of #33 (Phase 0: Personalized discovery). Adds the server-side matching described in that issue's locked spec — no frontend badge yet, this is the data plumbing it depends on.

- `GET /concerts/stream` now resolves the caller's session (if any) and, for accounts with Spotify connected, fetches their top artists (6-month window) and exact-normalize-matches them against each event's Ticketmaster attraction during normalization. Each `EventResponse` now carries `matchedArtist`.
- Personalization is entirely best-effort: no session, an unconnected account, or a failed Spotify fetch all silently disable it rather than breaking event browsing for anyone.
- Top-artist results are cached per account (`spotify_top_artist_cache`, 24h TTL) since `/concerts/stream` fires on every map pan/zoom — fetching from Spotify inline on every request would be wasteful and slow.
- Added `user-top-read` to the OAuth scope list (`apps/api/src/auth.rs`) — already-connected accounts will need to reconnect to pick it up.

## Why no standalone `/spotify/top-artists` endpoint

An earlier pass built one, but that shape means the frontend fetching top artists and events separately and diffing them client-side — reintroducing the "tag pops in after the card renders" flicker the original design explicitly ruled out. Matching lives in one place, server-side, embedded in the stream response instead.

## Test plan

- [x] `cargo check` / `cargo clippy` clean on all touched files
- [x] `cargo test` — 40 passed, including 4 new tests covering exact-normalized matching, case/punctuation insensitivity, no-match, and the no-personalization-set no-op
- [x] `tsc --noEmit` clean on `apps/web`
- [x] Migration applied to dev DB, `.sqlx` offline cache regenerated for CI
- [ ] Manual verification against a real Spotify-connected account once deployed (no frontend surface yet to observe `matchedArtist` directly — next slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)