### PR TITLE
Fix: cache insufficient-scope failures for personalized discovery

### DIFF
--- a/apps/api/.sqlx/query-38bc38b05e32596f871b6d80606fa50cc5caeca7e96a8f5c0fad6c5563595162.json
+++ b/apps/api/.sqlx/query-38bc38b05e32596f871b6d80606fa50cc5caeca7e96a8f5c0fad6c5563595162.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "delete from spotify_top_artist_cache where account_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "38bc38b05e32596f871b6d80606fa50cc5caeca7e96a8f5c0fad6c5563595162"
+}

--- a/apps/api/src/spotify/spotify_handlers/db.rs
+++ b/apps/api/src/spotify/spotify_handlers/db.rs
@@ -182,6 +182,17 @@ pub(super) async fn upsert_spotify_account(
     .execute(&mut *tx)
     .await?;
 
+    // A fresh OAuth grant may carry different scopes than whatever produced
+    // the cached top-artist result (e.g. the account reconnecting after
+    // `user-top-read` was added) — drop it so personalization picks up the
+    // new token immediately instead of waiting out the cache TTL.
+    sqlx::query!(
+        "delete from spotify_top_artist_cache where account_id = $1",
+        account_id
+    )
+    .execute(&mut *tx)
+    .await?;
+
     tx.commit().await?;
 
     Ok(account_id)

--- a/apps/api/src/spotify/top_artists.rs
+++ b/apps/api/src/spotify/top_artists.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 
+use axum::http::StatusCode;
 use chrono::{Duration, Utc};
 
 use crate::error::AppError;
@@ -53,16 +54,46 @@ pub(crate) async fn get_top_artist_names(
         Err(err) => return Err(err),
     };
 
-    let artists = state
+    let artists = match state
         .spotify
         .get_top_artists(&user_token, TopArtistsTimeRange::Medium, 50)
-        .await?;
+        .await
+    {
+        Ok(artists) => artists,
+        Err(AppError::SpotifyApi {
+            status: StatusCode::FORBIDDEN,
+            ..
+        }) => {
+            // Token predates the `user-top-read` scope (added after this
+            // account connected). Cache the empty result so we don't retry
+            // Spotify — and warn on every request — until the account
+            // reconnects, which clears this cache immediately (see
+            // `upsert_spotify_account`).
+            tracing::info!(
+                %account_id,
+                "spotify token missing user-top-read scope, disabling personalization until reconnect"
+            );
+            cache_names(state, account_id, &[]).await?;
+            return Ok(HashSet::new());
+        }
+        Err(err) => return Err(err),
+    };
 
     let normalized_names: Vec<String> = artists
         .iter()
         .map(|a| normalize_artist_name(&a.name))
         .collect();
 
+    cache_names(state, account_id, &normalized_names).await?;
+
+    Ok(normalized_names.into_iter().collect())
+}
+
+async fn cache_names(
+    state: &AppState,
+    account_id: uuid::Uuid,
+    normalized_names: &[String],
+) -> Result<(), AppError> {
     sqlx::query!(
         r#"
         insert into spotify_top_artist_cache (account_id, normalized_names, fetched_at)
@@ -72,10 +103,10 @@ pub(crate) async fn get_top_artist_names(
             fetched_at = excluded.fetched_at
         "#,
         account_id,
-        &normalized_names,
+        normalized_names,
     )
     .execute(&state.db.pool)
     .await?;
 
-    Ok(normalized_names.into_iter().collect())
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes a bug reported from server logs: `failed to fetch top artists for personalized discovery, skipping error=Spotify API error (403 Forbidden): Insufficient client scope`.

Root cause: any account that connected Spotify **before** `user-top-read` was added to the OAuth scope list (#34) has a stored token without that scope. `get_top_artist_names` never cached this failure, so every single `/concerts/stream` request (i.e. every map pan/zoom) re-hit Spotify, got a 403, and logged a warning — functionally harmless (personalization was already correctly disabled for that request), but wasteful and noisy.

## Changes

- `apps/api/src/spotify/top_artists.rs` — a 403 from `get_top_artists` is now caught and cached as an empty result (same TTL/mechanism as a successful fetch), so subsequent requests short-circuit via the cache instead of re-hitting Spotify. Logs once at `info` (not `warn` every request) when this is first detected.
- `apps/api/src/spotify/spotify_handlers/db.rs` — `upsert_spotify_account` now deletes any cached `spotify_top_artist_cache` row (in the same transaction) whenever an account completes OAuth. This means reconnecting — the actual fix for insufficient scope — takes effect on the very next `/concerts/stream` request instead of waiting out the 24h cache TTL.

## Test plan

- [x] `cargo check` / `cargo clippy` / `cargo fmt --check` clean
- [x] `cargo test` — all 40 existing tests pass (no behavior change to matching logic itself, only failure-caching)
- [ ] The affected account still needs to reconnect Spotify once to actually get the `user-top-read` scope — this PR stops the log spam and wasted calls, it doesn't retroactively grant the scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)