### PR TITLE
Fix web typecheck script to actually check the project

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
- `apps/web`'s `typecheck` script ran bare `tsc --noEmit`, which resolves against the root `tsconfig.json` (`files: []`, only project references) and silently checked zero files, always exiting 0 regardless of type errors
- Changed to `tsc -b --noEmit`, which builds both referenced configs (`tsconfig.app.json`, `tsconfig.node.json`) — 936 files instead of 0
- Not a CI issue (the `build` script already uses `tsc -b` correctly), but the standalone command was misleading anyone running it manually

## Test plan
- [x] Confirmed old script (`tsc --noEmit`) checks 0 files via `--listFiles`
- [x] Confirmed new script (`tsc -b --noEmit`) checks 936 files
- [x] Injected a deliberate type error in `src/main.tsx`: old script exited 0, new script caught it (`TS2322`)
- [x] Reverted the deliberate error, confirmed new script exits clean on current code

🤖 Generated with [Claude Code](https://claude.com/claude-code)