### PR TITLE
Foundation (rescoped): decouple normalized Event model from Ticketmaster

### DIFF
--- a/apps/api/src/events/mod.rs
+++ b/apps/api/src/events/mod.rs
@@ -1,0 +1,254 @@
+//! The normalized `Event` shape and the source-agnostic logic that operates
+//! on it — personalized-discovery matching and event deduplication. Neither
+//! needs any Ticketmaster-specific knowledge; the one function that does
+//! (`TmEvent -> EventResponse` mapping) stays in `ticketmaster_stream`.
+
+pub mod types;
+
+use std::collections::HashMap;
+
+use crate::spotify::client::normalize_artist_name;
+use crate::spotify::top_artists::MatchReason;
+use types::{EventResponse, Performer};
+
+/// Sets `matched_artist` (and, for a similar-artist match, `matched_via`) on
+/// `event` if any of its performers exact-normalize-matches an entry in
+/// `matches`. Keys in `matches` must already be exact-normalized (see
+/// `spotify::top_artists::get_personalization_matches`). A no-op when the
+/// caller has no personalization set (not connected, no session, or fetch
+/// failed).
+pub(crate) fn apply_personalization(
+    event: &mut EventResponse,
+    matches: &HashMap<String, MatchReason>,
+) {
+    if matches.is_empty() {
+        return;
+    }
+    let Some((name, reason)) = event
+        .performers
+        .as_ref()
+        .and_then(|performers| find_matching_performer(performers, matches))
+    else {
+        return;
+    };
+
+    event.matched_artist = Some(name);
+    event.matched_via = match reason {
+        MatchReason::Direct => None,
+        MatchReason::Similar { seed } => Some(seed),
+    };
+}
+
+fn find_matching_performer(
+    performers: &[Performer],
+    matches: &HashMap<String, MatchReason>,
+) -> Option<(String, MatchReason)> {
+    performers.iter().find_map(|p| {
+        let name = p.name.as_ref()?;
+        matches
+            .get(&normalize_artist_name(name))
+            .map(|reason| (name.clone(), reason.clone()))
+    })
+}
+
+pub(crate) fn dedupe_key(event: &EventResponse) -> String {
+    let venue_name = event.venue.as_ref().and_then(|v| v.name.clone());
+    let performer_id = event
+        .performers
+        .as_ref()
+        .and_then(|xs| xs.first())
+        .and_then(|p| p.id.clone());
+
+    format!(
+        "{}-{}-{}",
+        event.dates.clone().unwrap_or_default(),
+        venue_name.unwrap_or_default(),
+        performer_id.unwrap_or_default()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::VenueResponse;
+
+    fn event_with_performer(name: &str) -> EventResponse {
+        EventResponse {
+            id: "1".to_string(),
+            name: "Event".to_string(),
+            venue: None,
+            images: vec![],
+            dates: None,
+            dates_pretty: None,
+            classifications: None,
+            performers: Some(vec![Performer {
+                name: Some(name.to_string()),
+                id: Some("artist-1".to_string()),
+                classifications: None,
+                external_links: None,
+                images: None,
+            }]),
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+        }
+    }
+
+    fn direct_matches(names: &[&str]) -> HashMap<String, MatchReason> {
+        names
+            .iter()
+            .map(|n| (normalize_artist_name(n), MatchReason::Direct))
+            .collect()
+    }
+
+    #[test]
+    fn apply_personalization_matches_exact_normalized_name() {
+        let mut event = event_with_performer("Tyler, The Creator");
+        let matches = direct_matches(&["Tyler, The Creator"]);
+
+        apply_personalization(&mut event, &matches);
+
+        assert_eq!(event.matched_artist.as_deref(), Some("Tyler, The Creator"));
+        assert_eq!(event.matched_via, None);
+    }
+
+    #[test]
+    fn apply_personalization_is_case_and_punctuation_insensitive() {
+        let mut event = event_with_performer("Tyler, The Creator");
+        let matches = direct_matches(&["tyler the creator"]);
+
+        apply_personalization(&mut event, &matches);
+
+        assert_eq!(event.matched_artist.as_deref(), Some("Tyler, The Creator"));
+    }
+
+    #[test]
+    fn apply_personalization_leaves_none_when_no_match() {
+        let mut event = event_with_performer("Some Other Artist");
+        let matches = direct_matches(&["Tyler, The Creator"]);
+
+        apply_personalization(&mut event, &matches);
+
+        assert_eq!(event.matched_artist, None);
+        assert_eq!(event.matched_via, None);
+    }
+
+    #[test]
+    fn apply_personalization_sets_matched_via_for_similar_artist_match() {
+        let mut event = event_with_performer("Kali Uchis");
+        let matches = HashMap::from([(
+            normalize_artist_name("Kali Uchis"),
+            MatchReason::Similar {
+                seed: "Tyler, The Creator".to_string(),
+            },
+        )]);
+
+        apply_personalization(&mut event, &matches);
+
+        assert_eq!(event.matched_artist.as_deref(), Some("Kali Uchis"));
+        assert_eq!(event.matched_via.as_deref(), Some("Tyler, The Creator"));
+    }
+
+    #[test]
+    fn apply_personalization_prefers_direct_over_similar_for_the_same_name() {
+        let mut event = event_with_performer("Tyler, The Creator");
+        let mut matches = HashMap::new();
+        matches.insert(
+            normalize_artist_name("Tyler, The Creator"),
+            MatchReason::Similar {
+                seed: "Kali Uchis".to_string(),
+            },
+        );
+        // A direct match on the same normalized name always wins when
+        // building the cache (see `spotify::top_artists::expand_via_similar_artists`);
+        // this test just documents that `apply_personalization` renders
+        // whichever reason it's given rather than re-deciding precedence
+        // itself.
+        apply_personalization(&mut event, &matches);
+        assert_eq!(event.matched_via.as_deref(), Some("Kali Uchis"));
+
+        matches.insert(
+            normalize_artist_name("Tyler, The Creator"),
+            MatchReason::Direct,
+        );
+        apply_personalization(&mut event, &matches);
+        assert_eq!(event.matched_via, None);
+    }
+
+    #[test]
+    fn apply_personalization_is_a_noop_with_no_matches() {
+        let mut event = event_with_performer("Tyler, The Creator");
+
+        apply_personalization(&mut event, &HashMap::new());
+
+        assert_eq!(event.matched_artist, None);
+    }
+
+    #[test]
+    fn dedupe_key_is_stable_for_same_date_venue_and_performer() {
+        let event = |id: &str| EventResponse {
+            id: id.to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some("The Venue".to_string()),
+                location: None,
+                city: None,
+            }),
+            images: vec![],
+            dates: Some("2026-08-01T20:00:00Z".to_string()),
+            dates_pretty: None,
+            classifications: None,
+            performers: Some(vec![Performer {
+                name: Some("Artist".to_string()),
+                id: Some("artist-1".to_string()),
+                classifications: None,
+                external_links: None,
+                images: None,
+            }]),
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+        };
+
+        // Same date/venue/performer but a different Ticketmaster event id
+        // should still dedupe to the same key — this is the whole point of
+        // dedupe_key, since Ticketmaster returns the same show multiple
+        // times across overlapping date windows with different ids.
+        assert_eq!(dedupe_key(&event("id-a")), dedupe_key(&event("id-b")));
+    }
+
+    #[test]
+    fn dedupe_key_differs_when_venue_differs() {
+        let base = EventResponse {
+            id: "1".to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some("Venue A".to_string()),
+                location: None,
+                city: None,
+            }),
+            images: vec![],
+            dates: Some("2026-08-01T20:00:00Z".to_string()),
+            dates_pretty: None,
+            classifications: None,
+            performers: None,
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+        };
+        let mut other = EventResponse {
+            venue: Some(VenueResponse {
+                name: Some("Venue B".to_string()),
+                location: None,
+                city: None,
+            }),
+            ..base.clone()
+        };
+        other.id = "2".to_string();
+
+        assert_ne!(dedupe_key(&base), dedupe_key(&other));
+    }
+}

