### PR TITLE
Fix eventDateKey bucketing late shows into the next day

### DIFF
--- a/apps/web/src/reducers/events.test.ts
+++ b/apps/web/src/reducers/events.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   eventDateKey,
   eventsReducer,
@@ -21,6 +21,19 @@ function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
 }
 
 describe("eventDateKey", () => {
+  // Pinned rather than relying on the runner's own default timezone: the
+  // whole point of these cases is to exercise UTC-vs-local calendar-day
+  // boundaries, which only show up in a timezone behind UTC (a CI runner
+  // that happens to default to UTC would silently pass a broken
+  // implementation, since there'd be no offset to shift across).
+  beforeEach(() => {
+    vi.stubEnv("TZ", "America/New_York")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it("returns the YYYY-MM-DD portion of a valid date", () => {
     expect(eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }))).toBe(
       "2026-08-01"
@@ -33,6 +46,44 @@ describe("eventDateKey", () => {
 
   it("returns 'unknown' when dates is not a parseable date", () => {
     expect(eventDateKey(makeEvent({ dates: "not-a-date" }))).toBe("unknown")
+  })
+
+  it("buckets a late-evening show under its local calendar day, not the next UTC day", () => {
+    // Regression test: an 11pm Eastern show is 3am UTC the *next* day.
+    // The previous implementation extracted the UTC calendar day
+    // (toISOString().substring(0, 10)), which pushed this into
+    // "2026-08-02" even though the show itself is on Aug 1 locally.
+    expect(eventDateKey(makeEvent({ dates: "2026-08-02T03:00:00Z" }))).toBe(
+      "2026-08-01"
+    )
+  })
+
+  it("does not shift an early show that already falls on the same UTC day", () => {
+    // 4pm Eastern -- well clear of the UTC day boundary either way, so
+    // this should be unaffected by the local-vs-UTC change.
+    expect(eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }))).toBe(
+      "2026-08-01"
+    )
+  })
+
+  it("returns a bare YYYY-MM-DD date unchanged, without routing it through Date", () => {
+    // Ticketmaster events with only a localDate (no time) come through as
+    // a bare date string. Parsing that as `Date` would anchor it to UTC
+    // midnight, which reads back as the *previous* day in any timezone
+    // behind UTC -- e.g. UTC midnight Aug 1 is 8pm July 31 Eastern.
+    expect(eventDateKey(makeEvent({ dates: "2026-08-01" }))).toBe(
+      "2026-08-01"
+    )
+  })
+
+  it("treats a timezone-less local datetime as already-local, not UTC", () => {
+    // normalize_event's localDate+localTime fallback produces a string
+    // with no "Z"/offset, which JS parses as local wall-clock time
+    // already -- no conversion should happen here regardless of the
+    // runner's timezone.
+    expect(eventDateKey(makeEvent({ dates: "2026-08-01T23:30:00" }))).toBe(
+      "2026-08-01"
+    )
   })
 })
 

--- a/apps/web/src/reducers/events.ts
+++ b/apps/web/src/reducers/events.ts
@@ -15,15 +15,29 @@ type EventsState = {
 }
 
 function eventDateKey(event: EventResponse): string {
-  if (event.dates) {
-    const date = new Date(event.dates)
-    if (!Number.isNaN(date.getTime())) {
-      const formatted = date.toISOString().substring(0, 10)
-      return formatted
-    }
-  }
+  if (!event.dates) return "unknown"
 
-  return "unknown"
+  // A bare "YYYY-MM-DD" (no time-of-day -- see normalize_event's
+  // localDate-only fallback) already *is* the calendar day, with no
+  // timezone to resolve. Returning it as-is avoids routing it through
+  // `Date`, which would anchor it to UTC midnight and could read back a
+  // day early in any timezone behind UTC (see below).
+  if (/^\d{4}-\d{2}-\d{2}$/.test(event.dates)) return event.dates
+
+  const date = new Date(event.dates)
+  if (Number.isNaN(date.getTime())) return "unknown"
+
+  // Use local, not UTC, calendar-day components. `event.dates` is often a
+  // genuine UTC instant (e.g. "...T03:00:00Z"), and a late-evening show
+  // converts to the *next* UTC calendar day -- an 11pm Eastern show is
+  // 3am UTC the next day. Bucketing by the UTC day pushed those shows
+  // into tomorrow's list instead of tonight's. This assumes the viewer's
+  // timezone approximates the venue's, same as the rest of the app
+  // (lib/dates.ts formats event times via `getLocalTimeZone()`).
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
 }
 
 function sameEvent(a: EventResponse, b: EventResponse): boolean {


### PR DESCRIPTION
## Summary
- `eventDateKey` extracted the **UTC** calendar day from `event.dates` via `toISOString().substring(0, 10)`. Since `event.dates` is often a genuine UTC instant, a late-evening show (e.g. an 11pm Eastern show, which is 3am UTC the next day) was getting grouped under tomorrow's date heading in the events drawer instead of tonight's.
- Switched to local calendar-day components (`getFullYear`/`getMonth`/`getDate`), consistent with the rest of the app's existing assumption that the viewer's timezone approximates the venue's (`lib/dates.ts` already formats event times via `getLocalTimeZone()`).
- Bare `YYYY-MM-DD` dates (Ticketmaster events with only a `localDate`, no time) are now passed through directly instead of routed through `Date`, which would otherwise anchor them to UTC midnight and could read back a day *early* in any timezone behind UTC.

## Test plan
- [x] New regression tests in `events.test.ts`, with `TZ` pinned to `America/New_York` so the UTC-day-boundary cases are deterministic regardless of the CI runner's own timezone (a runner that happened to default to UTC would silently pass a broken implementation, since there'd be no offset to shift across):
  - late-evening show crossing into the next UTC day now buckets under the correct local day
  - early show unaffected (no regression)
  - bare `YYYY-MM-DD` passthrough
  - timezone-less local datetime treated as already-local
- [x] Full frontend suite: `test` (64 passed), `typecheck`, `lint` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)