### PR TITLE
Deepen LocalDay into one module instead of four scattered implementations

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,5 @@
+# Context Map
+
+## Contexts
+
+- [Web](./apps/web/CONTEXT.md) — React/Vite frontend: map/search UI, event drawer, Spotify/Apple Music playlist integrations

--- a/apps/web/CONTEXT.md
+++ b/apps/web/CONTEXT.md
@@ -1,0 +1,9 @@
+# Web
+
+React/Vite frontend for Gigeo — the map/search UI, event drawer, and Spotify/Apple Music playlist integrations.
+
+## Language
+
+**LocalDay**:
+The calendar day an event or search boundary falls on in the viewer's own timezone. Represented as a `YYYY-MM-DD` string. Owned by `lib/dates.ts` (`eventDateKey`, `dateRangeToApiParams`). Assumes the viewer's timezone approximates the venue's — the app has no reliable source for the venue's actual timezone.
+_Avoid_: CalendarDay (the backend's `reconcile.rs` has a `calendar_day` function that means the *UTC* day, a different concept used for cross-source event matching — don't conflate the two), UTC day.

--- a/apps/web/src/lib/dates.test.ts
+++ b/apps/web/src/lib/dates.test.ts
@@ -1,9 +1,131 @@
 import { describe, expect, it } from "vitest"
 import { CalendarDate } from "@internationalized/date"
-import { dateRangeToApiParams, groupDatesByWeek } from "./dates"
+import type { EventResponse } from "../hooks/eventsStream"
+import {
+  dateRangeToApiParams,
+  eventDateKey,
+  formatDate,
+  formatDateTime,
+  formatTime,
+  groupDatesByWeek,
+} from "./dates"
 
 const dates = (count: number) =>
   Array.from({ length: count }, (_, i) => `d${i}`)