--- a/apps/api/src/events/types.rs
+++ b/apps/api/src/events/types.rs
@@ -1,0 +1,106 @@
+//! The normalized `Event` shape this service returns to clients, and its
+//! constituent types — source-agnostic today by convention only (there's
+//! still exactly one source, Ticketmaster), not yet behind a real adapter
+//! boundary. That boundary (a `source`/`external_id`/`raw_payload` wrapper
+//! and a trait per source) is deliberately deferred until a second source
+//! actually exists to design it against — see `ticketmaster_stream::normalize`
+//! for the one place that still knows about Ticketmaster's raw shape.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Clone)]
+pub struct EventResponse {
+    pub id: String,
+    pub name: String,
+    pub venue: Option<VenueResponse>,
+    pub images: Vec<Images>,
+    pub dates: Option<String>,
+    #[serde(rename = "datesPretty")]
+    pub dates_pretty: Option<String>,
+    pub classifications: Option<Vec<Classification>>,
+    pub performers: Option<Vec<Performer>>,
+    pub url: Option<String>,
+    #[serde(rename = "priceRanges")]
+    pub price_ranges: Option<Vec<PriceRange>>,
+    /// Name of the performer that matched one of the caller's Spotify top
+    /// artists, for personalized discovery. `None` when the caller isn't
+    /// connected, has no personalization data, or no performer matched.
+    #[serde(rename = "matchedArtist")]
+    pub matched_artist: Option<String>,
+    /// Set only when `matched_artist` matched via Apple Music similar-artist
+    /// expansion rather than being one of the caller's own Spotify top
+    /// artists — names the top artist (`seed`) that produced the match, so
+    /// the frontend can render "similar to X" instead of implying the
+    /// caller directly listens to `matched_artist`.
+    #[serde(rename = "matchedVia")]
+    pub matched_via: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Performer {
+    pub name: Option<String>,
+    pub id: Option<String>,
+    pub classifications: Option<Vec<Classification>>,
+    #[serde(rename = "externalLinks")]
+    pub external_links: Option<ExternalLinks>,
+    pub images: Option<Vec<Images>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ExternalLinks {
+    wiki: Option<Vec<ExternalLink>>,
+    homepage: Option<Vec<ExternalLink>>,
+    instagram: Option<Vec<ExternalLink>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ExternalLink {
+    url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Classification {
+    primary: Option<bool>,
+    segment: Option<Segment>,
+    genre: Option<Segment>,
+    #[serde(rename = "subGenre")]
+    sub_genre: Option<Segment>,
+    #[serde(rename = "subType")]
+    sub_type: Option<Segment>,
+    family: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Segment {
+    id: String,
+    name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PriceRange {
+    currency: String,
+    min: f32,
+    max: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Images {
+    ratio: Option<String>,
+    url: String,
+    width: Option<i32>,
+    height: Option<i32>,
+    fallback: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct VenueResponse {
+    pub name: Option<String>,
+    pub location: Option<LocationResponse>,
+    pub city: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct LocationResponse {
+    pub latitude: Option<String>,
+    pub longitude: Option<String>,
+}

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 mod cookie;
 mod db;
 mod error;
+mod events;
 mod http_utils;
 mod mapbox_handlers;
 mod services;

--- a/apps/api/src/services/playlist_builder.rs
+++ b/apps/api/src/services/playlist_builder.rs
@@ -93,7 +93,7 @@ pub async fn find_artist_names_near(
 
     Ok(events
         .iter()
-        .flat_map(|e| e.attractions.as_ref().into_iter().flatten())
+        .flat_map(|e| e.performers.as_ref().into_iter().flatten())
         .filter_map(|a| a.name.clone())
         .collect::<HashSet<_>>()
         .into_iter()

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -1,12 +1,15 @@
 //! All access to the Ticketmaster Discovery API, split by concern:
-//! - `types`: raw Ticketmaster response shapes, this service's normalized
-//!   response shapes, and `PageLimit` (how far a caller pages through
-//!   results)
+//! - `types`: raw Ticketmaster response shapes and `PageLimit` (how far a
+//!   caller pages through results) — the normalized `EventResponse` shape
+//!   lives in `crate::events::types` instead, since it isn't
+//!   Ticketmaster-specific
 //! - `dates`: splitting a datetime range into per-calendar-day windows
 //! - `client`: fetching a single page from the Ticketmaster API, and the
 //!   `should_fetch_next` pagination decision
-//! - `normalize`: converting raw events into the normalized shape and
-//!   deriving a dedupe key
+//! - `normalize`: converting a raw `TmEvent` into an `EventResponse` — the
+//!   one place in this module that still needs to know Ticketmaster's raw
+//!   shape; `apply_personalization`/`dedupe_key` live in `crate::events`
+//!   since they only ever touch the normalized shape
 //!
 //! This file wires those pieces together into two HTTP handlers —
 //! `get_concerts_tm_stream` (incremental ndjson for the map, windowed and
@@ -23,9 +26,11 @@ mod types;
 
 pub use types::*;
 
-pub(crate) use normalize::{apply_personalization, dedupe_key, normalize_event};
+pub(crate) use normalize::normalize_event;
 
 use crate::error::AppError;
+use crate::events::types::EventResponse;
+use crate::events::{apply_personalization, dedupe_key};
 use crate::spotify::spotify_handlers::resolve_account_from_cookie_lenient;
 use crate::state::AppState;
 use axum::{

--- a/apps/api/src/ticketmaster_stream/normalize.rs
+++ b/apps/api/src/ticketmaster_stream/normalize.rs
@@ -1,12 +1,11 @@
-//! Converting raw Ticketmaster events into this service's response shape,
-//! and deriving a stable key for deduplicating events seen across
-//! overlapping date windows.
+//! Converting raw Ticketmaster events into this service's normalized
+//! `EventResponse` shape — the one place that still needs to know
+//! Ticketmaster's raw shape (see `crate::events` for everything downstream
+//! of it, which doesn't).
 
-use super::types::{EventResponse, LocationResponse, TmAttraction, TmEvent, VenueResponse};
-use crate::spotify::client::normalize_artist_name;
-use crate::spotify::top_artists::MatchReason;
+use super::types::TmEvent;
+use crate::events::types::{EventResponse, LocationResponse, VenueResponse};
 use chrono::{DateTime, Local};
-use std::collections::HashMap;
 
 pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
     let dates = e.dates.start.date_time.or_else(|| {
@@ -35,7 +34,7 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
         city: v.city.and_then(|c| c.name),
     });
 
-    let attractions = e.embedded.and_then(|a| a.attractions);
+    let performers = e.embedded.and_then(|a| a.attractions);
 
     let dates_pretty = dates.as_ref().map(|d| {
         DateTime::parse_from_rfc3339(d)
@@ -52,75 +51,17 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
         dates,
         dates_pretty,
         classifications: e.classifications,
-        attractions,
+        performers,
         price_ranges: e.price_ranges,
         matched_artist: None,
         matched_via: None,
     }
 }
 
-/// Sets `matched_artist` (and, for a similar-artist match, `matched_via`) on
-/// `event` if any of its Ticketmaster attractions exact-normalize-matches an
-/// entry in `matches`. Keys in `matches` must already be exact-normalized
-/// (see `spotify::top_artists::get_personalization_matches`). A no-op when
-/// the caller has no personalization set (not connected, no session, or
-/// fetch failed).
-pub(crate) fn apply_personalization(
-    event: &mut EventResponse,
-    matches: &HashMap<String, MatchReason>,
-) {
-    if matches.is_empty() {
-        return;
-    }
-    let Some((name, reason)) = event
-        .attractions
-        .as_ref()
-        .and_then(|attractions| find_matching_attraction(attractions, matches))
-    else {
-        return;
-    };
-
-    event.matched_artist = Some(name);
-    event.matched_via = match reason {
-        MatchReason::Direct => None,
-        MatchReason::Similar { seed } => Some(seed),
-    };
-}
-
-fn find_matching_attraction(
-    attractions: &[TmAttraction],
-    matches: &HashMap<String, MatchReason>,
-) -> Option<(String, MatchReason)> {
-    attractions.iter().find_map(|a| {
-        let name = a.name.as_ref()?;
-        matches
-            .get(&normalize_artist_name(name))
-            .map(|reason| (name.clone(), reason.clone()))
-    })
-}
-
-pub(crate) fn dedupe_key(event: &EventResponse) -> String {
-    let venue_name = event.venue.as_ref().and_then(|v| v.name.clone());
-    let attraction_id = event
-        .attractions
-        .as_ref()
-        .and_then(|xs| xs.first())
-        .and_then(|a| a.id.clone());
-
-    format!(
-        "{}-{}-{}",
-        event.dates.clone().unwrap_or_default(),
-        venue_name.unwrap_or_default(),
-        attraction_id.unwrap_or_default()
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ticketmaster_stream::types::{
-        EventEmbedded, TmAttraction, TmDate, TmDateStart, TmVenue,
-    };
+    use crate::ticketmaster_stream::types::{EventEmbedded, TmDate, TmDateStart, TmVenue};
 
     fn tm_event(id: &str, start: TmDateStart) -> TmEvent {
         TmEvent {
@@ -222,184 +163,5 @@ mod tests {
             normalized.venue.and_then(|v| v.name),
             Some("Second Venue".to_string())
         );
-    }
-
-    #[test]
-    fn dedupe_key_is_stable_for_same_date_venue_and_attraction() {
-        let event = |id: &str| EventResponse {
-            id: id.to_string(),
-            name: "Event".to_string(),
-            venue: Some(VenueResponse {
-                name: Some("The Venue".to_string()),
-                location: None,
-                city: None,
-            }),
-            images: vec![],
-            dates: Some("2026-08-01T20:00:00Z".to_string()),
-            dates_pretty: None,
-            classifications: None,
-            attractions: Some(vec![TmAttraction {
-                name: Some("Artist".to_string()),
-                id: Some("artist-1".to_string()),
-                classifications: None,
-                external_links: None,
-                images: None,
-            }]),
-            url: None,
-            price_ranges: None,
-            matched_artist: None,
-            matched_via: None,
-        };
-
-        // Same date/venue/attraction but a different Ticketmaster event id
-        // should still dedupe to the same key — this is the whole point of
-        // dedupe_key, since Ticketmaster returns the same show multiple
-        // times across overlapping date windows with different ids.
-        assert_eq!(dedupe_key(&event("id-a")), dedupe_key(&event("id-b")));
-    }
-
-    #[test]
-    fn dedupe_key_differs_when_venue_differs() {
-        let base = EventResponse {
-            id: "1".to_string(),
-            name: "Event".to_string(),
-            venue: Some(VenueResponse {
-                name: Some("Venue A".to_string()),
-                location: None,
-                city: None,
-            }),
-            images: vec![],
-            dates: Some("2026-08-01T20:00:00Z".to_string()),
-            dates_pretty: None,
-            classifications: None,
-            attractions: None,
-            url: None,
-            price_ranges: None,
-            matched_artist: None,
-            matched_via: None,
-        };
-        let mut other = EventResponse {
-            venue: Some(VenueResponse {
-                name: Some("Venue B".to_string()),
-                location: None,
-                city: None,
-            }),
-            ..base.clone()
-        };
-        other.id = "2".to_string();
-
-        assert_ne!(dedupe_key(&base), dedupe_key(&other));
-    }
-
-    fn event_with_attraction(name: &str) -> EventResponse {
-        EventResponse {
-            id: "1".to_string(),
-            name: "Event".to_string(),
-            venue: None,
-            images: vec![],
-            dates: None,
-            dates_pretty: None,
-            classifications: None,
-            attractions: Some(vec![TmAttraction {
-                name: Some(name.to_string()),
-                id: Some("artist-1".to_string()),
-                classifications: None,
-                external_links: None,
-                images: None,
-            }]),
-            url: None,
-            price_ranges: None,
-            matched_artist: None,
-            matched_via: None,
-        }
-    }
-
-    fn direct_matches(names: &[&str]) -> HashMap<String, MatchReason> {
-        names
-            .iter()
-            .map(|n| (normalize_artist_name(n), MatchReason::Direct))
-            .collect()
-    }
-
-    #[test]
-    fn apply_personalization_matches_exact_normalized_name() {
-        let mut event = event_with_attraction("Tyler, The Creator");
-        let matches = direct_matches(&["Tyler, The Creator"]);
-
-        apply_personalization(&mut event, &matches);
-
-        assert_eq!(event.matched_artist.as_deref(), Some("Tyler, The Creator"));
-        assert_eq!(event.matched_via, None);
-    }
-
-    #[test]
-    fn apply_personalization_is_case_and_punctuation_insensitive() {
-        let mut event = event_with_attraction("Tyler, The Creator");
-        let matches = direct_matches(&["tyler the creator"]);
-
-        apply_personalization(&mut event, &matches);
-
-        assert_eq!(event.matched_artist.as_deref(), Some("Tyler, The Creator"));
-    }
-
-    #[test]
-    fn apply_personalization_leaves_none_when_no_match() {
-        let mut event = event_with_attraction("Some Other Artist");
-        let matches = direct_matches(&["Tyler, The Creator"]);
-
-        apply_personalization(&mut event, &matches);
-
-        assert_eq!(event.matched_artist, None);
-        assert_eq!(event.matched_via, None);
-    }
-
-    #[test]
-    fn apply_personalization_sets_matched_via_for_similar_artist_match() {
-        let mut event = event_with_attraction("Kali Uchis");
-        let matches = HashMap::from([(
-            normalize_artist_name("Kali Uchis"),
-            MatchReason::Similar {
-                seed: "Tyler, The Creator".to_string(),
-            },
-        )]);
-
-        apply_personalization(&mut event, &matches);
-
-        assert_eq!(event.matched_artist.as_deref(), Some("Kali Uchis"));
-        assert_eq!(event.matched_via.as_deref(), Some("Tyler, The Creator"));
-    }
-
-    #[test]
-    fn apply_personalization_prefers_direct_over_similar_for_the_same_name() {
-        let mut event = event_with_attraction("Tyler, The Creator");
-        let mut matches = HashMap::new();
-        matches.insert(
-            normalize_artist_name("Tyler, The Creator"),
-            MatchReason::Similar {
-                seed: "Kali Uchis".to_string(),
-            },
-        );
-        // A direct match on the same normalized name always wins when
-        // building the cache (see `expand_via_similar_artists`); this test
-        // just documents that `apply_personalization` renders whichever
-        // reason it's given rather than re-deciding precedence itself.
-        apply_personalization(&mut event, &matches);
-        assert_eq!(event.matched_via.as_deref(), Some("Kali Uchis"));
-
-        matches.insert(
-            normalize_artist_name("Tyler, The Creator"),
-            MatchReason::Direct,
-        );
-        apply_personalization(&mut event, &matches);
-        assert_eq!(event.matched_via, None);
-    }
-
-    #[test]
-    fn apply_personalization_is_a_noop_with_no_matches() {
-        let mut event = event_with_attraction("Tyler, The Creator");
-
-        apply_personalization(&mut event, &HashMap::new());
-
-        assert_eq!(event.matched_artist, None);
     }
 }

--- a/apps/api/src/ticketmaster_stream/types.rs
+++ b/apps/api/src/ticketmaster_stream/types.rs
@@ -1,7 +1,9 @@
-//! Raw Ticketmaster API response shapes, and the normalized shapes this
-//! service returns to clients.
+//! Raw Ticketmaster API response shapes, and the query/control types this
+//! module's handlers accept. The normalized response shape lives in
+//! `crate::events::types` — see that module for why.
 
-use serde::{Deserialize, Serialize};
+use crate::events::types::{Classification, Images, Performer, PriceRange};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct EventsQuery {
@@ -56,21 +58,14 @@ pub struct TmEvent {
     pub id: String,
     pub url: Option<String>,
     #[serde(rename = "priceRanges")]
-    pub price_ranges: Option<Vec<TmPriceRange>>,
+    pub price_ranges: Option<Vec<PriceRange>>,
     pub name: String,
     #[serde(default)]
     pub images: Vec<Images>,
     pub dates: TmDate,
-    pub classifications: Option<Vec<TmClassification>>,
+    pub classifications: Option<Vec<Classification>>,
     #[serde(rename = "_embedded")]
     pub embedded: Option<EventEmbedded>,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct TmPriceRange {
-    currency: String,
-    min: f32,
-    max: f32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -91,47 +86,7 @@ pub struct TmDateStart {
 #[derive(Debug, Deserialize)]
 pub struct EventEmbedded {
     pub venues: Option<Vec<TmVenue>>,
-    pub attractions: Option<Vec<TmAttraction>>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TmAttraction {
-    pub name: Option<String>,
-    pub id: Option<String>,
-    pub classifications: Option<Vec<TmClassification>>,
-    #[serde(rename = "externalLinks")]
-    pub external_links: Option<TmExternalLinks>,
-    pub images: Option<Vec<Images>>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TmExternalLinks {
-    wiki: Option<Vec<TmExternalLink>>,
-    homepage: Option<Vec<TmExternalLink>>,
-    instagram: Option<Vec<TmExternalLink>>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TmExternalLink {
-    url: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TmClassification {
-    primary: Option<bool>,
-    segment: Option<TmSegment>,
-    genre: Option<TmSegment>,
-    #[serde(rename = "subGenre")]
-    sub_genre: Option<TmSegment>,
-    #[serde(rename = "subType")]
-    sub_type: Option<TmSegment>,
-    family: Option<bool>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TmSegment {
-    id: String,
-    name: String,
+    pub attractions: Option<Vec<Performer>>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -148,56 +103,6 @@ pub struct TmCity {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct TmLocation {
-    pub latitude: Option<String>,
-    pub longitude: Option<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Images {
-    ratio: Option<String>,
-    url: String,
-    width: Option<i32>,
-    height: Option<i32>,
-    fallback: Option<bool>,
-}
-
-#[derive(Debug, Serialize, Clone)]
-pub struct EventResponse {
-    pub id: String,
-    pub name: String,
-    pub venue: Option<VenueResponse>,
-    pub images: Vec<Images>,
-    pub dates: Option<String>,
-    #[serde(rename = "datesPretty")]
-    pub dates_pretty: Option<String>,
-    pub classifications: Option<Vec<TmClassification>>,
-    pub attractions: Option<Vec<TmAttraction>>,
-    pub url: Option<String>,
-    #[serde(rename = "priceRanges")]
-    pub price_ranges: Option<Vec<TmPriceRange>>,
-    /// Name of the attraction that matched one of the caller's Spotify top
-    /// artists, for personalized discovery. `None` when the caller isn't
-    /// connected, has no personalization data, or no attraction matched.
-    #[serde(rename = "matchedArtist")]
-    pub matched_artist: Option<String>,
-    /// Set only when `matched_artist` matched via Apple Music similar-artist
-    /// expansion rather than being one of the caller's own Spotify top
-    /// artists — names the top artist (`seed`) that produced the match, so
-    /// the frontend can render "similar to X" instead of implying the
-    /// caller directly listens to `matched_artist`.
-    #[serde(rename = "matchedVia")]
-    pub matched_via: Option<String>,
-}
-
-#[derive(Debug, Serialize, Clone)]
-pub struct VenueResponse {
-    pub name: Option<String>,
-    pub location: Option<LocationResponse>,
-    pub city: Option<String>,
-}
-
-#[derive(Debug, Serialize, Clone)]
-pub struct LocationResponse {
     pub latitude: Option<String>,
     pub longitude: Option<String>,
 }

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -1,4 +1,4 @@
-import type { Event, Attraction, AmArtistFull } from "./lib/types"
+import type { Attraction, AmArtistFull } from "./lib/types"
 import { Button } from "@workspace/ui/components/ui/Button"
 import { Link } from "@workspace/ui/components/ui/Link"
 import { useEffect, useState, useRef } from "react"
@@ -28,9 +28,11 @@ const EventDetails = ({
    * excluding eventData itself. */
   otherShowtimes?: EventResponse[]
 }) => {
-  const { attractions } = eventData
+  const { performers } = eventData
   const [artistInfo, setArtistInfo] = useState<AmArtistFull[]>([])
-  const [futureEvents, setFutureEvents] = useState<Record<string, Event[]>>({})
+  const [futureEvents, setFutureEvents] = useState<
+    Record<string, EventResponse[]>
+  >({})
   const [showStickyHeader, setShowStickyHeader] = useState(false)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const { selectEvents } = useEventsContext()
@@ -47,8 +49,8 @@ const EventDetails = ({
     async function fetchData() {
       try {
         const artistInfoQuery = eventData
-          .attractions!.map(
-            (attraction) => `name=${encodeURIComponent(attraction.name || "")}`
+          .performers!.map(
+            (performer) => `name=${encodeURIComponent(performer.name || "")}`
           )
           .join("&")
         const res = await fetch(`/api/apple/artist?${artistInfoQuery}`)
@@ -74,9 +76,9 @@ const EventDetails = ({
     if (segment === "Music") {
       fetchData()
     }
-    eventData.attractions?.forEach((attraction) => {
-      if (attraction.id) {
-        fetchFutureEvents(attraction.id)
+    eventData.performers?.forEach((performer) => {
+      if (performer.id) {
+        fetchFutureEvents(performer.id)
       }
     })
 
@@ -230,12 +232,12 @@ const EventDetails = ({
               />
             </>
           ))
-        : attractions?.map((attraction) => {
-            if (!attraction.id) return null
-            const id = attraction.id
+        : performers?.map((performer) => {
+            if (!performer.id) return null
+            const id = performer.id
             return (
               <div key={id}>
-                <h4 className="text-lg font-semibold">{attraction.name}</h4>
+                <h4 className="text-lg font-semibold">{performer.name}</h4>
                 <UpcomingEvents events={futureEvents[id] ?? []} />
               </div>
             )
@@ -254,7 +256,7 @@ type ArtistCardProps = {
   similarArtists?: SimilarArtist[]
   artworkSize?: number
   attraction?: Attraction
-  futureEvents?: Event[]
+  futureEvents?: EventResponse[]
 }
 
 export const ArtistCard: React.FC<ArtistCardProps> = ({
@@ -374,7 +376,7 @@ const ExternalLink = ({ url, label }: { url: string; label: string }) => {
   )
 }
 
-const UpcomingEvents = ({ events }: { events: Event[] }) => {
+const UpcomingEvents = ({ events }: { events: EventResponse[] }) => {
   return (
     <div className="mt-4">
       <h3 className="text-xs tracking-wide text-slate-400 uppercase">

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -396,7 +396,7 @@ const UpcomingEvents = ({ events }: { events: EventResponse[] }) => {
               </span>
             </div>
             <Link
-              href={e.url}
+              href={e.url ?? undefined}
               target="_blank"
               className="ml-auto text-(--color-toasted-almond-600) no-underline dark:text-(--color-text-secondary-dark-600)"
             >

--- a/apps/web/src/hooks/eventsStream.ts
+++ b/apps/web/src/hooks/eventsStream.ts
@@ -23,7 +23,7 @@ export type EventResponse = {
   dates?: string | null
   datesPretty?: string | null
   classifications?: Classification[] | null
-  attractions?: Array<{
+  performers?: Array<{
     id?: string
     name?: string
   }> | null

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,22 +1,3 @@
-interface TmEvent {
-  id: string
-  name: string
-  venue?: Venue
-  url?: string
-  priceRanges?: {
-    currency: string
-    max: number
-    min: number
-  }[]
-  images: Image[]
-  dates: string
-  datesPretty: string
-  classifications?: Classification[]
-  attractions: Attraction[]
-}
-
-type Event = TmEvent
-
 type Attraction = {
   name: string
   id: string
@@ -50,17 +31,6 @@ type Image = {
   fallback: boolean
 }
 
-type Venue = {
-  name: string
-  location: Location
-  city: string
-}
-
-type Location = {
-  latitude: string
-  longitude: string
-}
-
 type AmArtwork = {
   url: string
   width: number
@@ -80,11 +50,4 @@ interface AmArtistFull extends AmArtist {
   similar_artists: AmArtist[]
 }
 
-export type {
-  TmEvent,
-  Event,
-  Attraction,
-  Classification,
-  AmArtistFull,
-  ClassificationSegment,
-}
+export type { Attraction, Classification, AmArtistFull, ClassificationSegment }

--- a/apps/web/src/reducers/events.test.ts
+++ b/apps/web/src/reducers/events.test.ts
@@ -42,20 +42,20 @@ describe("sameEvent", () => {
     expect(sameEvent(a, b)).toBe(true)
   })
 
-  it("is true for different ids with matching date, venue, and attraction", () => {
+  it("is true for different ids with matching date, venue, and performer", () => {
     // Ticketmaster returns the same show under different ids across
     // overlapping date windows; this is the whole point of sameEvent.
     const a = makeEvent({
       id: "tm-1",
       dates: "2026-08-01T20:00:00Z",
       venue: { name: "The Venue" },
-      attractions: [{ id: "artist-1" }],
+      performers: [{ id: "artist-1" }],
     })
     const b = makeEvent({
       id: "tm-2",
       dates: "2026-08-01T20:00:00Z",
       venue: { name: "The Venue" },
-      attractions: [{ id: "artist-1" }],
+      performers: [{ id: "artist-1" }],
     })
     expect(sameEvent(a, b)).toBe(true)
   })

--- a/apps/web/src/reducers/events.ts
+++ b/apps/web/src/reducers/events.ts
@@ -31,13 +31,13 @@ function sameEvent(a: EventResponse, b: EventResponse): boolean {
 
   const aVenue = a.venue?.name ?? ""
   const bVenue = b.venue?.name ?? ""
-  const aAttraction = a.attractions?.[0]?.id ?? ""
-  const bAttraction = b.attractions?.[0]?.id ?? ""
+  const aPerformer = a.performers?.[0]?.id ?? ""
+  const bPerformer = b.performers?.[0]?.id ?? ""
 
   return (
     (a.dates ?? "") === (b.dates ?? "") &&
     aVenue === bVenue &&
-    aAttraction === bAttraction
+    aPerformer === bPerformer
   )
 }
 


### PR DESCRIPTION
## Summary

Roadmap Phase 1, "Foundation — normalized Event model," rescoped after a grilling session before writing any code.

**Premise correction:** the pipeline-unification work this phase was originally scoped against already happened — #40 ("Collapse three Ticketmaster event fetchers into one module") already unified everything into one `EventResponse`/`normalize_event` path.

**Scope decision:** don't build the `source`/`external_id`/`raw_payload` wrapper and adapter trait the roadmap describes — that's designing against a PredictHQ shape nobody's validated (Phase 2's own spike, which surfaces coverage/pricing/data shape, hasn't run yet). Ship the part that has value independent of a second source ever existing: get Ticketmaster's vendor-shaped types out of the public response contract.

## Changes

- **New `apps/api/src/events/` module** — `EventResponse` and its constituent types, renamed off their `Tm`-prefixed originals:
  - `TmAttraction` → `Performer` (not `Artist` — Ticketmaster's own "attraction" concept already covers non-music events too, e.g. the Portland Sea Dogs game that shows up in this app's own test data; renaming to `Artist` would've been a regression in accuracy)
  - `TmClassification`/`TmSegment` → `Classification`/`Segment`, `TmPriceRange` → `PriceRange`, `TmExternalLinks`/`TmExternalLink` → `ExternalLinks`/`ExternalLink`
  - `Images`, `VenueResponse`, `LocationResponse` moved alongside (already source-agnostic, referenced by `EventResponse`)
  - Plus `apply_personalization`/`dedupe_key` — pure `EventResponse`-level logic with no Ticketmaster knowledge, so it moved out of `ticketmaster_stream` too.
  - `ticketmaster_stream::normalize::normalize_event` (`TmEvent -> EventResponse`) is the one function left that still needs to know Ticketmaster's raw shape — today's de facto adapter, ready to be the seam a real trait eventually wraps.
- **`EventResponse.attractions` → `performers`**, Rust field and JSON key both, cascading through every consumer: `playlist_builder.rs` on the backend; `EventCard`, `EventFilter`, `EventDetails`, `reducers/events.ts`, `eventsStream.ts` on the frontend.
- **Collapsed a duplicate frontend type** — `lib/types.ts`'s hand-maintained `TmEvent`/`Event` (used only for the future-events-per-performer fetch in `EventDetails.tsx`) had already drifted from the real `EventResponse` (missing `matchedArtist`/`matchedVia`). Deleted it; that fetch now uses the real type.

**Explicitly deferred, not built here:** `source`/`external_id`/`raw_payload`, an adapter trait, anything PredictHQ-shaped. No ADR either — reasoning lives in this PR description and the originating conversation, and a docs culture that doesn't exist yet didn't need to start on a phase that was cut down twice before implementation began.

## Test plan

- [x] `cargo check` / `cargo clippy` / `cargo fmt --check` clean, `SQLX_OFFLINE=true` simulated exactly as CI runs it (no query text changed this PR, so no new `.sqlx` cache entries needed)
- [x] `cargo test` — 46 passed (all prior tests, relocated and renamed to match, plus the module move)
- [x] `tsc --noEmit`, `eslint`, `vitest run` — all clean, 59 frontend tests passed
- [x] Manually verified in a running dev instance (Denver): map/list rendering, event details, and — critically — the Apple Music artist-info + similar-artists lookup and the future-events-per-performer fetch, both of which depend on the renamed `performers` field, all confirmed working end-to-end against the real API

🤖 Generated with [Claude Code](https://claude.com/claude-code)