### PR TITLE
PredictHQ (2/2): cross-source dedup + streaming

### DIFF
--- a/apps/api/src/events/mod.rs
+++ b/apps/api/src/events/mod.rs
@@ -5,6 +5,10 @@
 
 pub mod types;
 
+mod reconcile;
+
+pub(crate) use reconcile::reconcile_predicthq_events;
+
 use std::collections::HashMap;
 
 use crate::spotify::client::normalize_artist_name;

--- a/apps/api/src/events/reconcile.rs
+++ b/apps/api/src/events/reconcile.rs
@@ -1,0 +1,314 @@
+//! Cross-source dedup: deciding whether a PredictHQ event is the same show
+//! as an already-normalized Ticketmaster event, or genuinely new coverage.
+//!
+//! Deliberately a separate concept from `dedupe_key` — that handles the same
+//! Ticketmaster event reappearing across overlapping date windows (same
+//! source, same identity, literal duplicate). This handles two different
+//! sources' independent listings of what might be the same real-world show.
+
+use std::collections::HashSet;
+
+use super::types::EventResponse;
+use crate::spotify::client::normalize_artist_name;
+
+/// Reconciles PredictHQ events against already-streamed Ticketmaster events.
+/// Each PredictHQ event either enriches a matching Ticketmaster event (same
+/// venue + calendar date, confirmed by performer name when both sides have
+/// one) or becomes its own new card — never both, and Ticketmaster is always
+/// preferred as the identity when a match exists (see `Source`'s own docs).
+///
+/// Returns `(enrichments, new_events)`: `enrichments` are clones of the
+/// matched Ticketmaster events with `rank`/`predicted_attendance` set,
+/// meant to be re-emitted under their original id as a second-wave update;
+/// `new_events` are the unmatched PredictHQ events, unchanged.
+pub(crate) fn reconcile_predicthq_events(
+    ticketmaster_events: &[EventResponse],
+    predicthq_events: Vec<EventResponse>,
+) -> (Vec<EventResponse>, Vec<EventResponse>) {
+    let mut enrichments = Vec::new();
+    let mut new_events = Vec::new();
+
+    for phq_event in predicthq_events {
+        match find_matching_ticketmaster_event(ticketmaster_events, &phq_event) {
+            Some(matched) => {
+                let mut enriched = matched.clone();
+                enriched.rank = phq_event.rank;
+                enriched.predicted_attendance = phq_event.predicted_attendance;
+                enrichments.push(enriched);
+            }
+            None => new_events.push(phq_event),
+        }
+    }
+
+    (enrichments, new_events)
+}
+
+fn find_matching_ticketmaster_event<'a>(
+    ticketmaster_events: &'a [EventResponse],
+    phq_event: &EventResponse,
+) -> Option<&'a EventResponse> {
+    ticketmaster_events.iter().find(|tm| {
+        venue_and_date_match(tm, phq_event) && performer_confirms_or_absent(tm, phq_event)
+    })
+}
+
+fn venue_and_date_match(a: &EventResponse, b: &EventResponse) -> bool {
+    let a_venue = venue_key(a);
+    let b_venue = venue_key(b);
+    if a_venue.is_none() || a_venue != b_venue {
+        return false;
+    }
+
+    let a_day = calendar_day(a);
+    let b_day = calendar_day(b);
+    a_day.is_some() && a_day == b_day
+}
+
+fn venue_key(event: &EventResponse) -> Option<String> {
+    let name = event.venue.as_ref()?.name.as_deref()?;
+    Some(normalize_artist_name(name))
+}
+
+/// The calendar-day portion of `event.dates` (both sources' dates are UTC
+/// ISO 8601 strings, so a plain string split is enough — no timezone math
+/// needed to compare "same day").
+fn calendar_day(event: &EventResponse) -> Option<&str> {
+    event
+        .dates
+        .as_deref()
+        .map(|d| d.split('T').next().unwrap_or(d))
+}
+
+/// When both sides have structured performer data, require at least one
+/// name to match (exact-normalized, same discipline as personalization
+/// matching) before confirming a venue+date match — guards against, e.g., a
+/// matinee and an evening show at the same venue on the same day getting
+/// merged. When either side lacks performer data, venue+date alone is
+/// already the strongest signal available, so it stands on its own.
+fn performer_confirms_or_absent(tm: &EventResponse, phq: &EventResponse) -> bool {
+    let tm_names = performer_names(tm);
+    let phq_names = performer_names(phq);
+
+    match (tm_names, phq_names) {
+        (Some(tm_names), Some(phq_names)) => tm_names.intersection(&phq_names).next().is_some(),
+        _ => true,
+    }
+}
+
+fn performer_names(event: &EventResponse) -> Option<HashSet<String>> {
+    let performers = event.performers.as_ref()?;
+    let names: HashSet<String> = performers
+        .iter()
+        .filter_map(|p| p.name.as_deref())
+        .map(normalize_artist_name)
+        .collect();
+    (!names.is_empty()).then_some(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::types::{Performer, Source, VenueResponse};
+
+    fn event(id: &str, venue: &str, date: &str) -> EventResponse {
+        EventResponse {
+            id: id.to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some(venue.to_string()),
+                location: None,
+                city: None,
+            }),
+            images: vec![],
+            dates: Some(date.to_string()),
+            dates_pretty: None,
+            classifications: None,
+            performers: None,
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+            source: Source::Ticketmaster,
+            rank: None,
+            predicted_attendance: None,
+        }
+    }
+
+    fn with_performers(mut e: EventResponse, names: &[&str]) -> EventResponse {
+        e.performers = Some(
+            names
+                .iter()
+                .map(|n| Performer {
+                    name: Some(n.to_string()),
+                    id: None,
+                    classifications: None,
+                    external_links: None,
+                    images: None,
+                })
+                .collect(),
+        );
+        e
+    }
+
+    fn phq_event(id: &str, venue: &str, date: &str, rank: u8) -> EventResponse {
+        let mut e = event(id, venue, date);
+        e.source = Source::PredictHq;
+        e.rank = Some(rank);
+        e.predicted_attendance = Some(500);
+        e
+    }
+
+    #[test]
+    fn matches_on_venue_and_date_alone_when_neither_side_has_performers() {
+        let tm = vec![event("tm-1", "State Theatre", "2026-08-09T23:00:00Z")];
+        let phq = vec![phq_event(
+            "phq-1",
+            "State Theatre",
+            "2026-08-09T23:00:00Z",
+            60,
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert_eq!(enrichments.len(), 1);
+        assert_eq!(enrichments[0].id, "tm-1");
+        assert_eq!(enrichments[0].rank, Some(60));
+        assert_eq!(enrichments[0].predicted_attendance, Some(500));
+        assert_eq!(enrichments[0].source, Source::Ticketmaster);
+        assert!(new_events.is_empty());
+    }
+
+    #[test]
+    fn does_not_match_when_venue_differs() {
+        let tm = vec![event("tm-1", "State Theatre", "2026-08-09T23:00:00Z")];
+        let phq = vec![phq_event(
+            "phq-1",
+            "Merrill Auditorium",
+            "2026-08-09T23:00:00Z",
+            60,
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
+    }
+
+    #[test]
+    fn does_not_match_when_date_differs() {
+        let tm = vec![event("tm-1", "State Theatre", "2026-08-09T23:00:00Z")];
+        let phq = vec![phq_event(
+            "phq-1",
+            "State Theatre",
+            "2026-08-10T23:00:00Z",
+            60,
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
+    }
+
+    #[test]
+    fn requires_performer_confirmation_when_both_sides_have_performers() {
+        let tm = vec![with_performers(
+            event("tm-1", "Thompson's Point", "2026-08-08T23:00:00Z"),
+            &["Guster"],
+        )];
+        // Same venue+date, but a different performer entirely on both
+        // sides — e.g. a matinee vs. an evening show sharing a venue/day.
+        let phq = vec![with_performers(
+            phq_event("phq-1", "Thompson's Point", "2026-08-08T23:00:00Z", 60),
+            &["Some Other Act"],
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
+    }
+
+    #[test]
+    fn confirms_match_when_performer_names_overlap() {
+        let tm = vec![with_performers(
+            event("tm-1", "Thompson's Point", "2026-08-08T23:00:00Z"),
+            &["Guster"],
+        )];
+        let phq = vec![with_performers(
+            phq_event("phq-1", "Thompson's Point", "2026-08-08T23:00:00Z", 60),
+            &["Iron & Wine", "Guster"],
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert_eq!(enrichments.len(), 1);
+        assert!(new_events.is_empty());
+    }
+
+    #[test]
+    fn matches_when_only_predicthq_side_lacks_performers() {
+        // The Barr Brothers case: a real act with no structured PredictHQ
+        // entity — venue+date alone must still be sufficient.
+        let tm = vec![with_performers(
+            event("tm-1", "Thompson's Point", "2026-08-08T23:00:00Z"),
+            &["The Barr Brothers"],
+        )];
+        let phq = vec![phq_event(
+            "phq-1",
+            "Thompson's Point",
+            "2026-08-08T23:00:00Z",
+            39,
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert_eq!(enrichments.len(), 1);
+        assert!(new_events.is_empty());
+    }
+
+    #[test]
+    fn unmatched_predicthq_events_pass_through_unchanged_as_new_events() {
+        let tm = vec![event("tm-1", "State Theatre", "2026-08-09T23:00:00Z")];
+        let phq = vec![phq_event("phq-1", "SPACE", "2026-08-06T23:00:00Z", 37)];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
+        assert_eq!(new_events[0].id, "phq-1");
+        assert_eq!(new_events[0].source, Source::PredictHq);
+    }
+
+    #[test]
+    fn venue_match_is_case_and_punctuation_insensitive() {
+        let tm = vec![event(
+            "tm-1",
+            "One Longfellow Square",
+            "2026-08-07T23:00:00Z",
+        )];
+        let phq = vec![phq_event(
+            "phq-1",
+            "one longfellow square",
+            "2026-08-07T23:00:00Z",
+            36,
+        )];
+
+        let (enrichments, _) = reconcile_predicthq_events(&tm, phq);
+
+        assert_eq!(enrichments.len(), 1);
+    }
+
+    #[test]
+    fn no_venue_on_either_side_never_matches() {
+        let mut tm_event = event("tm-1", "placeholder", "2026-08-09T23:00:00Z");
+        tm_event.venue = None;
+        let mut phq_evt = phq_event("phq-1", "placeholder", "2026-08-09T23:00:00Z", 60);
+        phq_evt.venue = None;
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&[tm_event], vec![phq_evt]);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
+    }
+}

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -17,7 +17,16 @@
 //! attraction's upcoming shows, fully paginated) — plus `fetch_events_near`,
 //! a non-streaming, non-windowed entry point used by
 //! `services::playlist_builder` to find nearby artists without paying for
-//! the map's full windowed pagination on every playlist build/update.
+//! the map's full windowed pagination on every playlist build/update
+//! (deliberately Ticketmaster-only — see `get_concerts_tm_stream` for why
+//! PredictHQ isn't part of this path).
+//!
+//! `get_concerts_tm_stream` also reconciles PredictHQ against Ticketmaster:
+//! Ticketmaster streams progressively exactly as it always has, and once
+//! both fetches complete, PredictHQ-sourced enrichment
+//! (`rank`/`predicted_attendance` on a matching Ticketmaster event) and
+//! genuinely new PredictHQ-only events are emitted as a second wave. See
+//! `crate::events::reconcile_predicthq_events` for the matching itself.
 
 mod client;
 mod dates;
@@ -30,7 +39,7 @@ pub(crate) use normalize::normalize_event;
 
 use crate::error::AppError;
 use crate::events::types::EventResponse;
-use crate::events::{apply_personalization, dedupe_key};
+use crate::events::{apply_personalization, dedupe_key, reconcile_predicthq_events};
 use crate::spotify::spotify_handlers::resolve_account_from_cookie_lenient;
 use crate::state::AppState;
 use axum::{
@@ -93,8 +102,31 @@ pub async fn get_concerts_tm_stream(
     let api_key = state.ticketmaster_key.clone();
     let radius = params.radius;
 
+    // Kicked off now so it runs concurrently with the Ticketmaster windowed
+    // fetch below rather than adding its own round-trip afterward. Absent
+    // entirely (no task spawned) when PREDICTHQ_API_KEY isn't configured —
+    // this whole feature is best-effort and must never hold up or break
+    // Ticketmaster's own results.
+    let predicthq_handle = state.predicthq_api_key.clone().map(|predicthq_key| {
+        let client = state.client.clone();
+        let within = format!("{radius}mi@{},{}", params.latitude, params.longitude);
+        let start_gte = params.start.clone();
+        let start_lte = params.end.clone();
+        tokio::spawn(async move {
+            crate::predicthq::search_concerts(
+                &client,
+                &predicthq_key,
+                &within,
+                &start_gte,
+                &start_lte,
+            )
+            .await
+        })
+    });
+
     let stream: BoxStream<'static, Result<Bytes, AppError>> = async_stream::try_stream! {
         let mut seen = HashSet::<String>::new();
+        let mut ticketmaster_events = Vec::<EventResponse>::new();
 
         for (start, end) in windows {
             let mut page = 0_u32;
@@ -139,6 +171,7 @@ pub async fn get_concerts_tm_stream(
                             .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
                         line.push(b'\n');
                         yield Bytes::from(line);
+                        ticketmaster_events.push(event);
                     }
                 }
 
@@ -151,6 +184,48 @@ pub async fn get_concerts_tm_stream(
                 }
 
                 page += 1;
+            }
+        }
+
+        // Second wave: reconcile PredictHQ against everything Ticketmaster
+        // just streamed. A failed/absent fetch degrades to "no PredictHQ
+        // data this request" rather than an error — this feature is
+        // additive and must never take down event browsing.
+        let predicthq_events = match predicthq_handle {
+            Some(handle) => match handle.await {
+                Ok(Ok(raw_events)) => raw_events
+                    .into_iter()
+                    .map(crate::predicthq::normalize_predicthq_event)
+                    .collect(),
+                Ok(Err(err)) => {
+                    tracing::warn!(error = %err, "failed to fetch PredictHQ events, skipping");
+                    Vec::new()
+                }
+                Err(join_err) => {
+                    tracing::warn!(error = %join_err, "PredictHQ fetch task failed, skipping");
+                    Vec::new()
+                }
+            },
+            None => Vec::new(),
+        };
+
+        if !predicthq_events.is_empty() {
+            let (enrichments, new_events) =
+                reconcile_predicthq_events(&ticketmaster_events, predicthq_events);
+
+            for event in enrichments {
+                let mut line = serde_json::to_vec(&event)
+                    .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
+                line.push(b'\n');
+                yield Bytes::from(line);
+            }
+
+            for mut event in new_events {
+                apply_personalization(&mut event, &personalization_matches);
+                let mut line = serde_json::to_vec(&event)
+                    .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
+                line.push(b'\n');
+                yield Bytes::from(line);
             }
         }
     }

--- a/apps/web/src/hooks/eventsStream.ts
+++ b/apps/web/src/hooks/eventsStream.ts
@@ -40,5 +40,10 @@ export type EventResponse = {
    * expansion rather than being one of the caller's own top artists — names
    * the top artist that produced the match. */
   matchedVia?: string | null
+  source: "ticketmaster" | "predicthq"
+  /** PredictHQ's 0-100 rank, when available (native PredictHQ events, or a
+   * Ticketmaster event enriched via cross-source dedup). */
+  rank?: number | null
+  predictedAttendance?: number | null
 }
 

--- a/apps/web/src/reducers/events.test.ts
+++ b/apps/web/src/reducers/events.test.ts
@@ -15,6 +15,7 @@ function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
     name: "Test Event",
     images: [],
     dates: "2026-08-01T20:00:00Z",
+    source: "ticketmaster",
     ...overrides,
   }
 }
@@ -152,7 +153,7 @@ describe("eventsReducer", () => {
     expect(next.eventsByDate["2026-08-01"]).toEqual([event])
   })
 
-  it("UPSERT_STREAMED_EVENT does not insert a duplicate of the same event", () => {
+  it("UPSERT_STREAMED_EVENT collapses a duplicate of the same event into one entry, not two", () => {
     const event = makeEvent({
       id: "tm-1",
       dates: "2026-08-01T20:00:00Z",
@@ -174,7 +175,37 @@ describe("eventsReducer", () => {
     })
 
     expect(afterSecond.eventsByDate["2026-08-01"]).toHaveLength(1)
-    expect(afterSecond).toBe(afterFirst)
+  })
+
+  it("UPSERT_STREAMED_EVENT replaces a matching event with the later payload rather than discarding it", () => {
+    // This is what makes cross-source enrichment work: the backend re-emits
+    // the same Ticketmaster event id with rank/predictedAttendance attached
+    // once PredictHQ reconciliation completes, and that update must actually
+    // reach the UI instead of being silently dropped as "already exists".
+    const original = makeEvent({
+      id: "tm-1",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "The Venue" },
+    })
+    const enriched = makeEvent({
+      id: "tm-1",
+      dates: "2026-08-01T20:00:00Z",
+      venue: { name: "The Venue" },
+      rank: 62,
+      predictedAttendance: 900,
+    })
+
+    const afterFirst = eventsReducer(initialEventsState, {
+      type: "UPSERT_STREAMED_EVENT",
+      payload: original,
+    })
+    const afterSecond = eventsReducer(afterFirst, {
+      type: "UPSERT_STREAMED_EVENT",
+      payload: enriched,
+    })
+
+    expect(afterSecond.eventsByDate["2026-08-01"]).toHaveLength(1)
+    expect(afterSecond.eventsByDate["2026-08-01"][0]).toEqual(enriched)
   })
 
   it("SELECT_EVENTS replaces selectedEvents", () => {

--- a/apps/web/src/reducers/events.ts
+++ b/apps/web/src/reducers/events.ts
@@ -79,15 +79,23 @@ function eventsReducer(state: EventsState, action: EventsAction): EventsState {
       const dateKey = eventDateKey(event)
       const existingBucket = state.eventsByDate[dateKey] ?? []
 
-      const alreadyExists = existingBucket.some((existing) =>
+      const existingIndex = existingBucket.findIndex((existing) =>
         sameEvent(existing, event)
       )
 
-      if (alreadyExists) {
-        return state
-      }
-
-      const nextBucket = sortEvents([...existingBucket, event])
+      // A later emission for the same event (by sameEvent's identity) always
+      // carries at least as much information as an earlier one — e.g. the
+      // cross-source reconciliation pass re-emitting a Ticketmaster event
+      // with rank/predictedAttendance attached — so replace rather than
+      // discard on a match.
+      const nextBucket =
+        existingIndex === -1
+          ? sortEvents([...existingBucket, event])
+          : sortEvents(
+              existingBucket.map((existing, i) =>
+                i === existingIndex ? event : existing
+              )
+            )
 
       return {
         ...state,


### PR DESCRIPTION
## Summary

Second and final PR for roadmap Phase 2 ("Second source: PredictHQ"). Stacked on #42 (schema/client/normalize) — this is the part that actually surfaces PredictHQ data to users.

## Changes

- **`apps/api/src/events/reconcile.rs`** — `reconcile_predicthq_events` matches a PredictHQ event to an already-streamed Ticketmaster event on venue (normalized) + calendar date as the required baseline, confirmed by performer-name overlap only when *both* sides have structured performer data — falls back to venue+date alone otherwise, since roughly a third of PredictHQ's own concert events (including real touring acts, e.g. The Barr Brothers) carry no performer entity at all. A match enriches the existing Ticketmaster event with `rank`/`predicted_attendance`; no match means the PredictHQ event becomes its own new card. Pure function, 9 unit tests.
- **`ticketmaster_stream::get_concerts_tm_stream`** — spawns the PredictHQ fetch concurrently with Ticketmaster's own windowed fetch (no added round-trip), skipping entirely (with a log line) if the key is unset or the fetch fails — this feature must never hold up or break event browsing. Ticketmaster streams progressively exactly as before; once both fetches complete, reconciliation runs and enrichments + new PredictHQ cards emit as a second wave (personalization is applied to the new cards too).
- **Fixed a real bug this design depends on**: `apps/web/src/reducers/events.ts`'s `UPSERT_STREAMED_EVENT` was named "upsert" but only ever inserted-if-not-exists — a second emission for an already-seen event id was silently discarded. That would have swallowed every enrichment update before it ever reached the UI. Now replaces on match instead, which is safe for the pre-existing same-source-duplicate case too (a later emission for the same identity is always at least as informative as an earlier one, never a regression).
- `EventResponse`'s `source`/`rank`/`predictedAttendance` fields (added to the Rust backend in #42) had never been added to the frontend TypeScript type — fixed here since this is the first PR that actually needs them.

## Test plan

- [x] `cargo check` / `cargo clippy --bins --tests -- -D clippy::all` / `cargo fmt --check` clean, simulated exactly as CI runs (`SQLX_OFFLINE=true`, no local `.env`)
- [x] `cargo test` — 64 passed (55 existing + 9 new `reconcile` tests covering venue/date matching, performer confirmation, the no-performer-entity fallback, and pass-through of unmatched events)
- [x] `tsc -b` / `eslint` / `vitest run` clean, 60 frontend tests passed (added a test specifically covering the enrichment-replace scenario, and fixed an existing test that asserted the old, incompatible discard-on-duplicate behavior)
- [x] **Verified against the real, live PredictHQ + Ticketmaster APIs together**, not just unit tests: confirmed exact enrichment behavior for two real overlapping shows (Hollywood Undead, Bruce Hornsby & The Noisemakers) — each appears exactly twice in the raw ndjson stream, first unenriched then with `rank`/`predictedAttendance` attached, with no third duplicate PredictHQ-sourced card for either
- [x] Live-verified in a running dev instance: Denver's event count went from a handful to dozens of pins/cards with the PredictHQ contribution live, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)