+
+const EASTERN = "America/New_York"
+
+function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
+  return {
+    id: "1",
+    name: "Test Event",
+    images: [],
+    dates: "2026-08-01T20:00:00Z",
+    source: "ticketmaster",
+    ...overrides,
+  }
+}
+
+describe("eventDateKey", () => {
+  // LocalDay: the calendar day an event falls on in the viewer's own
+  // timezone. Timezone passed explicitly rather than relying on the
+  // runner's own default -- the whole point of these cases is to exercise
+  // UTC-vs-local calendar-day boundaries, which only show up in a timezone
+  // behind UTC (a CI runner that happens to default to UTC would silently
+  // pass a broken implementation, since there'd be no offset to shift
+  // across).
+  it("returns the YYYY-MM-DD portion of a valid date", () => {
+    expect(
+      eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }), EASTERN)
+    ).toBe("2026-08-01")
+  })
+
+  it("returns 'unknown' when dates is missing", () => {
+    expect(eventDateKey(makeEvent({ dates: null }), EASTERN)).toBe("unknown")
+  })
+
+  it("returns 'unknown' when dates is not a parseable date", () => {
+    expect(eventDateKey(makeEvent({ dates: "not-a-date" }), EASTERN)).toBe(
+      "unknown"
+    )
+  })
+
+  it("buckets a late-evening show under its local calendar day, not the next UTC day", () => {
+    // Regression test: an 11pm Eastern show is 3am UTC the *next* day. The
+    // previous implementation extracted the UTC calendar day
+    // (toISOString().substring(0, 10)), which pushed this into
+    // "2026-08-02" even though the show itself is on Aug 1 locally.
+    expect(
+      eventDateKey(makeEvent({ dates: "2026-08-02T03:00:00Z" }), EASTERN)
+    ).toBe("2026-08-01")
+  })
+
+  it("does not shift an early show that already falls on the same UTC day", () => {
+    // 4pm Eastern -- well clear of the UTC day boundary either way, so
+    // this should be unaffected by the local-vs-UTC change.
+    expect(
+      eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }), EASTERN)
+    ).toBe("2026-08-01")
+  })
+
+  it("returns a bare YYYY-MM-DD date unchanged, regardless of timezone", () => {
+    // Ticketmaster events with only a localDate (no time) come through as
+    // a bare date string -- already the day, as written, with nothing to
+    // resolve. Proven independent of timezone by picking one nowhere near
+    // America/New_York.
+    expect(eventDateKey(makeEvent({ dates: "2026-08-01" }), "Asia/Tokyo")).toBe(
+      "2026-08-01"
+    )
+  })
+
+  it("treats a timezone-less local datetime as already-local, regardless of the target timezone", () => {
+    // normalize_event's localDate+localTime fallback produces a string
+    // with no "Z"/offset. Routing this through `Date` before reformatting
+    // in an arbitrary target timezone would double-convert it -- e.g. a
+    // 2am no-zone string reformatted in a different zone than whatever
+    // produced it can land on the *previous* day. Reading the date
+    // substring directly sidesteps that: proven here by using a timezone
+    // (Tokyo, UTC+9) that would expose a double-conversion if one were
+    // happening, and confirming the day doesn't move.
+    expect(
+      eventDateKey(makeEvent({ dates: "2026-08-01T23:30:00" }), "Asia/Tokyo")
+    ).toBe("2026-08-01")
+  })
+
+  it("defaults to the viewer's own timezone when none is passed", () => {
+    expect(eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }))).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/
+    )
+  })
+})
+
+describe("formatDate", () => {
+  it("formats a bare YYYY-MM-DD date", () => {
+    expect(formatDate("2026-08-01")).toBe("August 1, 2026")
+  })
+})
+
+describe("formatDateTime", () => {
+  it("formats a UTC instant in the given timezone", () => {
+    expect(formatDateTime("2026-08-01T23:00:00Z", EASTERN)).toBe(
+      "August 1 at 7:00 PM"
+    )
+  })
+
+  it("falls back to formatDate for a bare date with no time component", () => {
+    expect(formatDateTime("2026-08-01", EASTERN)).toBe("August 1, 2026")
+  })
+})
+
+describe("formatTime", () => {
+  it("formats a UTC instant's time-of-day in the given timezone", () => {
+    expect(formatTime("2026-08-01T23:00:00Z", EASTERN)).toBe("7:00 PM")
+  })
+
+  it("returns null for a bare date with no time component", () => {
+    expect(formatTime("2026-08-01", EASTERN)).toBe(null)
+  })
+})
 
 describe("dateRangeToApiParams", () => {
   // Timezone passed explicitly rather than relying on the runner's own

--- a/apps/web/src/lib/dates.ts
+++ b/apps/web/src/lib/dates.ts
@@ -4,6 +4,73 @@ import {
   getLocalTimeZone,
   type CalendarDate,
 } from "@internationalized/date"
+import type { EventResponse } from "../hooks/eventsStream"
+
+// ---------------------------------------------------------------------------
+// LocalDay — the calendar day an event or search boundary falls on in the
+// viewer's own timezone (not necessarily the venue's — the app assumes the
+// two approximate each other; see apps/web/CONTEXT.md). This is the single
+// owner of that concept: every place that needs to bucket, query, or display
+// something by local day goes through here.
+// ---------------------------------------------------------------------------
+
+const BARE_DATE = /^\d{4}-\d{2}-\d{2}$/
+const HAS_OFFSET = /[Zz]|[+-]\d{2}:?\d{2}$/
+
+/** Extracts the `YYYY-MM-DD` LocalDay from an arbitrary date-time string,
+ * honoring `timeZone` (defaults to the viewer's own).
+ *
+ * `EventResponse.dates` comes through in three shapes, and only one of them
+ * involves a real timezone conversion:
+ *
+ * - A bare `YYYY-MM-DD` (no time-of-day) — already the day, as written.
+ * - A timezone-less local wall-clock string, e.g. `"2026-08-01T23:30:00"`
+ *   (from `normalize_event`'s localDate+localTime fallback) — also already
+ *   the day, as written. Routing this through `Date` would silently assume
+ *   it's local to *this runtime*, then reformatting in an arbitrary target
+ *   `timeZone` would double-convert it — reading the date substring
+ *   directly avoids that entirely, and is correct regardless of what
+ *   `timeZone` is passed or what zone the runtime itself is in.
+ * - A genuine UTC/offset instant, e.g. `"2026-08-02T03:00:00Z"` — the only
+ *   shape that actually needs conversion. An 11pm Eastern show is 3am UTC
+ *   the *next* day; reading the UTC calendar day instead of the local one
+ *   is exactly the bug this module exists to prevent (see reducers/events.ts
+ *   history, and dateRangeToApiParams below for the matching search-side
+ *   bug it exposed).
+ */
+const toLocalDay = (
+  dateString: string,
+  timeZone: string = getLocalTimeZone()
+): string | null => {
+  if (!HAS_OFFSET.test(dateString)) {
+    const day = dateString.slice(0, 10)
+    return BARE_DATE.test(day) ? day : null
+  }
+
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) return null
+
+  // en-CA formats numeric dates as YYYY-MM-DD -- the standard idiom for
+  // getting an ISO-ordered date out of Intl without hand-assembling one
+  // from formatToParts.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date)
+}
+
+/** The LocalDay an event belongs to, or `"unknown"` if it has no (or an
+ * unparseable) `dates` value. Used to bucket events for the drawer and to
+ * key same-day/same-venue showtime grouping (`lib/groupEvents.ts`). */
+const eventDateKey = (
+  event: EventResponse,
+  timeZone: string = getLocalTimeZone()
+): string => {
+  if (!event.dates) return "unknown"
+  return toLocalDay(event.dates, timeZone) ?? "unknown"
+}
 
 const formatDate = (dateString: string) => {
   // Parse YYYY-MM-DD as UTC to avoid timezone shifts
@@ -25,7 +92,10 @@ const formatDate = (dateString: string) => {
  * have no time-of-day to format, only a date. */
 const hasTimeComponent = (dateString: string) => dateString.includes("T")
 
-const formatDateTime = (date: string) => {
+const formatDateTime = (
+  date: string,
+  timeZone: string = getLocalTimeZone()
+) => {
   if (!hasTimeComponent(date)) return formatDate(date)
 
   const parsedDate = parseAbsolute(date, "UTC")
@@ -36,12 +106,15 @@ const formatDateTime = (date: string) => {
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
-    timeZone: getLocalTimeZone(), // or a specific IANA tz
+    timeZone,
   })
   return dateFormatter.format(parsedDate.toDate())
 }
 
-const formatTime = (dateString: string) => {
+const formatTime = (
+  dateString: string,
+  timeZone: string = getLocalTimeZone()
+) => {
   if (!hasTimeComponent(dateString)) return null
 
   const parsedDate = parseAbsolute(dateString, "UTC")
@@ -50,7 +123,7 @@ const formatTime = (dateString: string) => {
     hour: "numeric",
     minute: "2-digit",
     hour12: true,
-    timeZone: getLocalTimeZone(),
+    timeZone,
   })
   return formatter.format(parsedDate.toDate())
 }
@@ -96,6 +169,7 @@ const groupDatesByWeek = (dates: string[]): string[][] => {
 }
 
 export {
+  eventDateKey,
   formatDateTime,
   formatDate,
   formatTime,

--- a/apps/web/src/lib/groupEvents.ts
+++ b/apps/web/src/lib/groupEvents.ts
@@ -1,5 +1,6 @@
 import type { EventResponse } from "../hooks/eventsStream"
-import { eventDateKey, sortEvents } from "../reducers/events"
+import { sortEvents } from "../reducers/events"
+import { eventDateKey } from "./dates"
 
 type EventGroup = {
   events: EventResponse[]

--- a/apps/web/src/reducers/events.test.ts
+++ b/apps/web/src/reducers/events.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
-  eventDateKey,
   eventsReducer,
   initialEventsState,
   sameEvent,
@@ -19,73 +18,6 @@ function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
     ...overrides,
   }
 }
-
-describe("eventDateKey", () => {
-  // Pinned rather than relying on the runner's own default timezone: the
-  // whole point of these cases is to exercise UTC-vs-local calendar-day
-  // boundaries, which only show up in a timezone behind UTC (a CI runner
-  // that happens to default to UTC would silently pass a broken
-  // implementation, since there'd be no offset to shift across).
-  beforeEach(() => {
-    vi.stubEnv("TZ", "America/New_York")
-  })
-
-  afterEach(() => {
-    vi.unstubAllEnvs()
-  })
-
-  it("returns the YYYY-MM-DD portion of a valid date", () => {
-    expect(eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }))).toBe(
-      "2026-08-01"
-    )
-  })
-
-  it("returns 'unknown' when dates is missing", () => {
-    expect(eventDateKey(makeEvent({ dates: null }))).toBe("unknown")
-  })
-
-  it("returns 'unknown' when dates is not a parseable date", () => {
-    expect(eventDateKey(makeEvent({ dates: "not-a-date" }))).toBe("unknown")
-  })
-
-  it("buckets a late-evening show under its local calendar day, not the next UTC day", () => {
-    // Regression test: an 11pm Eastern show is 3am UTC the *next* day.
-    // The previous implementation extracted the UTC calendar day
-    // (toISOString().substring(0, 10)), which pushed this into
-    // "2026-08-02" even though the show itself is on Aug 1 locally.
-    expect(eventDateKey(makeEvent({ dates: "2026-08-02T03:00:00Z" }))).toBe(
-      "2026-08-01"
-    )
-  })
-
-  it("does not shift an early show that already falls on the same UTC day", () => {
-    // 4pm Eastern -- well clear of the UTC day boundary either way, so
-    // this should be unaffected by the local-vs-UTC change.
-    expect(eventDateKey(makeEvent({ dates: "2026-08-01T20:00:00Z" }))).toBe(
-      "2026-08-01"
-    )
-  })
-
-  it("returns a bare YYYY-MM-DD date unchanged, without routing it through Date", () => {
-    // Ticketmaster events with only a localDate (no time) come through as
-    // a bare date string. Parsing that as `Date` would anchor it to UTC
-    // midnight, which reads back as the *previous* day in any timezone
-    // behind UTC -- e.g. UTC midnight Aug 1 is 8pm July 31 Eastern.
-    expect(eventDateKey(makeEvent({ dates: "2026-08-01" }))).toBe(
-      "2026-08-01"
-    )
-  })
-
-  it("treats a timezone-less local datetime as already-local, not UTC", () => {
-    // normalize_event's localDate+localTime fallback produces a string
-    // with no "Z"/offset, which JS parses as local wall-clock time
-    // already -- no conversion should happen here regardless of the
-    // runner's timezone.
-    expect(eventDateKey(makeEvent({ dates: "2026-08-01T23:30:00" }))).toBe(
-      "2026-08-01"
-    )
-  })
-})
 
 describe("sameEvent", () => {
   it("is true when ids match, regardless of other fields", () => {
@@ -135,20 +67,40 @@ describe("sameEvent", () => {
 
 describe("sortEvents", () => {
   it("sorts events by date ascending", () => {
-    const later = makeEvent({ id: "1", name: "Later", dates: "2026-08-02T00:00:00Z" })
-    const earlier = makeEvent({ id: "2", name: "Earlier", dates: "2026-08-01T00:00:00Z" })
+    const later = makeEvent({
+      id: "1",
+      name: "Later",
+      dates: "2026-08-02T00:00:00Z",
+    })
+    const earlier = makeEvent({
+      id: "2",
+      name: "Earlier",
+      dates: "2026-08-01T00:00:00Z",
+    })
     expect(sortEvents([later, earlier])).toEqual([earlier, later])
   })
 
   it("sorts events without a date after dated events", () => {
-    const dated = makeEvent({ id: "1", name: "Dated", dates: "2026-08-01T00:00:00Z" })
+    const dated = makeEvent({
+      id: "1",
+      name: "Dated",
+      dates: "2026-08-01T00:00:00Z",
+    })
     const undated = makeEvent({ id: "2", name: "Undated", dates: null })
     expect(sortEvents([undated, dated])).toEqual([dated, undated])
   })
 
   it("breaks ties on the same date by name", () => {
-    const b = makeEvent({ id: "1", name: "B Event", dates: "2026-08-01T00:00:00Z" })
-    const a = makeEvent({ id: "2", name: "A Event", dates: "2026-08-01T00:00:00Z" })
+    const b = makeEvent({
+      id: "1",
+      name: "B Event",
+      dates: "2026-08-01T00:00:00Z",
+    })
+    const a = makeEvent({
+      id: "2",
+      name: "A Event",
+      dates: "2026-08-01T00:00:00Z",
+    })
     expect(sortEvents([b, a])).toEqual([a, b])
   })
 

--- a/apps/web/src/reducers/events.ts
+++ b/apps/web/src/reducers/events.ts
@@ -1,4 +1,5 @@
 import { type EventResponse, type EventsByDate } from "../hooks/eventsStream"
+import { eventDateKey } from "../lib/dates"
 
 type EventsAction =
   | { type: "RESET_EVENTS" }
@@ -12,32 +13,6 @@ type EventsState = {
   isStreaming: boolean
   selectedEvents: EventResponse[]
   error: string | null
-}
-
-function eventDateKey(event: EventResponse): string {
-  if (!event.dates) return "unknown"
-
-  // A bare "YYYY-MM-DD" (no time-of-day -- see normalize_event's
-  // localDate-only fallback) already *is* the calendar day, with no
-  // timezone to resolve. Returning it as-is avoids routing it through
-  // `Date`, which would anchor it to UTC midnight and could read back a
-  // day early in any timezone behind UTC (see below).
-  if (/^\d{4}-\d{2}-\d{2}$/.test(event.dates)) return event.dates
-
-  const date = new Date(event.dates)
-  if (Number.isNaN(date.getTime())) return "unknown"
-
-  // Use local, not UTC, calendar-day components. `event.dates` is often a
-  // genuine UTC instant (e.g. "...T03:00:00Z"), and a late-evening show
-  // converts to the *next* UTC calendar day -- an 11pm Eastern show is
-  // 3am UTC the next day. Bucketing by the UTC day pushed those shows
-  // into tomorrow's list instead of tonight's. This assumes the viewer's
-  // timezone approximates the venue's, same as the rest of the app
-  // (lib/dates.ts formats event times via `getLocalTimeZone()`).
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, "0")
-  const day = String(date.getDate()).padStart(2, "0")
-  return `${year}-${month}-${day}`
 }
 
 function sameEvent(a: EventResponse, b: EventResponse): boolean {
@@ -144,7 +119,6 @@ export {
   type EventsState,
   eventsReducer,
   initialEventsState,
-  eventDateKey,
   sameEvent,
   sortEvents,
 }


### PR DESCRIPTION
## Summary

Architecture-review deepening candidate #1: "what local calendar day does this event/search-boundary belong to" was reimplemented independently in `reducers/events.ts` (`eventDateKey`), `lib/dates.ts` (`dateRangeToApiParams`), and `lib/groupEvents.ts`'s own key-building, with no interface owning the concept. Two real bugs shipped back-to-back in this exact area (#45, #47) because fixing one implementation never touched the others.

- **Moved `eventDateKey` into `lib/dates.ts`**, which becomes LocalDay's sole owner. It and `dateRangeToApiParams` stay two separate parsing paths (a raw date-time string vs. an already-structured `CalendarDate` from the picker) — legitimate adapters into the same concept, not duplication — but now share one file, one canonical `YYYY-MM-DD` representation, and one doc comment tying them together.
- **Injectable `timeZone` everywhere** (`eventDateKey`, `formatDateTime`, `formatTime`), defaulting to the viewer's own. Rewrote `eventDateKey`'s internals on `Intl.DateTimeFormat` instead of raw `Date` local getters, which can only ever read the *runtime's* timezone — the injectable parameter didn't actually work without this.
- **Correctness refinement found while rewriting**: a timezone-less local wall-clock string (from `normalize_event`'s localDate+localTime fallback) can't be safely routed through `Date` before reformatting in an explicit target timezone — `Date` bakes in an assumption about *whose* local time the string represents before the target timezone is ever applied, which double-converts it. Reading the date substring directly sidesteps this, since that shape needs no zone resolution at all.
- **Replaced, not layered**: `eventDateKey`'s tests (previously pinned via `vi.stubEnv("TZ", ...)`) moved to `lib/dates.test.ts` against the new interface, using the explicit `timeZone` parameter — one testing discipline for the whole module. Added first-time tests for `formatDate`/`formatDateTime`/`formatTime`.
- **First domain docs in the repo**: `CONTEXT-MAP.md` and `apps/web/CONTEXT.md`, naming **LocalDay** and explicitly flagging it as distinct from the backend's `calendar_day` (a UTC day, used for cross-source matching in `reconcile.rs`) — left untouched this round as a smaller, separate follow-up.

## Test plan
- [x] Full frontend suite: 74 tests pass (incl. new/moved `eventDateKey` tests using explicit timezones, and new tests proving the timezone-less-datetime fix with a deliberately-mismatched target zone)
- [x] `lint` clean
- [x] `tsc -b && vite build` (the real type-check — `pnpm typecheck` itself turned out to be silently checking 0 files, flagged separately) succeeds
- [x] `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)