### PR TITLE
Fix search date range to use local midnight, not UTC midnight

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -10,6 +10,7 @@ import { useNavigateToLocation } from "./hooks/useNavigateToLocation"
 import { DrawerWrapper } from "./Drawer/DrawerWrapper"
 import { useIsMobile } from "./providers/Breakpoint"
 import { boundsForRadius } from "./lib/geo"
+import { dateRangeToApiParams } from "./lib/dates"
 import "mapbox-gl/dist/mapbox-gl.css"
 import "./App.css"
 import type { Feature, FeatureCollection } from "geojson"
@@ -216,8 +217,7 @@ const MapWrapper = () => {
   const { latitude, longitude, start, end } = {
     latitude: selectedCoordinates[1],
     longitude: selectedCoordinates[0],
-    start: dateRange.start.toString() + "T00:00:00Z",
-    end: dateRange.end.toString() + "T23:59:59Z",
+    ...dateRangeToApiParams(dateRange.start, dateRange.end),
   }
   useEffect(() => {
     if (!rendered) return

--- a/apps/web/src/lib/dates.test.ts
+++ b/apps/web/src/lib/dates.test.ts
@@ -1,8 +1,63 @@
 import { describe, expect, it } from "vitest"
-import { groupDatesByWeek } from "./dates"
+import { CalendarDate } from "@internationalized/date"
+import { dateRangeToApiParams, groupDatesByWeek } from "./dates"
 
 const dates = (count: number) =>
   Array.from({ length: count }, (_, i) => `d${i}`)
+
+describe("dateRangeToApiParams", () => {
+  // Timezone passed explicitly rather than relying on the runner's own
+  // default (same reasoning as eventDateKey's regression tests): the bug
+  // only shows up in a timezone behind UTC, so a CI runner defaulting to
+  // UTC would silently pass a broken implementation.
+  const EASTERN = "America/New_York"
+
+  it("anchors start to local midnight, not UTC midnight", () => {
+    // Regression test: the previous implementation did
+    // `dateRange.start.toString() + "T00:00:00Z"`, treating the selected
+    // date as if it were already UTC midnight. In US Eastern (UTC-4 in
+    // August), that's 8pm the *previous* day local time -- so a search
+    // starting "August 3" silently began at 8pm on August 2, pulling in
+    // any show starting between 8pm and midnight on August 2.
+    const { start } = dateRangeToApiParams(
+      new CalendarDate(2026, 8, 3),
+      new CalendarDate(2026, 8, 10),
+      EASTERN
+    )
+    expect(start).toBe("2026-08-03T04:00:00.000Z")
+  })
+
+  it("anchors end to local midnight of the day after the selected end date", () => {
+    const { end } = dateRangeToApiParams(
+      new CalendarDate(2026, 8, 3),
+      new CalendarDate(2026, 8, 10),
+      EASTERN
+    )
+    expect(end).toBe("2026-08-11T04:00:00.000Z")
+  })
+
+  it("matches naive UTC-midnight construction when the timezone is UTC", () => {
+    const { start, end } = dateRangeToApiParams(
+      new CalendarDate(2026, 8, 3),
+      new CalendarDate(2026, 8, 3),
+      "UTC"
+    )
+    expect(start).toBe("2026-08-03T00:00:00.000Z")
+    expect(end).toBe("2026-08-04T00:00:00.000Z")
+  })
+
+  it("defaults to the runner's local timezone when none is passed", () => {
+    // Just confirms the default parameter path doesn't throw and returns
+    // valid ISO strings -- the timezone-specific behavior above is what's
+    // actually under test.
+    const { start, end } = dateRangeToApiParams(
+      new CalendarDate(2026, 8, 3),
+      new CalendarDate(2026, 8, 3)
+    )
+    expect(() => new Date(start)).not.toThrow()
+    expect(new Date(end).getTime()).toBeGreaterThan(new Date(start).getTime())
+  })
+})
 
 describe("groupDatesByWeek", () => {
   it("returns an empty array for no dates", () => {

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -2,6 +2,7 @@ import {
   parseAbsolute,
   DateFormatter,
   getLocalTimeZone,
+  type CalendarDate,
 } from "@internationalized/date"
 
 const formatDate = (dateString: string) => {
@@ -54,6 +55,36 @@ const formatTime = (dateString: string) => {
   return formatter.format(parsedDate.toDate())
 }
 
+/** Converts a user-picked local calendar-date range into the UTC instants
+ * the `/concerts/stream` API expects, anchored to *local* midnight rather
+ * than UTC midnight.
+ *
+ * `CalendarDate.toString()` + `"T00:00:00Z"` (the previous approach) treats
+ * the selected date as if it were already UTC midnight -- in any timezone
+ * behind UTC, that's several hours before the user's actual local midnight.
+ * E.g. for a search starting "August 3" in US Eastern (UTC-4), the query
+ * window silently began at 8pm on August 2 local time, pulling in any show
+ * starting between 8pm and midnight on the day *before* the one the user
+ * selected. This was invisible before the eventDateKey fix, which grouped
+ * everything by UTC day too (masking the mismatch); now that grouping is
+ * local, that spillover shows up as events under an unexpected date
+ * heading a day earlier than the search start.
+ *
+ * `end` uses local midnight of the day *after* the selected end date
+ * (rather than a same-day 23:59:59 local instant) as a simpler and
+ * equally-correct upper bound -- the backend's date range end is treated
+ * as inclusive, so this just adds a technically-unreachable extra instant
+ * rather than risking a sub-second gap from constructing 23:59:59 by hand.
+ */
+const dateRangeToApiParams = (
+  start: CalendarDate,
+  end: CalendarDate,
+  timeZone: string = getLocalTimeZone()
+): { start: string; end: string } => ({
+  start: start.toDate(timeZone).toISOString(),
+  end: end.add({ days: 1 }).toDate(timeZone).toISOString(),
+})
+
 const groupDatesByWeek = (dates: string[]): string[][] => {
   const groups: string[][] = []
 
@@ -64,4 +95,10 @@ const groupDatesByWeek = (dates: string[]): string[][] => {
   return groups
 }
 
-export { formatDateTime, formatDate, formatTime, groupDatesByWeek }
+export {
+  formatDateTime,
+  formatDate,
+  formatTime,
+  groupDatesByWeek,
+  dateRangeToApiParams,
+}


### PR DESCRIPTION
## Summary
Fixes the regression reported after PR #45: searching with a start date of, say, August 3 sometimes returns results marked August 2.

Root cause is one level up from `eventDateKey`: `MapWrapper.tsx` built the `/concerts/stream` `start`/`end` params via `dateRange.start.toString() + "T00:00:00Z"`, treating the user's selected local calendar date as if it were already UTC midnight. In any timezone behind UTC this starts the query several hours before the user's actual local midnight — e.g. in US Eastern (UTC-4), a search starting "August 3" silently began at **8pm on August 2**, pulling in any show starting between 8pm and midnight the day before.

This was invisible before PR #45's `eventDateKey` fix, because that also grouped results by UTC day — the two bugs canceled each other out. Once grouping switched to local calendar day (the correct behavior), the spillover became visible as events under an unexpected, earlier date heading.

Fix: extracted the conversion into `dateRangeToApiParams` (`lib/dates.ts`), which anchors both boundaries to local midnight via `CalendarDate.toDate(timeZone)` instead of naive string concatenation. The backend's `date_windows` already handles arbitrary UTC instants correctly (not just midnight-aligned ones), so no backend changes were needed.

## Test plan
- [x] New unit tests for `dateRangeToApiParams` with an explicit timezone parameter (same reasoning as PR #45's tests — pinned rather than relying on the CI runner's own timezone, since the bug only manifests in a timezone behind UTC)
- [x] Full frontend suite: `test` (68 passed), `typecheck`, `lint` all clean
- [x] Verified against the real API: `curl`'d `/concerts/stream` with both the old naive-UTC-midnight boundary and the new local-midnight boundary for a real Portland, ME event ("Role Model Presents: Chuck Comes Home" at `2026-08-08T00:30:00Z`, actually 8:30pm Eastern on August 7) — confirmed it's excluded from an "August 8" search and correctly included when searching August 7 instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)