### PR TITLE
Personalized discovery: For You badge on EventCard

### DIFF
--- a/apps/web/src/Drawer/EventsDrawer.tsx
+++ b/apps/web/src/Drawer/EventsDrawer.tsx
@@ -5,6 +5,7 @@ import { useEventsContext } from "../providers/eventsProvider"
 import type { Ref } from "react"
 import { formatDate } from "../lib/dates"
 import { EventFilter } from "../EventFilter"
+import { ForYouConnectNudge } from "../ForYouConnectNudge"
 
 type RegisterItem = (id: string) => Ref<HTMLDivElement>
 
@@ -29,6 +30,7 @@ export const EventsDrawer = ({
 
   return (
     <>
+      <ForYouConnectNudge />
       {entries.length ? (
         <div className="flex flex-col gap-4">
           {entries.map(([date, events]) => (

--- a/apps/web/src/EventCard.tsx
+++ b/apps/web/src/EventCard.tsx
@@ -7,6 +7,7 @@ import {
 import { HouseIcon } from "lucide-react"
 import { useEventsContext } from "./providers/eventsProvider"
 import { ResponsiveImage } from "@workspace/ui/components/ui/ResponsiveImage"
+import { ForYouTag } from "./ForYouTag"
 
 import { type ReactElement } from "react"
 import type { EventResponse } from "./hooks/eventsStream"
@@ -45,9 +46,14 @@ const EventCard = ({
         />
       </div>
       <div className="flex h-auto flex-3 flex-col justify-between gap-2 p-3">
-        <h3 className="leading-tight font-semibold text-black dark:text-(--color-primary-dark-900)">
-          {event.name}
-        </h3>
+        <div className="flex flex-col items-start gap-1">
+          <h3 className="leading-tight font-semibold text-black dark:text-(--color-primary-dark-900)">
+            {event.name}
+          </h3>
+          {event.matchedArtist && (
+            <ForYouTag matchedArtist={event.matchedArtist} />
+          )}
+        </div>
         <div className="flex flex-col gap-1">
           <div>{date}</div>
           <div className="flex items-center gap-1 text-sm leading-none text-indigo-600 dark:text-(--color-secondary-dark-900)">

--- a/apps/web/src/ForYouConnectNudge.tsx
+++ b/apps/web/src/ForYouConnectNudge.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react"
+import { X } from "lucide-react"
+import { Button } from "@workspace/ui/components/ui/Button"
+import SpotifyLogo from "./assets/Primary_Logo_Green_CMYK.svg"
+import { ReactSVG } from "react-svg"
+import { useSpotifyAuth } from "./hooks/spotify"
+
+const DISMISSED_STORAGE_KEY = "gigeo:for-you-nudge-dismissed"
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISSED_STORAGE_KEY) === "true"
+  } catch {
+    // localStorage unavailable (e.g. private browsing) — show the nudge.
+    return false
+  }
+}
+
+function persistDismissed() {
+  try {
+    localStorage.setItem(DISMISSED_STORAGE_KEY, "true")
+  } catch {
+    // Ignore — localStorage may be unavailable (e.g. private browsing).
+  }
+}
+
+/**
+ * One-time, dismissible prompt surfacing the "for you" feature to users who
+ * haven't connected Spotify yet — the only way this gets discovered
+ * organically, since matched events are otherwise invisible until connected.
+ * Hides permanently once dismissed or once Spotify is connected.
+ */
+export function ForYouConnectNudge() {
+  const { status, loading, connectSpotify } = useSpotifyAuth()
+  const [dismissed, setDismissed] = useState(readDismissed)
+
+  if (dismissed || loading || status?.spotify_connected) {
+    return null
+  }
+
+  const dismiss = () => {
+    persistDismissed()
+    setDismissed(true)
+  }
+
+  return (
+    <div className="relative mb-2 flex items-center justify-between gap-3 rounded-lg border border-black/10 bg-white/80 p-3 pr-8 dark:border-white/10 dark:bg-zinc-900/70">
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-primary">
+          See shows for artists you follow
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Connect Spotify to tag events matching your top artists.
+        </p>
+      </div>
+      <Button
+        onClick={connectSpotify}
+        className="shrink-0 gap-2 bg-[#1DB954] text-white hover:bg-[#1ed760]"
+      >
+        <ReactSVG className="h-4 w-4 [&_svg_path]:fill-white" src={SpotifyLogo} />
+        Connect
+      </Button>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={dismiss}
+        className="absolute top-2 right-2 rounded p-0.5 text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/ForYouTag.tsx
+++ b/apps/web/src/ForYouTag.tsx
@@ -1,0 +1,34 @@
+import { Sparkles } from "lucide-react"
+import { Button } from "@workspace/ui/components/ui/Button"
+import { Dialog } from "@workspace/ui/components/ui/Dialog"
+import { Popover } from "@workspace/ui/components/ui/Popover"
+import { DialogTrigger } from "react-aria-components"
+
+/**
+ * Neutral, provider-agnostic badge shown on events matching one of the
+ * viewer's Spotify top artists. Tap-to-reveal (not hover) on both desktop
+ * and mobile, since this drawer UI has no other hover-dependent affordance.
+ * Stops propagation so tapping it doesn't also open the event's details.
+ */
+export function ForYouTag({ matchedArtist }: { matchedArtist: string }) {
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      className="w-fit"
+    >
+      <DialogTrigger>
+        <Button className="flex w-fit shrink-0 cursor-default items-center gap-1 rounded-full border border-neutral-200 bg-white px-2.5 py-0.5 !h-auto whitespace-nowrap text-xs font-medium text-neutral-600 transition hover:border-neutral-300 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:border-neutral-500">
+          <Sparkles aria-hidden className="h-3 w-3 shrink-0" />
+          For You
+        </Button>
+        <Popover showArrow placement="top">
+          <Dialog className="w-auto max-w-[220px] p-3 text-sm">
+            Because you've been listening to{" "}
+            <span className="font-semibold">{matchedArtist}</span>
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Second slice of #33 (Phase 0: Personalized discovery). Adds the frontend surface for the `matchedArtist` field introduced in #34 — this PR is stacked on that branch and should merge after it (base is `spotify-top-artists-personalization`, not `main`).

- `ForYouTag.tsx` — neutral, non-Spotify-branded pill badge shown on `EventCard` when `event.matchedArtist` is set. Tap-to-reveal on both desktop and mobile (no hover dependency, consistent with the rest of this touch-first drawer UI) — tapping shows "Because you've been listening to {artist}". Stops click propagation so it doesn't also trigger the card's own "open event details" handler.
- `ForYouConnectNudge.tsx` — one-time, dismissible prompt in Explore ("See shows for artists you follow") for users who haven't connected Spotify, reusing the same connect flow (`useSpotifyAuth`/`connectSpotify`) and visual language as `PlaylistButtons`. Dismissal persists via `localStorage`, following the same defensive try/catch pattern already used in `searchProvider.tsx`.
- Wired `ForYouTag` into `EventCard.tsx` and `ForYouConnectNudge` into `EventsDrawer.tsx`, above the date-grouped list.

## Implementation note

Used `DialogTrigger` + `Popover` + `Dialog` (the same pattern already established in `EventFilter.tsx`) rather than the design system's `Tag`/`TagGroup` — those are built for selectable/removable tag *lists* and don't support press-to-reveal an overlay. The badge is styled to visually match `TagGroup`'s neutral "gray" tag color for consistency.

## Test plan

- [x] `tsc --noEmit` and `eslint` clean on all touched/new files
- [x] Manually verified in a running dev instance (Portland, ME): badge renders as a single-line pill (caught and fixed a text-wrapping bug), tap opens the popover with the correct artist name, and does **not** also open event details (propagation correctly stopped)
- [x] Verified the connect nudge appears for a logged-out session, dismiss persists across reload, and disappears once dismissed (caught and fixed a bug where it incorrectly required `logged_in: true`, which excluded first-time/anonymous visitors — exactly who the nudge is for)
- [ ] Verification against a real matched event (a connected account whose top artist is actually touring near the searched city) — not practical to set up in this pass; the badge/popover logic above was verified with a temporarily forced `matchedArtist` value, reverted before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)