### PR TITLE
PredictHQ (1/2): schema, client, and normalize

### DIFF
--- a/apps/api/src/error.rs
+++ b/apps/api/src/error.rs
@@ -13,6 +13,9 @@ pub enum AppError {
     #[error("Ticketmaster API error ({status}): {message}")]
     TicketmasterApi { status: StatusCode, message: String },
 
+    #[error("PredictHQ API error ({status}): {message}")]
+    PredictHqApi { status: StatusCode, message: String },
+
     #[error("Unauthorized API error ({status}): {message}")]
     Unauthorized { status: StatusCode, message: String },
 
@@ -66,6 +69,10 @@ impl IntoResponse for AppError {
                 (code, message.clone())
             }
             AppError::TicketmasterApi { status, message } => {
+                let code = *status;
+                (code, message.clone())
+            }
+            AppError::PredictHqApi { status, message } => {
                 let code = *status;
                 (code, message.clone())
             }

--- a/apps/api/src/events/mod.rs
+++ b/apps/api/src/events/mod.rs
@@ -70,7 +70,7 @@ pub(crate) fn dedupe_key(event: &EventResponse) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use types::VenueResponse;
+    use types::{Source, VenueResponse};
 
     fn event_with_performer(name: &str) -> EventResponse {
         EventResponse {
@@ -92,6 +92,9 @@ mod tests {
             price_ranges: None,
             matched_artist: None,
             matched_via: None,
+            source: Source::Ticketmaster,
+            rank: None,
+            predicted_attendance: None,
         }
     }
 
@@ -210,6 +213,9 @@ mod tests {
             price_ranges: None,
             matched_artist: None,
             matched_via: None,
+            source: Source::Ticketmaster,
+            rank: None,
+            predicted_attendance: None,
         };
 
         // Same date/venue/performer but a different Ticketmaster event id
@@ -238,6 +244,9 @@ mod tests {
             price_ranges: None,
             matched_artist: None,
             matched_via: None,
+            source: Source::Ticketmaster,
+            rank: None,
+            predicted_attendance: None,
         };
         let mut other = EventResponse {
             venue: Some(VenueResponse {

--- a/apps/api/src/events/types.rs
+++ b/apps/api/src/events/types.rs
@@ -1,12 +1,22 @@
 //! The normalized `Event` shape this service returns to clients, and its
-//! constituent types — source-agnostic today by convention only (there's
-//! still exactly one source, Ticketmaster), not yet behind a real adapter
-//! boundary. That boundary (a `source`/`external_id`/`raw_payload` wrapper
-//! and a trait per source) is deliberately deferred until a second source
-//! actually exists to design it against — see `ticketmaster_stream::normalize`
-//! for the one place that still knows about Ticketmaster's raw shape.
+//! constituent types. Two sources feed it now (`ticketmaster_stream` and
+//! `predicthq`, each owning the one function that knows its provider's raw
+//! shape); `source`/`rank`/`predicted_attendance` below are the fields that
+//! became real once a second source did.
 
 use serde::{Deserialize, Serialize};
+
+/// Which provider an event's identity comes from. An event matched across
+/// both providers (see the cross-source dedup in `ticketmaster_stream`)
+/// keeps `Ticketmaster` as its source — Ticketmaster is the identity,
+/// PredictHQ just contributes `rank`/`predicted_attendance` on top of it.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Source {
+    Ticketmaster,
+    #[serde(rename = "predicthq")]
+    PredictHq,
+}
 
 #[derive(Debug, Serialize, Clone)]
 pub struct EventResponse {
@@ -34,9 +44,18 @@ pub struct EventResponse {
     /// caller directly listens to `matched_artist`.
     #[serde(rename = "matchedVia")]
     pub matched_via: Option<String>,
+    pub source: Source,
+    /// PredictHQ's 0-100 rank, when available (native PredictHQ events, or a
+    /// Ticketmaster event enriched via cross-source dedup). `None` for a
+    /// Ticketmaster event with no PredictHQ match.
+    pub rank: Option<u8>,
+    /// PredictHQ's predicted attendance figure, under the same availability
+    /// rule as `rank`.
+    #[serde(rename = "predictedAttendance")]
+    pub predicted_attendance: Option<u32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Performer {
     pub name: Option<String>,
     pub id: Option<String>,
@@ -46,60 +65,63 @@ pub struct Performer {
     pub images: Option<Vec<Images>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ExternalLinks {
-    wiki: Option<Vec<ExternalLink>>,
-    homepage: Option<Vec<ExternalLink>>,
-    instagram: Option<Vec<ExternalLink>>,
+    pub wiki: Option<Vec<ExternalLink>>,
+    pub homepage: Option<Vec<ExternalLink>>,
+    pub instagram: Option<Vec<ExternalLink>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ExternalLink {
-    url: Option<String>,
+    pub url: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+/// A single genre/segment tag. Ticketmaster events can carry several
+/// (marking one `primary`); PredictHQ's weighted `phq_labels` map onto the
+/// same shape, one `Classification` per label (see `predicthq::normalize`).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Classification {
-    primary: Option<bool>,
-    segment: Option<Segment>,
-    genre: Option<Segment>,
+    pub primary: Option<bool>,
+    pub segment: Option<Segment>,
+    pub genre: Option<Segment>,
     #[serde(rename = "subGenre")]
-    sub_genre: Option<Segment>,
+    pub sub_genre: Option<Segment>,
     #[serde(rename = "subType")]
-    sub_type: Option<Segment>,
-    family: Option<bool>,
+    pub sub_type: Option<Segment>,
+    pub family: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Segment {
-    id: String,
-    name: String,
+    pub id: String,
+    pub name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct PriceRange {
-    currency: String,
-    min: f32,
-    max: f32,
+    pub currency: String,
+    pub min: f32,
+    pub max: f32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Images {
-    ratio: Option<String>,
-    url: String,
-    width: Option<i32>,
-    height: Option<i32>,
-    fallback: Option<bool>,
+    pub ratio: Option<String>,
+    pub url: String,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub fallback: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct VenueResponse {
     pub name: Option<String>,
     pub location: Option<LocationResponse>,
     pub city: Option<String>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct LocationResponse {
     pub latitude: Option<String>,
     pub longitude: Option<String>,

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 mod events;
 mod http_utils;
 mod mapbox_handlers;
+mod predicthq;
 mod services;
 mod spotify;
 mod state;
@@ -90,6 +91,11 @@ pub async fn build_app() -> Result<Router> {
 
     let client = Client::new();
 
+    let predicthq_api_key = std::env::var("PREDICTHQ_API_KEY").ok();
+    if predicthq_api_key.is_none() {
+        tracing::info!("PREDICTHQ_API_KEY not set — PredictHQ integration inactive");
+    }
+
     // Apple Music optional setup
     let (apple_client, apple_dev, apple_user) = if std::env::var("APPLE_MUSIC_TEAM_ID").is_ok() {
         let creds = AppleMusicCredentials::from_env();
@@ -118,6 +124,7 @@ pub async fn build_app() -> Result<Router> {
         apple_music_client: apple_client,
         apple_dev_token: apple_dev,
         apple_user_token: apple_user,
+        predicthq_api_key,
         cookie_domain: config.cookie_domain.clone(),
         cookie_secure: config.cookie_secure,
         cookie_key: Key::from(config.cookie_key.as_bytes()),

--- a/apps/api/src/predicthq/client.rs
+++ b/apps/api/src/predicthq/client.rs
@@ -1,0 +1,211 @@
+//! PredictHQ Events API client.
+//!
+//! Endpoint reference: https://docs.predicthq.com/api/events/search-events.md
+//!
+//! Static bearer-token auth (no OAuth/refresh, unlike Spotify) — architecturally
+//! closer to `ticketmaster_stream::client` than to `spotify::client`, so this
+//! follows the same free-function-over-a-shared-`reqwest::Client` shape rather
+//! than a client struct with methods.
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::http_utils::request_with_backoff;
+
+const BASE: &str = "https://api.predicthq.com/v1";
+/// PredictHQ's own default/max-reasonable page size; matched here so a full
+/// `search_concerts` call needs the fewest round-trips.
+const PAGE_LIMIT: u32 = 100;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PredictHqResponse {
+    pub(crate) next: Option<String>,
+    pub(crate) results: Vec<PredictHqEvent>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PredictHqEvent {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    /// 0-100; PredictHQ's confidence/significance score for the event.
+    pub(crate) rank: u8,
+    pub(crate) phq_attendance: Option<u32>,
+    #[serde(default)]
+    pub(crate) entities: Vec<PredictHqEntity>,
+    pub(crate) start: String,
+    pub(crate) geo: Option<PredictHqGeo>,
+    pub(crate) phq_labels: Option<Vec<PhqLabel>>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PredictHqEntity {
+    pub(crate) entity_id: String,
+    pub(crate) name: String,
+    #[serde(rename = "type")]
+    pub(crate) entity_type: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PredictHqGeo {
+    pub(crate) geometry: PredictHqGeometry,
+    pub(crate) address: Option<PredictHqAddress>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PredictHqGeometry {
+    /// `[longitude, latitude]` — GeoJSON's field order, not `(lat, lng)`.
+    pub(crate) coordinates: [f64; 2],
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PredictHqAddress {
+    pub(crate) locality: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct PhqLabel {
+    pub(crate) label: String,
+    pub(crate) weight: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PredictHqErrorBody {
+    error: String,
+}
+
+fn map_error(status: StatusCode, text: String) -> AppError {
+    let message = serde_json::from_str::<PredictHqErrorBody>(&text)
+        .map(|e| e.error)
+        .unwrap_or(text);
+    AppError::PredictHqApi { status, message }
+}
+
+/// Fetches every concert-category PredictHQ event within `within` (PredictHQ's
+/// own radius format, e.g. `"25mi@43.6591,-70.2568"`) starting between
+/// `start_gte` and `start_lte` (ISO 8601), following `next` until exhausted.
+///
+/// Scoped to `category=concerts` only — see the roadmap discussion on why
+/// `performing-arts`/`festivals` are deliberately not pulled in yet.
+pub(crate) async fn search_concerts(
+    client: &reqwest::Client,
+    api_key: &str,
+    within: &str,
+    start_gte: &str,
+    start_lte: &str,
+) -> Result<Vec<PredictHqEvent>, AppError> {
+    let mut events = Vec::new();
+    let mut url = format!(
+        "{BASE}/events/?category=concerts&within={within}&start.gte={start_gte}&start.lte={start_lte}&limit={PAGE_LIMIT}"
+    );
+
+    loop {
+        let resp = request_with_backoff(
+            "predicthq",
+            || client.get(&url).bearer_auth(api_key),
+            map_error,
+        )
+        .await?;
+
+        let page: PredictHqResponse = resp.json().await.map_err(AppError::from)?;
+        events.extend(page.results);
+
+        match page.next {
+            Some(next_url) => url = next_url,
+            None => break,
+        }
+    }
+
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Hits the real PredictHQ API — not run by default (needs
+    /// `PREDICTHQ_API_KEY` and network access). Run manually with
+    /// `cargo test -- --ignored` to confirm the response types still
+    /// deserialize real payloads correctly.
+    #[tokio::test]
+    #[ignore]
+    async fn search_concerts_deserializes_real_response() {
+        let api_key = std::env::var("PREDICTHQ_API_KEY")
+            .expect("PREDICTHQ_API_KEY must be set to run this test");
+        let client = reqwest::Client::new();
+
+        let events = search_concerts(
+            &client,
+            &api_key,
+            "25mi@43.6591,-70.2568",
+            "2026-08-02",
+            "2026-08-09",
+        )
+        .await
+        .expect("search_concerts should succeed against the real API");
+
+        assert!(!events.is_empty(), "expected at least one real event back");
+        // At least one event in this market/window is known to carry a
+        // structured performer entity and phq_labels — confirms the nested
+        // entity/label deserialization isn't just parsing the envelope.
+        assert!(
+            events.iter().any(|e| e
+                .entities
+                .iter()
+                .any(|en| en.entity_type == "person" || en.entity_type == "organization")),
+            "expected at least one event with a person/organization entity"
+        );
+        assert!(
+            events.iter().any(|e| e.phq_labels.is_some()),
+            "expected at least one event with phq_labels"
+        );
+    }
+
+    /// Same real fetch, but through the full normalize path — confirms
+    /// `normalize_predicthq_event` doesn't panic on any of the messier real
+    /// shapes (missing geo, no entities, no phq_labels) across a real,
+    /// heterogeneous 30+ event dataset, not just the hand-built fixtures in
+    /// `normalize`'s own unit tests.
+    #[tokio::test]
+    #[ignore]
+    async fn normalizes_every_real_event_without_panicking() {
+        use crate::predicthq::normalize_predicthq_event;
+
+        let api_key = std::env::var("PREDICTHQ_API_KEY")
+            .expect("PREDICTHQ_API_KEY must be set to run this test");
+        let client = reqwest::Client::new();
+
+        let events = search_concerts(
+            &client,
+            &api_key,
+            "25mi@43.6591,-70.2568",
+            "2026-08-02",
+            "2026-08-09",
+        )
+        .await
+        .expect("search_concerts should succeed against the real API");
+
+        let normalized: Vec<_> = events.into_iter().map(normalize_predicthq_event).collect();
+
+        assert!(
+            normalized.iter().any(|e| e.performers.is_none()),
+            "expected at least one real event with no structured performer entity"
+        );
+        assert!(
+            normalized
+                .iter()
+                .any(|e| e.performers.as_ref().is_some_and(|p| p.len() > 1)),
+            "expected at least one real event with multiple performer entities"
+        );
+        assert!(
+            normalized
+                .iter()
+                .any(|e| e.classifications.as_ref().is_some_and(|c| c.len() > 1)),
+            "expected at least one real event with multiple phq_labels"
+        );
+        assert!(
+            normalized.iter().all(|e| e.id.starts_with("phq:")),
+            "every normalized event should have a source-prefixed id"
+        );
+    }
+}

--- a/apps/api/src/predicthq/mod.rs
+++ b/apps/api/src/predicthq/mod.rs
@@ -1,0 +1,10 @@
+//! PredictHQ as a second event source — currently just the fetch +
+//! normalize path (`client`/`normalize`), not yet wired into
+//! `/concerts/stream`. Cross-source dedup against Ticketmaster and the
+//! live-stream wiring are a separate, stacked follow-up.
+
+mod client;
+mod normalize;
+
+pub(crate) use client::search_concerts;
+pub(crate) use normalize::normalize_predicthq_event;

--- a/apps/api/src/predicthq/normalize.rs
+++ b/apps/api/src/predicthq/normalize.rs
@@ -1,0 +1,290 @@
+//! Converting a raw PredictHQ event into this service's normalized
+//! `EventResponse` shape — the one place that needs to know PredictHQ's raw
+//! shape, mirroring `ticketmaster_stream::normalize`.
+
+use super::client::{PhqLabel, PredictHqEvent};
+use crate::events::types::{
+    Classification, EventResponse, LocationResponse, Performer, Segment, Source, VenueResponse,
+};
+use chrono::{DateTime, Local};
+
+pub(crate) fn normalize_predicthq_event(e: PredictHqEvent) -> EventResponse {
+    let venue_entity = e.entities.iter().find(|en| en.entity_type == "venue");
+
+    let geo = e.geo.as_ref();
+    let venue = match (venue_entity, geo) {
+        (None, None) => None,
+        (venue_entity, geo) => Some(VenueResponse {
+            name: venue_entity.map(|v| v.name.clone()),
+            location: geo.map(|g| {
+                let [lng, lat] = g.geometry.coordinates;
+                LocationResponse {
+                    latitude: Some(lat.to_string()),
+                    longitude: Some(lng.to_string()),
+                }
+            }),
+            city: geo.and_then(|g| g.address.as_ref()?.locality.clone()),
+        }),
+    };
+
+    let performers: Vec<Performer> = e
+        .entities
+        .iter()
+        .filter(|en| en.entity_type == "person" || en.entity_type == "organization")
+        .map(|en| Performer {
+            name: Some(en.name.clone()),
+            id: Some(en.entity_id.clone()),
+            classifications: None,
+            external_links: None,
+            images: None,
+        })
+        .collect();
+    let performers = (!performers.is_empty()).then_some(performers);
+
+    let dates_pretty = DateTime::parse_from_rfc3339(&e.start)
+        .map(|dt| dt.with_timezone(&Local).format("%B %d").to_string())
+        .ok();
+
+    EventResponse {
+        // PredictHQ and Ticketmaster ids are both opaque alphanumeric
+        // strings from unrelated generators, but the collision risk costs
+        // nothing to close off entirely with a source-prefixed id.
+        id: format!("phq:{}", e.id),
+        name: e.title,
+        venue,
+        images: vec![],
+        dates: Some(e.start),
+        dates_pretty,
+        classifications: Some(build_classifications(e.phq_labels.as_deref())),
+        performers,
+        url: None,
+        price_ranges: None,
+        matched_artist: None,
+        matched_via: None,
+        source: Source::PredictHq,
+        rank: Some(e.rank),
+        predicted_attendance: e.phq_attendance,
+    }
+}
+
+/// Maps PredictHQ's weighted `phq_labels` (e.g. `[{label: "rock", weight:
+/// 0.77}, {label: "pop", weight: 0.23}]`) onto one `Classification` per
+/// label — same shape as Ticketmaster's own multi-classification-with-a-
+/// `primary`-flag list. Falls back to a bare `Music`-segment classification
+/// (no genre) when PredictHQ has no labels for this event, which is common
+/// for events lacking a structured performer entity too (same underlying
+/// data gap) — the event still needs *a* classification so it groups
+/// correctly under the existing "Music" filter.
+fn build_classifications(labels: Option<&[PhqLabel]>) -> Vec<Classification> {
+    let music_segment = || Segment {
+        id: "predicthq-music".to_string(),
+        name: "Music".to_string(),
+    };
+
+    let Some(labels) = labels.filter(|l| !l.is_empty()) else {
+        return vec![Classification {
+            primary: Some(true),
+            segment: Some(music_segment()),
+            genre: None,
+            sub_genre: None,
+            sub_type: None,
+            family: Some(false),
+        }];
+    };
+
+    let max_weight = labels.iter().map(|l| l.weight).fold(f64::MIN, f64::max);
+
+    labels
+        .iter()
+        .map(|l| Classification {
+            primary: Some(l.weight == max_weight),
+            segment: Some(music_segment()),
+            genre: Some(Segment {
+                id: l.label.clone(),
+                name: title_case_label(&l.label),
+            }),
+            sub_genre: None,
+            sub_type: None,
+            family: Some(false),
+        })
+        .collect()
+}
+
+/// `"jazz-and-classical"` -> `"Jazz And Classical"`.
+fn title_case_label(label: &str) -> String {
+    label
+        .split('-')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::predicthq::client::{
+        PredictHqAddress, PredictHqEntity, PredictHqGeo, PredictHqGeometry,
+    };
+
+    fn base_event() -> PredictHqEvent {
+        PredictHqEvent {
+            id: "abc123".to_string(),
+            title: "Test Show".to_string(),
+            rank: 50,
+            phq_attendance: Some(300),
+            entities: vec![],
+            start: "2026-08-09T23:00:00Z".to_string(),
+            geo: None,
+            phq_labels: None,
+        }
+    }
+
+    #[test]
+    fn maps_id_with_source_prefix_and_source_field() {
+        let normalized = normalize_predicthq_event(base_event());
+        assert_eq!(normalized.id, "phq:abc123");
+        assert_eq!(normalized.source, Source::PredictHq);
+    }
+
+    #[test]
+    fn maps_rank_and_attendance() {
+        let normalized = normalize_predicthq_event(base_event());
+        assert_eq!(normalized.rank, Some(50));
+        assert_eq!(normalized.predicted_attendance, Some(300));
+    }
+
+    #[test]
+    fn has_no_url_price_ranges_or_images() {
+        let normalized = normalize_predicthq_event(base_event());
+        assert_eq!(normalized.url, None);
+        assert_eq!(normalized.price_ranges, None);
+        assert!(normalized.images.is_empty());
+    }
+
+    #[test]
+    fn maps_person_and_organization_entities_to_performers_but_not_venue() {
+        let mut event = base_event();
+        event.entities = vec![
+            PredictHqEntity {
+                entity_id: "p1".to_string(),
+                name: "Ryan Miller".to_string(),
+                entity_type: "person".to_string(),
+            },
+            PredictHqEntity {
+                entity_id: "o1".to_string(),
+                name: "Guster".to_string(),
+                entity_type: "organization".to_string(),
+            },
+            PredictHqEntity {
+                entity_id: "v1".to_string(),
+                name: "One Longfellow Square".to_string(),
+                entity_type: "venue".to_string(),
+            },
+        ];
+
+        let normalized = normalize_predicthq_event(event);
+        let performers = normalized.performers.expect("expected performers");
+        let names: Vec<_> = performers
+            .iter()
+            .filter_map(|p| p.name.as_deref())
+            .collect();
+
+        assert_eq!(names, vec!["Ryan Miller", "Guster"]);
+        assert_eq!(
+            normalized.venue.unwrap().name.as_deref(),
+            Some("One Longfellow Square")
+        );
+    }
+
+    #[test]
+    fn no_performer_entities_yields_none_not_empty_vec() {
+        let mut event = base_event();
+        event.entities = vec![PredictHqEntity {
+            entity_id: "v1".to_string(),
+            name: "Some Venue".to_string(),
+            entity_type: "venue".to_string(),
+        }];
+
+        let normalized = normalize_predicthq_event(event);
+        assert_eq!(normalized.performers, None);
+    }
+
+    #[test]
+    fn maps_venue_location_and_city_from_geo() {
+        let mut event = base_event();
+        event.geo = Some(PredictHqGeo {
+            geometry: PredictHqGeometry {
+                coordinates: [-70.39, 43.52],
+            },
+            address: Some(PredictHqAddress {
+                locality: Some("Old Orchard Beach".to_string()),
+            }),
+        });
+
+        let normalized = normalize_predicthq_event(event);
+        let venue = normalized.venue.expect("expected venue");
+        assert_eq!(venue.city.as_deref(), Some("Old Orchard Beach"));
+        assert_eq!(venue.location.unwrap().latitude.as_deref(), Some("43.52"));
+    }
+
+    #[test]
+    fn no_phq_labels_falls_back_to_bare_music_classification() {
+        let normalized = normalize_predicthq_event(base_event());
+        let classifications = normalized
+            .classifications
+            .expect("expected classifications");
+        assert_eq!(classifications.len(), 1);
+        assert_eq!(classifications[0].segment.as_ref().unwrap().name, "Music");
+        assert!(classifications[0].genre.is_none());
+        assert_eq!(classifications[0].primary, Some(true));
+    }
+
+    #[test]
+    fn phq_labels_map_to_one_classification_each_with_highest_weight_primary() {
+        let mut event = base_event();
+        event.phq_labels = Some(vec![
+            PhqLabel {
+                label: "pop".to_string(),
+                weight: 0.363,
+            },
+            PhqLabel {
+                label: "rock".to_string(),
+                weight: 0.364,
+            },
+            PhqLabel {
+                label: "jazz-and-classical".to_string(),
+                weight: 0.273,
+            },
+        ]);
+
+        let normalized = normalize_predicthq_event(event);
+        let classifications = normalized
+            .classifications
+            .expect("expected classifications");
+        assert_eq!(classifications.len(), 3);
+
+        let primary_count = classifications
+            .iter()
+            .filter(|c| c.primary == Some(true))
+            .count();
+        assert_eq!(primary_count, 1);
+
+        let primary = classifications
+            .iter()
+            .find(|c| c.primary == Some(true))
+            .unwrap();
+        assert_eq!(primary.genre.as_ref().unwrap().name, "Rock");
+    }
+
+    #[test]
+    fn title_cases_hyphenated_labels() {
+        assert_eq!(title_case_label("jazz-and-classical"), "Jazz And Classical");
+        assert_eq!(title_case_label("rock"), "Rock");
+    }
+}

--- a/apps/api/src/state.rs
+++ b/apps/api/src/state.rs
@@ -32,6 +32,11 @@ pub struct AppStateInner {
     pub apple_music_client: Option<AppleMusicClient>,
     pub apple_dev_token: Option<Arc<DeveloperTokenManager>>,
     pub apple_user_token: Option<Arc<MusicUserTokenStore>>,
+
+    /// `None` when `PREDICTHQ_API_KEY` isn't set — PredictHQ isn't wired
+    /// into any live route yet (see `crate::predicthq`), so this is
+    /// deliberately optional rather than a boot-time requirement.
+    pub predicthq_api_key: Option<String>,
 }
 
 impl Deref for AppState {

--- a/apps/api/src/ticketmaster_stream/normalize.rs
+++ b/apps/api/src/ticketmaster_stream/normalize.rs
@@ -4,7 +4,7 @@
 //! of it, which doesn't).
 
 use super::types::TmEvent;
-use crate::events::types::{EventResponse, LocationResponse, VenueResponse};
+use crate::events::types::{EventResponse, LocationResponse, Source, VenueResponse};
 use chrono::{DateTime, Local};
 
 pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
@@ -55,6 +55,9 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
         price_ranges: e.price_ranges,
         matched_artist: None,
         matched_via: None,
+        source: Source::Ticketmaster,
+        rank: None,
+        predicted_attendance: None,
     }
 }
 


### PR DESCRIPTION
## Summary

First of two stacked PRs for roadmap Phase 2 ("Second source: PredictHQ"), scoped through a grilling session against **real spike data**, not the roadmap's original assumptions:

- Real API comparison: PredictHQ returned 37 concert events near Portland, ME for a one-week window; Ticketmaster returned 5 for the same market/window, and every one of those 5 was already inside PredictHQ's 37.
- Cross-checked against Bandsintown's and Songkick's public listings for the same market/week — both surfaced additional real touring acts (Iron & Wine, Watchhouse, Neal Francis) that neither Ticketmaster nor PredictHQ had, confirming this gap is real coverage, not PredictHQ noise.
- About a third of PredictHQ's own concert events (including real acts, e.g. The Barr Brothers) carry no structured performer entity at all — confirmed against real data, not assumed.

This PR is **schema + client + normalize only** — fully unit-tested in isolation, nothing wired into any live route yet. Cross-source dedup and `/concerts/stream` wiring are PR2, stacked on this one.

## Changes

- **`EventResponse` gains `source`, `rank`, `predicted_attendance`** — `source` is the field #41 deliberately deferred until a second real source existed to design it against. `rank`/`predicted_attendance` populate whenever PredictHQ data is available, which makes Phase 3 ("surface rank/predicted attendance") nearly free once Phase 2 fully lands.
- **New `apps/api/src/predicthq/` module** — a free-function client (static bearer-token auth, no OAuth — closer to `ticketmaster_stream::client`'s shape than `spotify::client`'s) and `normalize_predicthq_event`, the PredictHQ-specific analog to `normalize_event`.
- **Entity mapping**: `person`/`organization` entities → `Performer`; `venue` entity + `geo.address.locality` → `VenueResponse`. Events with no structured performer entity normalize cleanly to `performers: None` rather than guessing from the free-text title.
- **Classification mapping**: PredictHQ's weighted `phq_labels` (e.g. `rock` 0.68 / `pop` 0.32) map to one `Classification` per label, highest-weight marked `primary` — mirroring Ticketmaster's own multi-classification-with-primary-flag shape. Falls back to a bare `Music`-segment classification when `phq_labels` is absent, so every event still groups correctly under the existing genre filter.
- **`PREDICTHQ_API_KEY` is optional at boot** (`state.predicthq_api_key: Option<String>`), not required — this module has no live consumer yet, so a hard requirement would risk breaking deployment (e.g. Render) for a feature that doesn't do anything until PR2 lands.

## Test plan

- [x] `cargo check` / `cargo clippy --bins --tests -- -D clippy::all` / `cargo fmt --check` clean, simulated exactly as CI runs (`SQLX_OFFLINE=true`, no local `.env`)
- [x] `cargo test` — 55 passed (46 existing + 9 new unit tests covering entity mapping, classification mapping, id prefixing, missing-data fallbacks)
- [x] Two `#[ignore]`-gated integration tests (run manually via `cargo test -- --ignored`, correctly skipped in CI) verify against the **real PredictHQ API**: response deserialization, and that `normalize_predicthq_event` handles the full real 37-event heterogeneous dataset (missing geo/entities/labels included) without panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)