### PR TITLE
Improve PredictHQ dedup and backfill missing images/links

### DIFF
--- a/apps/api/src/apple_music/artwork_cache.rs
+++ b/apps/api/src/apple_music/artwork_cache.rs
@@ -1,0 +1,156 @@
+//! In-memory best-effort cache mapping a normalized artist name to Apple
+//! Music catalog artwork/URL, used to backfill images and links for
+//! PredictHQ-only events (which carry neither — see `crate::predicthq`).
+//!
+//! Deliberately process-local with no TTL: artist artwork rarely changes,
+//! entries are tiny, and this is a "nice to have" enrichment rather than a
+//! source of truth — a stale or absent entry just means one card renders
+//! without a photo. Misses are cached too (as `None`), since a meaningful
+//! fraction of PredictHQ titles aren't clean artist names (e.g. "The Sauce
+//! w/ Jeff Beam") and would otherwise be re-searched, fruitlessly, on every
+//! request that includes them.
+
+use std::collections::HashMap;
+use tokio::sync::Mutex;
+
+use crate::apple_music::client::{AppleMusicClient, Artwork};
+use crate::spotify::client::normalize_artist_name;
+
+#[derive(Debug, Clone)]
+pub struct ArtistArtwork {
+    pub artwork: Option<Artwork>,
+    pub apple_music_url: Option<String>,
+}
+
+#[derive(Default)]
+pub struct ArtworkCache {
+    entries: Mutex<HashMap<String, Option<ArtistArtwork>>>,
+}
+
+impl ArtworkCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Looks up `name`'s artwork, using the cache when possible and falling
+    /// back to a live Apple Music catalog search on a miss.
+    ///
+    /// Verifies the top search result's own name actually matches the
+    /// query (Apple's search can return an unrelated artist for an
+    /// ambiguous or messy term) — an unverified match would silently
+    /// attach the wrong photo to an event, which is worse than showing no
+    /// photo at all. Returns `None` on no confident match, no artwork, or
+    /// any API error; never propagates a failure, since this is a
+    /// best-effort enrichment that must not break event streaming.
+    pub async fn get_or_fetch(
+        &self,
+        am: &AppleMusicClient,
+        token: &str,
+        name: &str,
+    ) -> Option<ArtistArtwork> {
+        let key = normalize_artist_name(name);
+        if key.is_empty() {
+            return None;
+        }
+
+        if let Some(cached) = self.entries.lock().await.get(&key) {
+            return cached.clone();
+        }
+
+        let result = Self::fetch(am, token, name, &key).await;
+        self.entries.lock().await.insert(key, result.clone());
+        result
+    }
+
+    async fn fetch(
+        am: &AppleMusicClient,
+        token: &str,
+        name: &str,
+        normalized_query: &str,
+    ) -> Option<ArtistArtwork> {
+        let results = am.search_artists(token, name, 1).await.ok()?;
+        let attrs = results.into_iter().next()?.attributes?;
+
+        if normalize_artist_name(&attrs.name) != normalized_query {
+            return None;
+        }
+        if attrs.artwork.is_none() && attrs.url.is_none() {
+            return None;
+        }
+
+        Some(ArtistArtwork {
+            artwork: attrs.artwork,
+            apple_music_url: attrs.url,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `fetch` requires a live Apple Music API call, so it isn't exercised
+    // here — same reasoning as `predicthq::client`'s `#[ignore]`-gated real
+    // API tests, kept out of the default `cargo test` run since CI has no
+    // network access. Only the pure, network-free short-circuit is
+    // covered directly.
+    #[tokio::test]
+    async fn empty_name_short_circuits_without_touching_the_network_or_cache() {
+        let cache = ArtworkCache::new();
+        let am = AppleMusicClient::new(reqwest::Client::new(), "us".to_string());
+        assert!(cache.get_or_fetch(&am, "token", "").await.is_none());
+        assert!(cache.entries.lock().await.is_empty());
+    }
+
+    /// Hits the real Apple Music API — not run by default (needs
+    /// `APPLE_MUSIC_TEAM_ID`/`APPLE_MUSIC_KEY_ID`/`APPLE_MUSIC_PRIVATE_KEY`
+    /// and network access). Run manually with `cargo test -- --ignored` to
+    /// confirm the name-match verification and cache both behave correctly
+    /// against real search results, not just hand-built fixtures.
+    #[tokio::test]
+    #[ignore]
+    async fn real_lookup_returns_verified_artwork_and_caches_it() {
+        use crate::apple_music::auth::{AppleMusicCredentials, DeveloperTokenManager};
+
+        let creds = AppleMusicCredentials::from_env();
+        let dev_token = DeveloperTokenManager::new(creds)
+            .get_token()
+            .await
+            .expect("should be able to mint a developer token");
+
+        let am = AppleMusicClient::new(reqwest::Client::new(), "us".to_string());
+        let cache = ArtworkCache::new();
+
+        // A clean, unambiguous artist name — expect a confident match with
+        // real, resolvable artwork and an apple_music_url.
+        let found = cache
+            .get_or_fetch(&am, &dev_token, "Role Model")
+            .await
+            .expect("Role Model should resolve to a real Apple Music artist");
+        assert!(found.artwork.is_some(), "expected real artwork");
+        assert!(
+            found.artwork.as_ref().unwrap().url.contains("{w}"),
+            "raw Apple artwork url should still be a template at this layer"
+        );
+        assert!(found.apple_music_url.is_some());
+
+        // Same name again should be served from cache, not a second
+        // network round-trip -- can't observe that directly here, but at
+        // minimum the result must be identical.
+        let cached = cache.get_or_fetch(&am, &dev_token, "Role Model").await;
+        assert_eq!(
+            cached.map(|a| a.apple_music_url),
+            Some(found.apple_music_url)
+        );
+
+        // A messy, non-artist PredictHQ-style title should not produce a
+        // false positive match.
+        let messy = cache
+            .get_or_fetch(&am, &dev_token, "The Sauce w/ Jeff Beam")
+            .await;
+        assert!(
+            messy.is_none(),
+            "expected no confident match for a non-artist title, got {messy:?}"
+        );
+    }
+}

--- a/apps/api/src/apple_music/mod.rs
+++ b/apps/api/src/apple_music/mod.rs
@@ -1,3 +1,4 @@
+pub mod artwork_cache;
 pub mod auth;
 pub mod client;
 pub mod handlers;

--- a/apps/api/src/events/reconcile.rs
+++ b/apps/api/src/events/reconcile.rs
@@ -53,20 +53,88 @@ fn find_matching_ticketmaster_event<'a>(
 }
 
 fn venue_and_date_match(a: &EventResponse, b: &EventResponse) -> bool {
-    let a_venue = venue_key(a);
-    let b_venue = venue_key(b);
-    if a_venue.is_none() || a_venue != b_venue {
+    let a_day = calendar_day(a);
+    let b_day = calendar_day(b);
+    if a_day.is_none() || a_day != b_day {
         return false;
     }
 
-    let a_day = calendar_day(a);
-    let b_day = calendar_day(b);
-    a_day.is_some() && a_day == b_day
+    venues_match(a, b)
+}
+
+/// Venues match on an exact normalized name, e.g. both sources spelling
+/// "Thompson's Point" the same way once case/punctuation is stripped.
+///
+/// Real sources don't always agree on *which* name to use for the same
+/// physical venue, though — observed in Portland, ME testing: PredictHQ
+/// attached a show to a named room/stage ("The Rink at Thompson's Point")
+/// while Ticketmaster used the parent venue's own name ("Thompson's
+/// Point") for the identical show. Neither normalized string matches the
+/// other, but they sit ~0.15 miles apart. So we also accept a close geo
+/// match — but only when it's confirmed by an actual performer-name
+/// overlap (not the "absent = pass" leniency `performer_confirms_or_absent`
+/// allows for the exact-name path). Proximity alone is too weak a signal:
+/// two genuinely different real venues in this same test market (State
+/// Theatre and Aura) sit only ~0.28 miles apart — well within a naive
+/// "same complex" radius.
+fn venues_match(a: &EventResponse, b: &EventResponse) -> bool {
+    let a_venue = venue_key(a);
+    let b_venue = venue_key(b);
+    if a_venue.is_some() && a_venue == b_venue {
+        return true;
+    }
+
+    match (venue_coords(a), venue_coords(b)) {
+        (Some(a_coords), Some(b_coords)) => {
+            distance_miles(a_coords, b_coords) <= VENUE_PROXIMITY_MILES_THRESHOLD
+                && performer_names_overlap(a, b)
+        }
+        _ => false,
+    }
 }
 
 fn venue_key(event: &EventResponse) -> Option<String> {
     let name = event.venue.as_ref()?.name.as_deref()?;
     Some(normalize_artist_name(name))
+}
+
+/// Miles within which two differently-named venues are treated as the same
+/// physical complex, provided performer names also confirm the match. Wide
+/// enough to cover a named sub-venue (a room, stage, or rink) within a
+/// larger complex; tighter than the ~0.28mi gap observed between two
+/// genuinely distinct downtown venues in the same test market.
+const VENUE_PROXIMITY_MILES_THRESHOLD: f64 = 0.2;
+
+fn venue_coords(event: &EventResponse) -> Option<(f64, f64)> {
+    let location = event.venue.as_ref()?.location.as_ref()?;
+    let lat: f64 = location.latitude.as_deref()?.parse().ok()?;
+    let lng: f64 = location.longitude.as_deref()?.parse().ok()?;
+    Some((lat, lng))
+}
+
+/// Approximate great-circle distance in miles between two lat/lng points
+/// (equirectangular approximation — accurate enough at sub-mile scale
+/// without pulling in a geodesy dependency for what's just a "same venue
+/// complex?" sanity check).
+fn distance_miles(a: (f64, f64), b: (f64, f64)) -> f64 {
+    const EARTH_RADIUS_MILES: f64 = 3958.8;
+    let (lat1, lng1) = a;
+    let (lat2, lng2) = b;
+    let avg_lat_rad = ((lat1 + lat2) / 2.0).to_radians();
+    let dx = (lng2 - lng1).to_radians() * avg_lat_rad.cos();
+    let dy = (lat2 - lat1).to_radians();
+    EARTH_RADIUS_MILES * (dx * dx + dy * dy).sqrt()
+}
+
+/// Strict performer-name overlap — unlike `performer_confirms_or_absent`,
+/// missing performer data on either side does NOT pass. Used to gate the
+/// geo-proximity venue fallback, where positive confirmation is required
+/// because proximity alone isn't a strong enough signal.
+fn performer_names_overlap(a: &EventResponse, b: &EventResponse) -> bool {
+    match (performer_names(a), performer_names(b)) {
+        (Some(a_names), Some(b_names)) => a_names.intersection(&b_names).next().is_some(),
+        _ => false,
+    }
 }
 
 /// The calendar-day portion of `event.dates` (both sources' dates are UTC
@@ -132,6 +200,14 @@ mod tests {
             rank: None,
             predicted_attendance: None,
         }
+    }
+
+    fn with_location(mut e: EventResponse, lat: &str, lng: &str) -> EventResponse {
+        e.venue.as_mut().unwrap().location = Some(crate::events::types::LocationResponse {
+            latitude: Some(lat.to_string()),
+            longitude: Some(lng.to_string()),
+        });
+        e
     }
 
     fn with_performers(mut e: EventResponse, names: &[&str]) -> EventResponse {
@@ -297,6 +373,94 @@ mod tests {
         let (enrichments, _) = reconcile_predicthq_events(&tm, phq);
 
         assert_eq!(enrichments.len(), 1);
+    }
+
+    #[test]
+    fn matches_via_geo_proximity_when_venue_names_differ_but_performer_confirms() {
+        // The real Portland, ME case: Ticketmaster's "Role Model Presents:
+        // Chuck Comes Home" at "Thompson's Point" vs. PredictHQ's "Role
+        // Model" at "The Rink at Thompson's Point" -- same show, same day,
+        // ~0.15 miles apart, names don't normalize to the same string.
+        let tm = vec![with_location(
+            with_performers(
+                event("tm-1", "Thompson's Point", "2026-08-07T23:00:00Z"),
+                &["Role Model"],
+            ),
+            "43.648693",
+            "-70.289493",
+        )];
+        let phq = vec![with_location(
+            with_performers(
+                phq_event(
+                    "phq-1",
+                    "The Rink at Thompson's Point",
+                    "2026-08-07T23:00:00Z",
+                    60,
+                ),
+                &["Role Model"],
+            ),
+            "43.649943",
+            "-70.291827",
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert_eq!(enrichments.len(), 1);
+        assert_eq!(enrichments[0].id, "tm-1");
+        assert!(new_events.is_empty());
+    }
+
+    #[test]
+    fn geo_proximity_alone_without_performer_confirmation_does_not_match() {
+        // Two genuinely different venues in the same test market sitting
+        // close together (State Theatre / Aura, ~0.28mi apart) must not
+        // merge just because they're near each other and neither side
+        // happens to carry performer data.
+        let tm = vec![with_location(
+            event("tm-1", "State Theatre", "2026-08-09T23:00:00Z"),
+            "43.65397160",
+            "-70.26329240",
+        )];
+        let phq = vec![with_location(
+            phq_event("phq-1", "Aura", "2026-08-09T23:00:00Z", 50),
+            "43.65655100",
+            "-70.25894300",
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
+    }
+
+    #[test]
+    fn geo_proximity_with_conflicting_performers_does_not_match() {
+        let tm = vec![with_location(
+            with_performers(
+                event("tm-1", "Thompson's Point", "2026-08-07T23:00:00Z"),
+                &["Role Model"],
+            ),
+            "43.648693",
+            "-70.289493",
+        )];
+        let phq = vec![with_location(
+            with_performers(
+                phq_event(
+                    "phq-1",
+                    "The Rink at Thompson's Point",
+                    "2026-08-07T23:00:00Z",
+                    60,
+                ),
+                &["Some Other Act"],
+            ),
+            "43.649943",
+            "-70.291827",
+        )];
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&tm, phq);
+
+        assert!(enrichments.is_empty());
+        assert_eq!(new_events.len(), 1);
     }
 
     #[test]

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -28,6 +28,7 @@ use sqlx::migrate;
 use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
 use tracing_subscriber::EnvFilter;
 
+use apple_music::artwork_cache::ArtworkCache;
 use apple_music::auth::{AppleMusicCredentials, DeveloperTokenManager, MusicUserTokenStore};
 use apple_music::client::AppleMusicClient;
 use auth::{ClientCredentialsManager, SpotifyCredentials, UserTokenManager};
@@ -124,6 +125,7 @@ pub async fn build_app() -> Result<Router> {
         apple_music_client: apple_client,
         apple_dev_token: apple_dev,
         apple_user_token: apple_user,
+        apple_artwork_cache: Arc::new(ArtworkCache::new()),
         predicthq_api_key,
         cookie_domain: config.cookie_domain.clone(),
         cookie_secure: config.cookie_secure,

--- a/apps/api/src/predicthq/artwork.rs
+++ b/apps/api/src/predicthq/artwork.rs
@@ -1,0 +1,186 @@
+//! Backfills images/url for PredictHQ-only events using the same Apple
+//! Music catalog artist lookup already powering the on-demand artist
+//! panel (`apple_music::handlers::get_artist_info`) — see
+//! `crate::apple_music::artwork_cache` for the caching/name-verification
+//! rules this relies on.
+//!
+//! Deliberately scoped to *unmatched* PredictHQ events (the `new_events`
+//! half of `reconcile_predicthq_events`'s output): a matched event is a
+//! clone of its Ticketmaster counterpart, which already has a real photo
+//! and ticket URL, so backfilling there would just be wasted API calls.
+
+use futures::{StreamExt, stream};
+
+use crate::apple_music::artwork_cache::{ArtistArtwork, ArtworkCache};
+use crate::apple_music::client::AppleMusicClient;
+use crate::events::types::{EventResponse, Images};
+
+/// Apple Music artwork URLs are a template (`.../{w}x{h}bb.jpg`) that must
+/// be resolved to a concrete size before use — the frontend's own
+/// `buildArtworkUrl` does this for the on-demand artist lookup, but
+/// `EventResponse.images` is rendered as a plain, ready-to-use URL
+/// (`ResponsiveImage` has no notion of Apple's template), so it happens
+/// here instead.
+const ARTWORK_SIZE_PX: u32 = 1200;
+
+/// Caps how many Apple Music lookups run at once. A cold cache in a dense
+/// market can mean a couple dozen unmatched events in one request — firing
+/// all of them at once was tried first and reliably tripped Apple's rate
+/// limiter (confirmed live: ~30 concurrent lookups produced 32 real 429s
+/// in one request), which just pushes the same work through
+/// `http_utils::request_with_backoff`'s retry/backoff instead of avoiding
+/// it. A small bound still gets most of the concurrency benefit over fully
+/// serial lookups without provoking the limiter in the first place.
+const MAX_CONCURRENT_LOOKUPS: usize = 4;
+
+/// Populates `images`/`url` on `events` in place from the first performer
+/// with a usable Apple Music match, looking up a bounded number of events
+/// concurrently (see `MAX_CONCURRENT_LOOKUPS`) rather than either fully
+/// serially or all at once.
+///
+/// Best-effort throughout: an event with no performer name, no confident
+/// Apple Music match, or that already has its own image/url, is left
+/// exactly as PredictHQ gave it rather than showing something misleading.
+pub(crate) async fn backfill_artwork(
+    events: &mut [EventResponse],
+    am: &AppleMusicClient,
+    token: &str,
+    cache: &ArtworkCache,
+) {
+    // Collected as owned `String`s up front (rather than borrowing from
+    // `events` inside the stream combinator below) so each lookup future
+    // only captures `am`/`token`/`cache` from this function's own scope --
+    // borrowing `events` there instead runs into a higher-ranked lifetime
+    // error, since `buffered` needs the map closure to work generically
+    // over the stream item's lifetime.
+    let candidate_names: Vec<Vec<String>> = events
+        .iter()
+        .map(|event| {
+            if !event.images.is_empty() && event.url.is_some() {
+                return Vec::new();
+            }
+            event
+                .performers
+                .as_ref()
+                .map(|performers| performers.iter().filter_map(|p| p.name.clone()).collect())
+                .unwrap_or_default()
+        })
+        .collect();
+
+    let results: Vec<Option<ArtistArtwork>> = stream::iter(candidate_names)
+        .map(|names| async move {
+            for name in &names {
+                if let Some(found) = cache.get_or_fetch(am, token, name).await {
+                    return Some(found);
+                }
+            }
+            None
+        })
+        .buffered(MAX_CONCURRENT_LOOKUPS)
+        .collect::<Vec<_>>()
+        .await;
+
+    for (event, found) in events.iter_mut().zip(results) {
+        let Some(found) = found else { continue };
+
+        if event.images.is_empty()
+            && let Some(artwork) = &found.artwork
+        {
+            let url = artwork
+                .url
+                .replace("{w}", &ARTWORK_SIZE_PX.to_string())
+                .replace("{h}", &ARTWORK_SIZE_PX.to_string());
+            event.images = vec![Images {
+                url,
+                width: Some(ARTWORK_SIZE_PX as i32),
+                height: Some(ARTWORK_SIZE_PX as i32),
+                ratio: None,
+                // Signals this is a stand-in artist photo, not a photo of
+                // the event itself — same field Ticketmaster-side fallback
+                // images already use.
+                fallback: Some(true),
+            }];
+        }
+
+        if event.url.is_none() {
+            event.url = found.apple_music_url;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::types::{Performer, Source, VenueResponse};
+
+    fn phq_event(id: &str, performer: Option<&str>) -> EventResponse {
+        EventResponse {
+            id: id.to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some("Some Venue".to_string()),
+                location: None,
+                city: None,
+            }),
+            images: vec![],
+            dates: Some("2026-08-09T23:00:00Z".to_string()),
+            dates_pretty: None,
+            classifications: None,
+            performers: performer.map(|name| {
+                vec![Performer {
+                    name: Some(name.to_string()),
+                    id: None,
+                    classifications: None,
+                    external_links: None,
+                    images: None,
+                }]
+            }),
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+            source: Source::PredictHq,
+            rank: Some(50),
+            predicted_attendance: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn leaves_events_without_performer_data_untouched() {
+        let mut events = vec![phq_event("phq-1", None)];
+        let am = AppleMusicClient::new(reqwest::Client::new(), "us".to_string());
+        let cache = ArtworkCache::new();
+
+        // No dev token needed -- there's no performer name to look up, so
+        // the network path is never reached.
+        backfill_artwork(&mut events, &am, "unused-token", &cache).await;
+
+        assert!(events[0].images.is_empty());
+        assert!(events[0].url.is_none());
+    }
+
+    #[tokio::test]
+    async fn skips_events_that_already_have_an_image_and_url() {
+        let mut event = phq_event("phq-1", Some("Role Model"));
+        event.images = vec![Images {
+            url: "https://example.com/real.jpg".to_string(),
+            width: None,
+            height: None,
+            ratio: None,
+            fallback: None,
+        }];
+        event.url = Some("https://tickets.example.com".to_string());
+        let mut events = vec![event];
+
+        let am = AppleMusicClient::new(reqwest::Client::new(), "us".to_string());
+        let cache = ArtworkCache::new();
+
+        backfill_artwork(&mut events, &am, "unused-token", &cache).await;
+
+        assert_eq!(events[0].images[0].url, "https://example.com/real.jpg");
+        assert_eq!(
+            events[0].url.as_deref(),
+            Some("https://tickets.example.com")
+        );
+    }
+}

--- a/apps/api/src/predicthq/mod.rs
+++ b/apps/api/src/predicthq/mod.rs
@@ -1,10 +1,14 @@
-//! PredictHQ as a second event source — currently just the fetch +
-//! normalize path (`client`/`normalize`), not yet wired into
-//! `/concerts/stream`. Cross-source dedup against Ticketmaster and the
-//! live-stream wiring are a separate, stacked follow-up.
+//! PredictHQ as a second event source: fetch + normalize
+//! (`client`/`normalize`), plus a best-effort Apple Music image/link
+//! backfill (`artwork`) for events that pass through
+//! `crate::events::reconcile_predicthq_events` unmatched — PredictHQ's own
+//! API provides neither field. Cross-source dedup and the live-stream
+//! wiring live in `ticketmaster_stream` and `crate::events`.
 
+mod artwork;
 mod client;
 mod normalize;
 
+pub(crate) use artwork::backfill_artwork;
 pub(crate) use client::search_concerts;
 pub(crate) use normalize::normalize_predicthq_event;

--- a/apps/api/src/state.rs
+++ b/apps/api/src/state.rs
@@ -4,6 +4,7 @@ use crate::auth::{ClientCredentialsManager, UserTokenManager};
 use crate::db::AppDatabase;
 use crate::spotify::client::SpotifyClient;
 
+use crate::apple_music::artwork_cache::ArtworkCache;
 use crate::apple_music::auth::{DeveloperTokenManager, MusicUserTokenStore};
 use crate::apple_music::client::AppleMusicClient;
 use axum_extra::extract::cookie::Key;
@@ -32,6 +33,11 @@ pub struct AppStateInner {
     pub apple_music_client: Option<AppleMusicClient>,
     pub apple_dev_token: Option<Arc<DeveloperTokenManager>>,
     pub apple_user_token: Option<Arc<MusicUserTokenStore>>,
+    /// Shared regardless of whether Apple Music is configured — cheap to
+    /// hold, and only ever consulted when `apple_music_client`/
+    /// `apple_dev_token` are also present (see
+    /// `crate::predicthq::backfill_artwork`).
+    pub apple_artwork_cache: Arc<ArtworkCache>,
 
     /// `None` when `PREDICTHQ_API_KEY` isn't set — PredictHQ isn't wired
     /// into any live route yet (see `crate::predicthq`), so this is

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -210,7 +210,7 @@ pub async fn get_concerts_tm_stream(
         };
 
         if !predicthq_events.is_empty() {
-            let (enrichments, new_events) =
+            let (enrichments, mut new_events) =
                 reconcile_predicthq_events(&ticketmaster_events, predicthq_events);
 
             for event in enrichments {
@@ -218,6 +218,34 @@ pub async fn get_concerts_tm_stream(
                     .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
                 line.push(b'\n');
                 yield Bytes::from(line);
+            }
+
+            // Best-effort image/link backfill for the PredictHQ-only cards
+            // (a matched event above is already a Ticketmaster clone with
+            // its own real photo/ticket URL, so it's excluded from this).
+            // Absent entirely when Apple Music isn't configured or its
+            // developer token can't be fetched right now — same
+            // never-block-the-feed posture as the PredictHQ fetch itself.
+            if let (Some(am), Some(dev_token_mgr)) =
+                (&state.apple_music_client, &state.apple_dev_token)
+            {
+                match dev_token_mgr.get_token().await {
+                    Ok(token) => {
+                        crate::predicthq::backfill_artwork(
+                            &mut new_events,
+                            am,
+                            &token,
+                            &state.apple_artwork_cache,
+                        )
+                        .await;
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            "failed to fetch Apple Music developer token, skipping PredictHQ image/link backfill"
+                        );
+                    }
+                }
             }
 
             for mut event in new_events {

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -19,6 +19,13 @@ import { useEventsContext } from "./providers/eventsProvider"
 import { buildArtworkUrl, normalizeBg } from "./lib/artwork"
 import { formatTime } from "./lib/dates"
 
+/** PredictHQ never provides a ticket purchase link -- when `url` is set on
+ * a PredictHQ-sourced event, it's the backend's Apple Music artist-page
+ * backfill instead (see `predicthq::artwork::backfill_artwork`). Labeling
+ * that link "Tickets" would wrongly suggest it's a place to buy tickets. */
+const eventLinkLabel = (event: Pick<EventResponse, "source">) =>
+  event.source === "predicthq" ? "Listen" : "Tickets"
+
 const EventDetails = ({
   eventData,
   otherShowtimes = [],
@@ -133,7 +140,7 @@ const EventDetails = ({
               variant="button"
               className="ml-2 shrink-0 rounded-full bg-(--color-toasted-almond-600) px-2 py-1 text-[11px] font-medium text-(--color-blush-rose-600) no-underline dark:bg-(--color-toasted-almond-dark-600) dark:text-(--color-text-primary-dark-600)"
             >
-              Tickets
+              {eventLinkLabel(eventData)}
             </Link>
           )}
         </div>
@@ -156,7 +163,7 @@ const EventDetails = ({
           href={eventData.url}
           target="_blank"
         >
-          Tickets
+          {eventLinkLabel(eventData)}
         </Link>
       )}
 
@@ -211,7 +218,7 @@ const EventDetails = ({
                     target="_blank"
                     className="text-(--color-toasted-almond-600) no-underline dark:text-(--color-text-secondary-dark-600)"
                   >
-                    Tickets
+                    {eventLinkLabel(showtime)}
                   </Link>
                 )}
               </li>
@@ -400,7 +407,7 @@ const UpcomingEvents = ({ events }: { events: EventResponse[] }) => {
               target="_blank"
               className="ml-auto text-(--color-toasted-almond-600) no-underline dark:text-(--color-text-secondary-dark-600)"
             >
-              Tickets
+              {eventLinkLabel(e)}
             </Link>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- Fix cross-source venue matching in `reconcile_predicthq_events` to catch a real dedup failure in the Portland, ME test market: PredictHQ's "Role Model" (venue: "The Rink at Thompson's Point") and Ticketmaster's "Role Model Presents: Chuck Comes Home" (venue: "Thompson's Point") are the same show, ~0.15mi apart, but the exact-normalized-name venue match failed to merge them. Adds a geo-proximity fallback gated by a strict performer-name-overlap requirement — proximity alone isn't safe, since two genuinely different real venues in this same market (State Theatre / Aura) sit only ~0.28mi apart.
- Backfill `images`/`url` for PredictHQ-only events (PredictHQ's API provides neither) by reusing the Apple Music artist lookup already used in the event-details panel. Verifies the search result's own name matches the query before attaching a photo (avoids misattributing a photo to the wrong artist), caches results in-memory, and bounds lookup concurrency to 4 at a time — live testing showed firing all lookups at once reliably tripped Apple's rate limiter (32 real 429s in one request); bounded concurrency saw zero.
- Frontend: PredictHQ-sourced events' link now reads "Listen" instead of "Tickets", since it's an Apple Music artist page, not a ticket purchase link.

## Test plan
- [x] `cargo test --lib` (73 tests incl. new reconcile.rs geo-fallback cases and artwork backfill cases)
- [x] `cargo clippy --bins --tests -- -D clippy::all` clean
- [x] `cargo fmt --check` clean
- [x] Ignored real-API test (`apple_music::artwork_cache::tests::real_lookup_returns_verified_artwork_and_caches_it`) run manually against live Apple Music API
- [x] Frontend `typecheck`/`lint`/`test` all pass
- [x] Verified live end-to-end against real Ticketmaster/PredictHQ/Apple Music APIs (Portland, ME): Role Model now merges into one enriched card instead of two; real artists ("Ryan Miller", "Terrance Simien...") get backfilled images+links; messy non-artist titles correctly stay empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)