### PR TITLE
Group same-day multi-showtime events into a single card

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -15,6 +15,7 @@ import { EventsDrawer, EventsDrawerHeader } from "./EventsDrawer"
 import { useTopMostVisibleInScrollContainer } from "../hooks/listItemObserver"
 import type { Key } from "react-aria-components/Tabs"
 import { useDrawerProvider } from "@/providers/drawerProvider"
+import { groupEvents } from "../lib/groupEvents"
 
 const PlaylistsDrawerBody = lazy(() =>
   import("./PlaylistsDrawer").then((m) => ({ default: m.PlaylistsDrawerBody }))
@@ -127,6 +128,11 @@ const DrawerWrapper = () => {
   })
 
   const entries = Object.entries(eventsByDate).sort()
+  // A single group means selectedEvents is either one event, or several
+  // showtimes of the *same* event (selected via a GroupedEventCard) — both
+  // go to EventDetails. More than one group means genuinely distinct events
+  // (e.g. a venue-marker click), which go to VenueDetails.
+  const selectedGroups = groupEvents(selectedEvents)
 
   // Kept in lockstep with the DrawerContent slide transition in the shared
   // Drawer component, so the reserved layout width and the visible slide
@@ -183,9 +189,12 @@ const DrawerWrapper = () => {
             ref={eventsScrollRef}
             className="h-full flex-1 overflow-y-auto scroll-smooth"
           >
-            {selectedEvents.length === 1 ? (
-              <EventDetails eventData={selectedEvents[0]} />
-            ) : selectedEvents.length ? (
+            {selectedGroups.length === 1 ? (
+              <EventDetails
+                eventData={selectedGroups[0].events[0]}
+                otherShowtimes={selectedGroups[0].events.slice(1)}
+              />
+            ) : selectedGroups.length ? (
               <VenueDetails events={selectedEvents} />
             ) : (
               <EventsDrawer registerItem={registerItem} />

--- a/apps/web/src/Drawer/EventsDrawer.tsx
+++ b/apps/web/src/Drawer/EventsDrawer.tsx
@@ -1,11 +1,12 @@
-import { EventCard } from "../EventCard"
+import { EventCard, GroupedEventCard } from "../EventCard"
 import { DateSlider } from "../DateSlider"
 
 import { useEventsContext } from "../providers/eventsProvider"
 import type { Ref } from "react"
-import { formatDate } from "../lib/dates"
+import { formatDate, formatDateTime } from "../lib/dates"
 import { EventFilter } from "../EventFilter"
 import { ForYouConnectNudge } from "../ForYouConnectNudge"
+import { groupEvents } from "../lib/groupEvents"
 
 type RegisterItem = (id: string) => Ref<HTMLDivElement>
 
@@ -37,19 +38,25 @@ export const EventsDrawer = ({
             <div key={date}>
               <DateAnchor date={date} ref={registerItem(date)} />
               <ul className="flex w-full flex-col justify-between gap-2.5 pt-2.5">
-                {events.map((event) => (
-                  <li className="relative" key={event.id}>
-                    <EventCard
-                      key={event.id}
-                      event={event}
-                      date={
-                        <span className="text-gray-600 dark:text-gray-400">
-                          {event.dates}
-                        </span>
-                      }
-                    />
-                  </li>
-                ))}
+                {groupEvents(events).map((group) => {
+                  const primary = group.events[0]
+                  return (
+                    <li className="relative" key={primary.id}>
+                      {group.events.length > 1 ? (
+                        <GroupedEventCard group={group} />
+                      ) : (
+                        <EventCard
+                          event={primary}
+                          date={
+                            <span className="text-gray-600 dark:text-gray-400">
+                              {primary.dates ? formatDateTime(primary.dates) : null}
+                            </span>
+                          }
+                        />
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             </div>
           ))}

--- a/apps/web/src/EventCard.tsx
+++ b/apps/web/src/EventCard.tsx
@@ -1,4 +1,4 @@
-import type { GroupedEvents } from "./lib/types"
+import type { EventGroup } from "./lib/groupEvents"
 import {
   parseAbsolute,
   DateFormatter,
@@ -8,28 +8,34 @@ import { HouseIcon } from "lucide-react"
 import { useEventsContext } from "./providers/eventsProvider"
 import { ResponsiveImage } from "@workspace/ui/components/ui/ResponsiveImage"
 import { ForYouTag } from "./ForYouTag"
+import { formatDate } from "./lib/dates"
 
 import { type ReactElement } from "react"
 import type { EventResponse } from "./hooks/eventsStream"
 const EventCard = ({
   event,
   date,
+  onSelect,
 }: {
   event: EventResponse
   date: ReactElement
+  /** Overrides the default "select just this event" click behavior — used
+   * by GroupedEventCard to select the whole group of showtimes instead. */
+  onSelect?: () => void
 }) => {
   const { selectEvents } = useEventsContext()
+  const handleSelect = onSelect ?? (() => selectEvents([event]))
 
   return (
     <div
       role="button"
       tabIndex={0}
       className="relative flex cursor-pointer overflow-hidden rounded-xl border border-slate-100 bg-white shadow-sm transition hover:border-slate-200 hover:shadow-md active:scale-[0.99] dark:border-(--color-surface-dark-200) dark:bg-(--color-surface-dark-400) dark:hover:border-(--color-surface-dark-300)"
-      onClick={() => selectEvents([event])}
+      onClick={handleSelect}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
-          selectEvents([event])
+          handleSelect()
         }
       }}
     >
@@ -69,26 +75,38 @@ const EventCard = ({
   )
 }
 
-const GroupedEventCard = ({ events }: { events: GroupedEvents }) => {
-  const startDate = parseAbsolute(events.dateRange.start, "UTC")
-  const endDate = parseAbsolute(events.dateRange.end, "UTC")
+const GroupedEventCard = ({ group }: { group: EventGroup }) => {
+  const { selectEvents } = useEventsContext()
+  const primary = group.events[0]
+  const count = group.events.length
+
   const dateFormatter = new DateFormatter("en-US", {
-    month: "long",
+    month: "short",
     day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-    timeZone: getLocalTimeZone(), // or a specific IANA tz
+    timeZone: getLocalTimeZone(),
   })
-  const dateString = `${dateFormatter.format(startDate.toDate())} - ${dateFormatter.format(endDate.toDate())}`
+  // Events without a specific start time come through as a bare "YYYY-MM-DD"
+  // (no "T"), which parseAbsolute rejects as invalid.
+  const dateLabel = primary.dates
+    ? primary.dates.includes("T")
+      ? dateFormatter.format(parseAbsolute(primary.dates, "UTC").toDate())
+      : formatDate(primary.dates)
+    : null
+
   return (
     <>
       <span className="absolute top-[-8px] right-[-8px] m-auto flex h-9 w-12 items-center justify-center rounded-4xl bg-red-600 p-3 text-center text-xs font-thin outline outline-rose-500 dark:bg-[#FF5D73]">
-        {events.events.length} events
+        {count} showtimes
       </span>
       <EventCard
-        event={events.events[0]}
-        date={<span className="text-xs text-[#7C7A7A]">{dateString}</span>}
+        event={primary}
+        date={
+          <span className="text-xs text-[#7C7A7A]">
+            {dateLabel ? `${dateLabel} · ` : ""}
+            {count} showtimes
+          </span>
+        }
+        onSelect={() => selectEvents(group.events)}
       />
     </>
   )

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -17,14 +17,23 @@ import "react-social-icons/instagram"
 import type { EventResponse } from "./hooks/eventsStream"
 import { useEventsContext } from "./providers/eventsProvider"
 import { buildArtworkUrl, normalizeBg } from "./lib/artwork"
+import { formatTime } from "./lib/dates"
 
-const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
+const EventDetails = ({
+  eventData,
+  otherShowtimes = [],
+}: {
+  eventData: EventResponse
+  /** Other showtimes of this same event today (same name/venue/day),
+   * excluding eventData itself. */
+  otherShowtimes?: EventResponse[]
+}) => {
   const { attractions } = eventData
   const [artistInfo, setArtistInfo] = useState<AmArtistFull[]>([])
   const [futureEvents, setFutureEvents] = useState<Record<string, Event[]>>({})
   const [showStickyHeader, setShowStickyHeader] = useState(false)
   const scrollRef = useRef<HTMLDivElement | null>(null)
-  const { selectEvents, setSelectedEvent } = useEventsContext()
+  const { selectEvents } = useEventsContext()
 
   const { classifications } = eventData
   const segment =
@@ -133,7 +142,7 @@ const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
         aria-label="Back to events"
         className="absolute top-2 left-2 z-10 dark:border-(--color-border-subtle-dark-200) dark:bg-(--color-dusty-olive-dark-600)"
         variant="secondary"
-        onClick={() => setSelectedEvent(undefined)}
+        onClick={() => selectEvents([])}
       >
         <ArrowLeftIcon aria-hidden className="h-4 w-4" />
       </Button>
@@ -178,6 +187,36 @@ const EventDetails = ({ eventData }: { eventData: EventResponse }) => {
           )}
         </div>
       </div>
+
+      {otherShowtimes.length > 0 && (
+        <div className="p-2">
+          <h3 className="text-xs tracking-wide text-slate-400 uppercase">
+            Other showtimes today
+          </h3>
+          <ul className="mt-1 flex flex-col gap-2 text-sm">
+            {otherShowtimes.map((showtime) => (
+              <li
+                key={showtime.id}
+                className="flex items-center justify-between gap-2 border-b border-slate-700/50 pb-2 last:border-b-0"
+              >
+                <span>
+                  {(showtime.dates && formatTime(showtime.dates)) ||
+                    showtime.datesPretty}
+                </span>
+                {showtime.url && (
+                  <Link
+                    href={showtime.url}
+                    target="_blank"
+                    className="text-(--color-toasted-almond-600) no-underline dark:text-(--color-text-secondary-dark-600)"
+                  >
+                    Tickets
+                  </Link>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {artistInfo.length
         ? artistInfo.map((artist) => (

--- a/apps/web/src/VenueDetails.tsx
+++ b/apps/web/src/VenueDetails.tsx
@@ -1,11 +1,14 @@
 import { type EventResponse } from "./hooks/eventsStream"
-import { EventCard } from "./EventCard"
+import { EventCard, GroupedEventCard } from "./EventCard"
 import { Button } from "@workspace/ui/components/ui/Button"
 import { ArrowLeftIcon } from "lucide-react"
 import { useEventsContext } from "./providers/eventsProvider"
+import { groupEvents } from "./lib/groupEvents"
+import { formatDateTime } from "./lib/dates"
 const VenueDetails = ({ events }: { events: EventResponse[] }) => {
   const { selectEvents } = useEventsContext()
   const venue = events[0].venue
+  const groups = groupEvents(events)
   return (
     <div className="p-3">
       <Button
@@ -17,21 +20,28 @@ const VenueDetails = ({ events }: { events: EventResponse[] }) => {
         <ArrowLeftIcon aria-hidden className="h-4 w-4" />
       </Button>
       <h2 className="mt-3 leading-none font-semibold text-black dark:text-(--color-primary-dark-900)">
-        {events.length} Events at {venue?.name}
+        {groups.length} Events at {venue?.name}
       </h2>
       <ul className="flex w-full flex-col justify-between gap-2.5 pt-4">
-        {events.map((event) => (
-          <li className="relative" key={event.id}>
-            <EventCard
-              event={event}
-              date={
-                <span className="text-gray-600 dark:text-gray-400">
-                  {event.dates}
-                </span>
-              }
-            />
-          </li>
-        ))}
+        {groups.map((group) => {
+          const primary = group.events[0]
+          return (
+            <li className="relative" key={primary.id}>
+              {group.events.length > 1 ? (
+                <GroupedEventCard group={group} />
+              ) : (
+                <EventCard
+                  event={primary}
+                  date={
+                    <span className="text-gray-600 dark:text-gray-400">
+                      {primary.dates ? formatDateTime(primary.dates) : null}
+                    </span>
+                  }
+                />
+              )}
+            </li>
+          )
+        })}
       </ul>
     </div>
   )

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -4,20 +4,6 @@ import {
   getLocalTimeZone,
 } from "@internationalized/date"
 
-const formatDateTime = (date: string) => {
-  const parsedDate = parseAbsolute(date, "UTC")
-
-  const dateFormatter = new DateFormatter("en-US", {
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-    timeZone: getLocalTimeZone(), // or a specific IANA tz
-  })
-  return dateFormatter.format(parsedDate.toDate())
-}
-
 const formatDate = (dateString: string) => {
   // Parse YYYY-MM-DD as UTC to avoid timezone shifts
   const [year, month, day] = dateString.split("-").map(Number)
@@ -33,6 +19,41 @@ const formatDate = (dateString: string) => {
   return formatter.format(date)
 }
 
+/** Ticketmaster events without a specific start time come through as a bare
+ * `YYYY-MM-DD` (no "T"), which `parseAbsolute` rejects as invalid — those
+ * have no time-of-day to format, only a date. */
+const hasTimeComponent = (dateString: string) => dateString.includes("T")
+
+const formatDateTime = (date: string) => {
+  if (!hasTimeComponent(date)) return formatDate(date)
+
+  const parsedDate = parseAbsolute(date, "UTC")
+
+  const dateFormatter = new DateFormatter("en-US", {
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: getLocalTimeZone(), // or a specific IANA tz
+  })
+  return dateFormatter.format(parsedDate.toDate())
+}
+
+const formatTime = (dateString: string) => {
+  if (!hasTimeComponent(dateString)) return null
+
+  const parsedDate = parseAbsolute(dateString, "UTC")
+
+  const formatter = new DateFormatter("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZone: getLocalTimeZone(),
+  })
+  return formatter.format(parsedDate.toDate())
+}
+
 const groupDatesByWeek = (dates: string[]): string[][] => {
   const groups: string[][] = []
 
@@ -43,4 +64,4 @@ const groupDatesByWeek = (dates: string[]): string[][] => {
   return groups
 }
 
-export { formatDateTime, formatDate, groupDatesByWeek }
+export { formatDateTime, formatDate, formatTime, groupDatesByWeek }

--- a/apps/web/src/lib/groupEvents.ts
+++ b/apps/web/src/lib/groupEvents.ts
@@ -1,0 +1,42 @@
+import type { EventResponse } from "../hooks/eventsStream"
+import { eventDateKey, sortEvents } from "../reducers/events"
+
+type EventGroup = {
+  events: EventResponse[]
+}
+
+function eventGroupKey(event: EventResponse): string {
+  return `${event.name}__${event.venue?.name ?? ""}__${eventDateKey(event)}`
+}
+
+function eventTime(event: EventResponse): number {
+  return event.dates ? Date.parse(event.dates) : Number.MAX_SAFE_INTEGER
+}
+
+/** Collapses same-day, same-venue showtimes of the same event (e.g. a
+ * museum exhibit running hourly) into single groups, ordered by their
+ * earliest showtime. */
+function groupEvents(events: EventResponse[]): EventGroup[] {
+  const buckets = new Map<string, EventResponse[]>()
+
+  for (const event of events) {
+    const key = eventGroupKey(event)
+    const bucket = buckets.get(key)
+    if (bucket) {
+      bucket.push(event)
+    } else {
+      buckets.set(key, [event])
+    }
+  }
+
+  return Array.from(buckets.values())
+    .map((bucketEvents) => ({ events: sortEvents(bucketEvents) }))
+    .sort((a, b) => {
+      const aTime = eventTime(a.events[0])
+      const bTime = eventTime(b.events[0])
+      if (aTime !== bTime) return aTime - bTime
+      return a.events[0].name.localeCompare(b.events[0].name)
+    })
+}
+
+export { groupEvents, type EventGroup }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -42,18 +42,6 @@ type Classification = {
 
 type ClassificationSegment = { id: string; name: string }
 
-interface GroupedEvents {
-  name: string
-  grouped: boolean
-  venue: string
-  dateRange: {
-    start: string
-    end: string
-  }
-  attractions: Attraction[]
-  events: Event[]
-}
-
 type Image = {
   ratio: string
   url: string
@@ -95,7 +83,6 @@ interface AmArtistFull extends AmArtist {
 export type {
   TmEvent,
   Event,
-  GroupedEvents,
   Attraction,
   Classification,
   AmArtistFull,

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -37,8 +37,6 @@ type EventsContextValue = EventsState & {
   cancelStream: () => void
   selectEvents: (events: EventResponse[]) => void
   resetEvents: () => void
-  selectedEvent: EventResponse | undefined
-  setSelectedEvent: (event: EventResponse | undefined) => void
   /** The radius (miles) the current/last search actually used. */
   searchRadius: number | null
   /** Whether searchRadius went beyond the base tier to find results. */
@@ -186,9 +184,6 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
     },
     [runStream]
   )
-  const [selectedEvent, setSelectedEvent] = React.useState<
-    EventResponse | undefined
-  >(undefined)
 
   const radiusExpanded = searchRadius !== null && searchRadius > BASE_RADIUS
 
@@ -199,8 +194,6 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       cancelStream,
       resetEvents,
       selectEvents,
-      selectedEvent,
-      setSelectedEvent,
       searchRadius,
       radiusExpanded,
     }),
@@ -210,7 +203,6 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       cancelStream,
       resetEvents,
       selectEvents,
-      selectedEvent,
       searchRadius,
       radiusExpanded,
     ]


### PR DESCRIPTION
## Summary
- Events that run multiple times a day (e.g. "Bodies - The Science Within - Denver") no longer spam the events drawer with one card per showtime — same name/venue/day showtimes now collapse into a single `GroupedEventCard` with a "N showtimes" badge, computed frontend-only in a new `groupEvents` helper.
- Clicking a grouped card opens `EventDetails` for the earliest showtime, with a new "Other showtimes today" section listing sibling times and their own ticket links.
- The venue-marker path (`VenueDetails`) gets the same grouping treatment.
- Fixed the drawer/venue cards showing raw ISO date strings (e.g. `2026-08-02T22:00:00Z`) instead of formatted dates — surfaced (and fixed) a related crash on Ticketmaster's date-only (no time-of-day) events.
- Fixed a dead back button in `EventDetails` that called disconnected `setSelectedEvent` state instead of the actual `selectEvents` used elsewhere; removed the now-unused state from `eventsProvider`.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (59 tests)
- [x] Verified live against real Ticketmaster data (Denver, CO): "Bodies - The Science Within" collapses from 17 separate cards to one card/day with a showtimes badge; clicking it shows the earliest showtime plus sibling times with ticket links
- [x] Verified other real multi-showtime events (Beetlejuice, 504: The Musical, Ron Taylor, Rockies games) group correctly
- [x] Verified the back button in `EventDetails` now correctly returns to the events list

🤖 Generated with [Claude Code](https://claude.com/claude-code)