### PR TITLE
Fall back to formatted address when PredictHQ has no venue entity

### DIFF
--- a/apps/api/src/predicthq/client.rs
+++ b/apps/api/src/predicthq/client.rs
@@ -61,6 +61,10 @@ pub(crate) struct PredictHqGeometry {
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct PredictHqAddress {
     pub(crate) locality: Option<String>,
+    /// Full street address, e.g. "Fore River Parkway, Portland, ME 04102,
+    /// United States of America" — used as a venue-name fallback for the
+    /// ~28% of events (confirmed live) with no `venue`-type entity at all.
+    pub(crate) formatted_address: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -206,6 +210,19 @@ mod tests {
         assert!(
             normalized.iter().all(|e| e.id.starts_with("phq:")),
             "every normalized event should have a source-prefixed id"
+        );
+        // The fix this test dataset was chosen to exercise: real events
+        // with no `venue`-type entity (~28% of this market/window,
+        // confirmed live) should still get a usable venue name via
+        // `geo.address.formatted_address`, rather than rendering no venue
+        // at all.
+        assert!(
+            normalized.iter().any(|e| e
+                .venue
+                .as_ref()
+                .is_some_and(|v| v.name.as_deref().is_some_and(|n| n.contains(",")))),
+            "expected at least one real event whose venue name came from a \
+             formatted address fallback (contains a comma), not a venue entity"
         );
     }
 }

--- a/apps/api/src/predicthq/normalize.rs
+++ b/apps/api/src/predicthq/normalize.rs
@@ -15,7 +15,14 @@ pub(crate) fn normalize_predicthq_event(e: PredictHqEvent) -> EventResponse {
     let venue = match (venue_entity, geo) {
         (None, None) => None,
         (venue_entity, geo) => Some(VenueResponse {
-            name: venue_entity.map(|v| v.name.clone()),
+            // Prefer the structured venue entity's own name; if PredictHQ
+            // didn't attach one (~28% of events, confirmed live -- often
+            // events with no performer entity either, same underlying data
+            // gap), fall back to the full street address from `geo`
+            // instead of leaving the card with no venue at all.
+            name: venue_entity
+                .map(|v| v.name.clone())
+                .or_else(|| geo.and_then(|g| g.address.as_ref()?.formatted_address.clone())),
             location: geo.map(|g| {
                 let [lng, lat] = g.geometry.coordinates;
                 LocationResponse {
@@ -224,6 +231,7 @@ mod tests {
             },
             address: Some(PredictHqAddress {
                 locality: Some("Old Orchard Beach".to_string()),
+                formatted_address: None,
             }),
         });
 
@@ -231,6 +239,59 @@ mod tests {
         let venue = normalized.venue.expect("expected venue");
         assert_eq!(venue.city.as_deref(), Some("Old Orchard Beach"));
         assert_eq!(venue.location.unwrap().latitude.as_deref(), Some("43.52"));
+    }
+
+    #[test]
+    fn falls_back_to_formatted_address_when_there_is_no_venue_entity() {
+        // The real-world gap this fixes: ~28% of live PredictHQ events
+        // (confirmed via the API) have no `venue`-type entity at all, only
+        // `geo.address` -- without this fallback the event card renders no
+        // venue whatsoever instead of a usable location string.
+        let mut event = base_event();
+        event.entities = vec![]; // no venue entity
+        event.geo = Some(PredictHqGeo {
+            geometry: PredictHqGeometry {
+                coordinates: [-70.2774488, 43.6444097],
+            },
+            address: Some(PredictHqAddress {
+                locality: Some("Portland".to_string()),
+                formatted_address: Some(
+                    "Fore River Parkway, Portland, ME 04102, United States of America".to_string(),
+                ),
+            }),
+        });
+
+        let normalized = normalize_predicthq_event(event);
+        let venue = normalized.venue.expect("expected venue");
+        assert_eq!(
+            venue.name.as_deref(),
+            Some("Fore River Parkway, Portland, ME 04102, United States of America")
+        );
+    }
+
+    #[test]
+    fn prefers_venue_entity_name_over_formatted_address_when_both_present() {
+        let mut event = base_event();
+        event.entities = vec![PredictHqEntity {
+            entity_id: "v1".to_string(),
+            name: "One Longfellow Square".to_string(),
+            entity_type: "venue".to_string(),
+        }];
+        event.geo = Some(PredictHqGeo {
+            geometry: PredictHqGeometry {
+                coordinates: [-70.2656, 43.6531],
+            },
+            address: Some(PredictHqAddress {
+                locality: Some("Portland".to_string()),
+                formatted_address: Some("181 State St, Portland, ME 04101, USA".to_string()),
+            }),
+        });
+
+        let normalized = normalize_predicthq_event(event);
+        assert_eq!(
+            normalized.venue.unwrap().name.as_deref(),
+            Some("One Longfellow Square")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes the "no venue shown at all" bug on PredictHQ-sourced event cards.

Confirmed live against the real API: ~28% of PredictHQ concert events (14/50 in a Portland, ME sample) have no `venue`-type entity at all (`entities: []`). Venue entities that *do* exist always have a name (0/36 empty in the same sample) — so the actual gap is a missing entity, not an empty name on one that exists.

For these venue-less events, `geo.address.formatted_address` (e.g. `"Fore River Parkway, Portland, ME 04102, United States of America"`) is available and gives a usable location string, in place of showing nothing. This is a sibling field to the already-captured `locality`, not something on the entity itself.

`normalize_predicthq_event` now falls back to it only when there's no venue entity name to use; a real venue entity's own name is always preferred when present.

## Test plan
- [x] `cargo test --lib` (72 passed)
- [x] `cargo clippy --bins --tests -- -D clippy::all` clean
- [x] `cargo fmt --check` clean
- [x] Ignored real-API tests (`search_concerts_deserializes_real_response`, `normalizes_every_real_event_without_panicking`) run manually against live PredictHQ data — the latter now specifically asserts at least one real event's venue name came from the formatted-address fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)