### PR TITLE
Deepen MapWrapper: split six unrelated concerns into focused modules

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -1,27 +1,22 @@
-import { useRef, useEffect, useState } from "react"
-import mapboxgl, {
-  GeoJSONSource,
-  InteractionEvent,
-  type GeoJSONFeature,
-} from "mapbox-gl"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+import type { GeoJSONFeature } from "mapbox-gl"
 import { useSearchProvider } from "./providers/searchProvider"
 import { useEventsContext } from "./providers/eventsProvider"
 import { useNavigateToLocation } from "./hooks/useNavigateToLocation"
+import { useMapInstance } from "./hooks/useMapInstance"
+import { useResizeFix } from "./hooks/useResizeFix"
+import { useMapCamera } from "./hooks/useMapCamera"
+import { useEventLayer } from "./hooks/useEventLayer"
+import { useClusterSelection } from "./hooks/useClusterSelection"
 import { locationFromFeature } from "./lib/mapbox"
 import { DrawerWrapper } from "./Drawer/DrawerWrapper"
 import { useIsMobile } from "./providers/Breakpoint"
-import { boundsForRadius } from "./lib/geo"
-import { dateRangeToApiParams } from "./lib/dates"
 import "mapbox-gl/dist/mapbox-gl.css"
 import "./App.css"
-import type { Feature, FeatureCollection } from "geojson"
-import type { EventResponse } from "./hooks/eventsStream"
-
-const INITIAL_ZOOM = 1
 
 const MapWrapper = () => {
-  const { selectedCoordinates, setSelectedLocation, dateRange } =
-    useSearchProvider()
+  const { selectedCoordinates, setSelectedLocation } = useSearchProvider()
   const navigateToLocation = useNavigateToLocation()
   const [rendered, setRendered] = useState(false)
   useEffect(() => {
@@ -32,8 +27,6 @@ const MapWrapper = () => {
   }, [])
 
   const {
-    streamEvents,
-    cancelStream,
     eventsByDate,
     selectEvents,
     selectedEvents,
@@ -41,413 +34,75 @@ const MapWrapper = () => {
     searchRadius,
     radiusExpanded,
   } = useEventsContext()
-  const mapRef = useRef<mapboxgl.Map | null>(null)
+
+  const mapRef = useRef<MapboxMap | null>(null)
   const mapContainer = useRef<HTMLDivElement | null>(null)
-  const [selectedFeature, setSelectedFeature] = useState(null)
-  // Initialize the GeolocateControl.
-  const geolocate = new mapboxgl.GeolocateControl({
-    positionOptions: {
-      enableHighAccuracy: false,
-    },
-    fitBoundsOptions: { maxZoom: INITIAL_ZOOM },
-    trackUserLocation: false,
-  })
-
-  useEffect(() => {
-    // Debounced rather than calling resize() on every tick: Mapbox
-    // recalculates its internal camera transform on each resize() call, and
-    // the drawer's open/close transition fires this observer continuously
-    // as its reserved width animates (~150ms). Resizing the GL canvas that
-    // often before it settles produces a visible zoom/scale glitch. Waiting
-    // for the container to go quiet avoids it — the canvas just stretches
-    // via CSS in the meantime, which is cheap and doesn't touch the camera.
-    let settleTimeout: ReturnType<typeof setTimeout> | null = null
-    const resizeObserver = new ResizeObserver(() => {
-      if (settleTimeout) clearTimeout(settleTimeout)
-      settleTimeout = setTimeout(() => {
-        mapRef.current?.resize()
-      }, 200)
-    })
-    if (mapContainer.current) {
-      resizeObserver.observe(mapContainer.current)
-    }
-    return () => {
-      if (settleTimeout) clearTimeout(settleTimeout)
-      resizeObserver.disconnect()
-    }
-  }, [])
-
-  useEffect(() => {
-    const venueLocation = selectedEvents[0]?.venue?.location
-    if (selectedEvents.length && venueLocation !== undefined) {
-      const { latitude, longitude } = venueLocation
-      mapRef.current?.setLayoutProperty("events", "icon-image", [
-        "case",
-        ["==", ["get", "id"], selectedEvents[0].id],
-        "marker-yellow",
-        [
-          "in",
-          ["get", "clusterVenue"],
-          ["literal", selectedEvents.map((e) => e.venue?.name)],
-        ],
-
-        "marker-yellow",
-        "marker-red",
-      ])
-      // Selecting an event from the drawer list doesn't necessarily mean
-      // the map is already showing its venue (unlike clicking a marker
-      // directly, where it's a harmless no-op), so fly there.
-      if (latitude && longitude) {
-        mapRef.current?.flyTo({
-          center: { lat: parseFloat(latitude), lng: parseFloat(longitude) },
-          speed: 0.8,
-        })
-      }
-    }
-  }, [selectedEvents])
 
   const theme =
     window.matchMedia &&
     window.matchMedia("(prefers-color-scheme: dark)").matches
       ? import.meta.env.VITE_MAPBOX_DARK_STYLE
       : import.meta.env.VITE_MAPBOX_LIGHT_STYLE
-  useEffect(() => {
-    mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN
 
-    mapRef.current = new mapboxgl.Map({
-      style: theme,
-      container: "map-container",
-      center: selectedCoordinates,
-      zoom: INITIAL_ZOOM,
-    })
+  // What happens with a geolocated position (reverse-geocoding it, updating
+  // search state) isn't a map concern -- useMapInstance just reports the
+  // coordinates back via this callback.
+  const handleGeolocate = useCallback(
+    (coordinates: [number, number]) => {
+      navigateToLocation(coordinates)
 
-    mapRef.current.on("load", () => {
-      mapRef.current?.resize()
-    })
-
-    if (!mapRef.current.hasControl(geolocate)) {
-      // Add the control to the map.
-      mapRef.current.addControl(geolocate, "bottom-right")
-      // Set an event listener that fires
-      // when a geolocate event occurs.
-      geolocate.on("geolocate", (e) => {
-        const { longitude, latitude } = e.coords
-        navigateToLocation([longitude, latitude])
-
-        fetch(
-          `/api/reverse-geocode?longitude=${longitude}&latitude=${latitude}`
-        )
-          .then((res) => res.json())
-          .then((data: { features?: GeoJSONFeature[] }) => {
-            const feature = data.features?.[0]
-            const location = feature && locationFromFeature(feature)
-            if (location) {
-              setSelectedLocation(location)
-            }
-          })
-          .catch((err) => {
-            console.error("Failed to reverse geocode geolocated position", err)
-          })
-      })
-
-      // Only auto-center on the user's real location if permission was
-      // already granted in a previous visit — never surprise a first-time
-      // visitor with a location prompt before they've done anything. If
-      // permission is still undecided or denied, the geolocate control
-      // above remains available for the user to trigger explicitly.
-      // Some browsers (and this app's own automated preview environment)
-      // throw synchronously for unsupported permission queries rather
-      // than rejecting the returned promise, so this whole check is
-      // wrapped defensively.
-      try {
-        navigator.permissions
-          ?.query({ name: "geolocation" })
-          .then((status) => {
-            if (status.state === "granted") {
-              geolocate.trigger()
-            }
-          })
-          .catch(() => {
-            // Permission query unsupported/rejected — fall back to
-            // requiring an explicit button click.
-          })
-      } catch {
-        // Permissions API not available at all in this browser.
-      }
-    }
-
-    // When a click event occurs on a feature in the places layer, open a popup at the
-    // location of the feature, with description HTML from its properties.
-
-    mapRef.current?.addInteraction("map-click", {
-      type: "click",
-      target: { layerId: "events" },
-      handler: () => {
-        if (selectedFeature) {
-          mapRef.current?.setFeatureState(selectedFeature, { selected: false })
-          setSelectedFeature(null)
-        }
-      },
-    })
-    // Change the cursor to a pointer when the mouse is over a POI.
-    mapRef.current?.addInteraction("places-mouseenter-interaction", {
-      type: "mouseenter",
-      target: { layerId: "events" },
-      handler: () => {
-        if (mapRef.current) {
-          mapRef.current.getCanvas().style.cursor = "pointer"
-        }
-      },
-    })
-
-    // Change the cursor back to a pointer when it stops hovering over a POI.
-    mapRef.current?.addInteraction("places-mouseleave-interaction", {
-      type: "mouseleave",
-      target: { layerId: "events" },
-      handler: () => {
-        if (mapRef.current) {
-          mapRef.current.getCanvas().style.cursor = ""
-        }
-      },
-    })
-    // Intentionally run once: this creates the Mapbox instance itself.
-    // Re-running on every dependency change would tear down and recreate
-    // the map, not just update it.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const { latitude, longitude, start, end } = {
-    latitude: selectedCoordinates[1],
-    longitude: selectedCoordinates[0],
-    ...dateRangeToApiParams(dateRange.start, dateRange.end),
-  }
-  useEffect(() => {
-    if (!rendered) return
-    void streamEvents({
-      latitude,
-      longitude,
-      start,
-      end,
-    })
-
-    return () => {
-      cancelStream()
-    }
-  }, [latitude, longitude, start, end, streamEvents, cancelStream, rendered])
-
-  useEffect(() => {
-    const markEvents = () => {
-      selectEvents([])
-
-      const dataSource: FeatureCollection = {
-        type: "FeatureCollection",
-        features: [],
-      }
-      Object.values(eventsByDate).forEach((events: EventResponse[]) => {
-        events.forEach((event) => {
-          const { venue } = event
-
-          if (!venue || !venue.location) {
-            return
+      fetch(
+        `/api/reverse-geocode?longitude=${coordinates[0]}&latitude=${coordinates[1]}`
+      )
+        .then((res) => res.json())
+        .then((data: { features?: GeoJSONFeature[] }) => {
+          const feature = data.features?.[0]
+          const location = feature && locationFromFeature(feature)
+          if (location) {
+            setSelectedLocation(location)
           }
-          const location = venue.location
-
-          const [longitude, latitude] = [
-            parseFloat(location?.longitude ?? ""),
-            parseFloat(location?.latitude ?? ""),
-          ]
-          const feature: Feature = {
-            type: "Feature",
-            properties: {
-              description: event.name,
-              venue: venue.name,
-              color: "#373630",
-              id: event.id,
-              selected: "false",
-            },
-            geometry: {
-              type: "Point",
-              coordinates: [longitude, latitude],
-            },
-          }
-          dataSource.features.push(feature)
         })
-      })
-
-      // This effect re-runs on every streamed-in event (it depends on
-      // eventsByDate, which changes per NDJSON line), so for a city with
-      // many results it can fire dozens of times in quick succession —
-      // and can fire before the map's style has finished loading, which
-      // makes Mapbox throw ("Style is not done loading") on addSource.
-      // Kansas-sparse locations rarely hit this race; a dense city like
-      // New York reliably does. Defer to the map's own "load" event when
-      // the style isn't ready yet, and once a source exists, update its
-      // data in place instead of removing/re-adding it every run (which
-      // also separately trips an internal Mapbox GL terrain-update bug
-      // when done rapidly).
-      const applyToMap = () => {
-        const existingSource = mapRef.current?.getSource(
-          "event-data-source"
-        ) as GeoJSONSource | undefined
-
-        if (existingSource) {
-          existingSource.setData(dataSource)
-          return
-        }
-
-        mapRef.current?.addSource("event-data-source", {
-          type: "geojson",
-          promoteId: "id",
-          cluster: true,
-          clusterRadius: 0,
-          clusterProperties: {
-            clusterEvent: ["string", ["get", "description"]],
-            clusterVenue: ["string", ["get", "venue"]],
-          },
-          data: dataSource,
+        .catch((err) => {
+          console.error("Failed to reverse geocode geolocated position", err)
         })
-        mapRef.current?.addLayer({
-          id: "events",
-          type: "symbol",
-          source: "event-data-source",
-          layout: {
-            "text-field": [
-              "case",
-              ["boolean", ["has", "point_count"], false],
-              [
-                "concat",
-                ["get", "point_count"],
-                " events at ",
-                ["get", "clusterVenue"],
-              ],
-              ["get", "description"],
-            ],
-            "text-variable-anchor": ["top", "bottom", "left", "right"],
-            "text-radial-offset": 0.5,
-            "text-justify": "auto",
-            "icon-image": [
-              "case",
-              [
-                "in",
-                ["get", "id"],
-                ["literal", selectedEvents.map((e) => e.id)],
-              ],
-              "marker-yellow",
-              [
-                "in",
-                ["get", "clusterVenue"],
-                ["literal", selectedEvents.map((e) => e.venue?.name)],
-              ],
+    },
+    [navigateToLocation, setSelectedLocation]
+  )
 
-              "marker-yellow",
-              "marker-red",
-            ],
-            "icon-size": 1.6,
-          },
-          paint: {
-            "icon-halo-color": "#ffffff",
-            "icon-halo-width": 1,
-            "text-color": [
-              "case",
-              ["boolean", ["feature-state", "hover"], false],
-              "#627BC1",
-              ["boolean", ["has", "point_count"], false],
-              "#373630",
-              ["get", "color"],
-            ],
-            "text-halo-color": "#ffffff",
-            "text-halo-width": 2,
-          },
-        })
-      }
-
-      if (mapRef.current?.isStyleLoaded()) {
-        applyToMap()
-      } else {
-        mapRef.current?.once("load", applyToMap)
-      }
-    }
-
-    markEvents()
-    // selectedEvents intentionally omitted: this effect calls selectEvents([])
-    // itself (inside markEvents), so including selectedEvents here would
-    // make the effect re-trigger the state change that re-runs it — an
-    // infinite loop. The effect above already patches icon-image via
-    // setLayoutProperty when the selection changes, so rebuilding the whole
-    // layer/source here on every click isn't needed either.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventsByDate, selectEvents])
+  useMapInstance(
+    mapRef,
+    "map-container",
+    theme,
+    selectedCoordinates,
+    handleGeolocate
+  )
+  useResizeFix(mapRef, mapContainer)
+  const camera = useMapCamera(mapRef)
+  useEventLayer(mapRef, eventsByDate, selectedEvents, selectEvents)
+  useClusterSelection(mapRef, eventsByDate, selectEvents)
 
   useEffect(() => {
-    if (!mapRef.current) return
-
-    mapRef.current.addInteraction("event-click-interaction", {
-      type: "click",
-      target: { layerId: "events" },
-      handler: ({ feature }: InteractionEvent) => {
-        const event: EventResponse | undefined = [
-          ...Object.values(eventsByDate),
-        ]
-          .flat()
-          ?.find((ev) => ev.id === feature?.id)
-        const eventSource = mapRef.current?.getSource(
-          "event-data-source"
-        ) as GeoJSONSource
-        if (event) {
-          selectEvents([event])
-        }
-        eventSource.getClusterChildren(
-          feature?.properties.cluster_id as number,
-          (error, features) => {
-            if (!error) {
-              const eventIds = features?.map(
-                (feature) => feature?.properties?.id
-              )
-              const selectedEvents = Object.values(eventsByDate).reduce(
-                (acc, curr) => {
-                  const selectedEvents = [...curr].filter((i) =>
-                    eventIds?.includes(i.id)
-                  )
-                  acc.push(...selectedEvents)
-                  return acc
-                },
-                []
-              )
-
-              selectEvents(selectedEvents)
-            }
-          }
-        )
-      },
-    })
-
-    return () => {
-      mapRef.current?.removeInteraction("event-click-interaction")
+    // Only flies when there's a selected event with a venue location --
+    // matches useEventLayer's icon-highlight guard, since both come from
+    // the same original combined effect.
+    const venueLocation = selectedEvents[0]?.venue?.location
+    if (selectedEvents.length && venueLocation !== undefined) {
+      camera.flyToVenue(venueLocation.latitude, venueLocation.longitude)
     }
-  }, [eventsByDate, selectEvents])
+  }, [selectedEvents, camera])
 
   useEffect(() => {
     if (!rendered) return
-    mapRef.current?.easeTo({
-      center: { lat: selectedCoordinates[1], lng: selectedCoordinates[0] },
-      zoom: 12,
-      speed: 0.8,
-    })
-  }, [selectedCoordinates, rendered])
+    camera.easeToLocation(selectedCoordinates)
+  }, [selectedCoordinates, rendered, camera])
 
   // Once a search had to widen past the base radius to find anything,
   // zoom out to frame the actual area covered instead of staying zoomed
   // in on a radius that came up empty.
   useEffect(() => {
     if (isStreaming || !radiusExpanded || !searchRadius) return
-    mapRef.current?.fitBounds(
-      boundsForRadius(selectedCoordinates, searchRadius),
-      {
-        padding: 60,
-        duration: 800,
-      }
-    )
-  }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates])
+    camera.fitToRadius(selectedCoordinates, searchRadius)
+  }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates, camera])
 
   return (
     <>

--- a/apps/web/src/hooks/useClusterSelection.ts
+++ b/apps/web/src/hooks/useClusterSelection.ts
@@ -1,0 +1,45 @@
+import { useEffect, type RefObject } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+import type { GeoJSONSource, InteractionEvent } from "mapbox-gl"
+import { resolveEventsByIds } from "../lib/mapbox"
+import type { EventResponse, EventsByDate } from "./eventsStream"
+
+/** Wires the click interaction on the "events" layer: resolves whatever
+ * was clicked (a single marker, or a cluster) back to the real
+ * `EventResponse`s it represents, and selects them. */
+export function useClusterSelection(
+  mapRef: RefObject<MapboxMap | null>,
+  eventsByDate: EventsByDate,
+  selectEvents: (events: EventResponse[]) => void
+) {
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map) return
+
+    map.addInteraction("event-click-interaction", {
+      type: "click",
+      target: { layerId: "events" },
+      handler: ({ feature }: InteractionEvent) => {
+        const [event] = resolveEventsByIds(eventsByDate, [feature?.id])
+        if (event) {
+          selectEvents([event])
+        }
+
+        const eventSource = map.getSource("event-data-source") as GeoJSONSource
+        eventSource.getClusterChildren(
+          feature?.properties.cluster_id as number,
+          (error, features) => {
+            if (!error) {
+              const ids = features?.map((f) => f?.properties?.id) ?? []
+              selectEvents(resolveEventsByIds(eventsByDate, ids))
+            }
+          }
+        )
+      },
+    })
+
+    return () => {
+      map.removeInteraction("event-click-interaction")
+    }
+  }, [eventsByDate, selectEvents, mapRef])
+}

--- a/apps/web/src/hooks/useEventLayer.ts
+++ b/apps/web/src/hooks/useEventLayer.ts
@@ -1,0 +1,130 @@
+import { useEffect, type RefObject } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+import type { GeoJSONSource } from "mapbox-gl"
+import {
+  buildEventFeatureCollection,
+  eventIconImageExpression,
+} from "../lib/mapbox"
+import type { EventResponse, EventsByDate } from "./eventsStream"
+
+/** Owns the "events" Mapbox source/layer end to end: its data (from
+ * `eventsByDate`) and its selection-driven icon styling (from
+ * `selectedEvents`). These used to be split across two effects that both
+ * independently touched the same layer -- keeping them in one hook means
+ * one place to change if, say, the clustering or highlight rules change. */
+export function useEventLayer(
+  mapRef: RefObject<MapboxMap | null>,
+  eventsByDate: EventsByDate,
+  selectedEvents: EventResponse[],
+  selectEvents: (events: EventResponse[]) => void
+) {
+  useEffect(() => {
+    const markEvents = () => {
+      selectEvents([])
+
+      const dataSource = buildEventFeatureCollection(eventsByDate)
+
+      // This effect re-runs on every streamed-in event (it depends on
+      // eventsByDate, which changes per NDJSON line), so for a city with
+      // many results it can fire dozens of times in quick succession —
+      // and can fire before the map's style has finished loading, which
+      // makes Mapbox throw ("Style is not done loading") on addSource.
+      // Kansas-sparse locations rarely hit this race; a dense city like
+      // New York reliably does. Defer to the map's own "load" event when
+      // the style isn't ready yet, and once a source exists, update its
+      // data in place instead of removing/re-adding it every run (which
+      // also separately trips an internal Mapbox GL terrain-update bug
+      // when done rapidly).
+      const applyToMap = () => {
+        const existingSource = mapRef.current?.getSource(
+          "event-data-source"
+        ) as GeoJSONSource | undefined
+
+        if (existingSource) {
+          existingSource.setData(dataSource)
+          return
+        }
+
+        mapRef.current?.addSource("event-data-source", {
+          type: "geojson",
+          promoteId: "id",
+          cluster: true,
+          clusterRadius: 0,
+          clusterProperties: {
+            clusterEvent: ["string", ["get", "description"]],
+            clusterVenue: ["string", ["get", "venue"]],
+          },
+          data: dataSource,
+        })
+        mapRef.current?.addLayer({
+          id: "events",
+          type: "symbol",
+          source: "event-data-source",
+          layout: {
+            "text-field": [
+              "case",
+              ["boolean", ["has", "point_count"], false],
+              [
+                "concat",
+                ["get", "point_count"],
+                " events at ",
+                ["get", "clusterVenue"],
+              ],
+              ["get", "description"],
+            ],
+            "text-variable-anchor": ["top", "bottom", "left", "right"],
+            "text-radial-offset": 0.5,
+            "text-justify": "auto",
+            "icon-image": eventIconImageExpression(selectedEvents),
+            "icon-size": 1.6,
+          },
+          paint: {
+            "icon-halo-color": "#ffffff",
+            "icon-halo-width": 1,
+            "text-color": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              "#627BC1",
+              ["boolean", ["has", "point_count"], false],
+              "#373630",
+              ["get", "color"],
+            ],
+            "text-halo-color": "#ffffff",
+            "text-halo-width": 2,
+          },
+        })
+      }
+
+      if (mapRef.current?.isStyleLoaded()) {
+        applyToMap()
+      } else {
+        mapRef.current?.once("load", applyToMap)
+      }
+    }
+
+    markEvents()
+    // selectedEvents intentionally omitted: this effect calls selectEvents([])
+    // itself (inside markEvents), so including selectedEvents here would
+    // make the effect re-trigger the state change that re-runs it — an
+    // infinite loop. The effect below already patches icon-image via
+    // setLayoutProperty when the selection changes, so rebuilding the whole
+    // layer/source here on every click isn't needed either.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventsByDate, selectEvents])
+
+  useEffect(() => {
+    // Only updates when there's a selected event with a venue location --
+    // matches the original combined effect's guard (which also gated the
+    // camera fly-to, now in useMapCamera). Preserved as-is rather than
+    // loosened to "any non-empty selection," since that's a slightly
+    // different, untested behavior change outside this deepening's scope.
+    const venueLocation = selectedEvents[0]?.venue?.location
+    if (selectedEvents.length && venueLocation !== undefined) {
+      mapRef.current?.setLayoutProperty(
+        "events",
+        "icon-image",
+        eventIconImageExpression(selectedEvents)
+      )
+    }
+  }, [selectedEvents, mapRef])
+}

--- a/apps/web/src/hooks/useMapCamera.ts
+++ b/apps/web/src/hooks/useMapCamera.ts
@@ -1,0 +1,51 @@
+import { useCallback, useMemo, type RefObject } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+import { boundsForRadius } from "../lib/geo"
+
+/** Every camera movement the map makes, behind one interface. Three
+ * different triggers (selecting an event, changing location, a search
+ * widening past its base radius) each used to call `mapRef.current.flyTo`/
+ * `easeTo`/`fitBounds` directly -- one module now owns how the camera
+ * moves regardless of why. */
+export function useMapCamera(mapRef: RefObject<MapboxMap | null>) {
+  /** Flies to a venue's coordinates -- a no-op if either is missing or
+   * unparseable, which is common: not every event has venue geo data. */
+  const flyToVenue = useCallback(
+    (latitude: string | undefined, longitude: string | undefined) => {
+      if (!latitude || !longitude) return
+      const lat = parseFloat(latitude)
+      const lng = parseFloat(longitude)
+      if (Number.isNaN(lat) || Number.isNaN(lng)) return
+      mapRef.current?.flyTo({ center: { lat, lng }, speed: 0.8 })
+    },
+    [mapRef]
+  )
+
+  const easeToLocation = useCallback(
+    (coordinates: [number, number]) => {
+      mapRef.current?.easeTo({
+        center: { lat: coordinates[1], lng: coordinates[0] },
+        zoom: 12,
+        speed: 0.8,
+      })
+    },
+    [mapRef]
+  )
+
+  const fitToRadius = useCallback(
+    (coordinates: [number, number], radiusMiles: number) => {
+      mapRef.current?.fitBounds(boundsForRadius(coordinates, radiusMiles), {
+        padding: 60,
+        duration: 800,
+      })
+    },
+    [mapRef]
+  )
+
+  // Memoized as a whole so callers can depend on `camera` itself in effect
+  // dependency arrays without it changing identity every render.
+  return useMemo(
+    () => ({ flyToVenue, easeToLocation, fitToRadius }),
+    [flyToVenue, easeToLocation, fitToRadius]
+  )
+}

--- a/apps/web/src/hooks/useMapInstance.ts
+++ b/apps/web/src/hooks/useMapInstance.ts
@@ -1,0 +1,131 @@
+import { useEffect, useState, type RefObject } from "react"
+import mapboxgl, { type GeoJSONFeature } from "mapbox-gl"
+
+const INITIAL_ZOOM = 1
+
+/** Creates the Mapbox instance and wires up controls/interactions that
+ * don't depend on event data: the geolocate control, and cursor changes on
+ * hover over the "events" layer.
+ *
+ * Reports a geolocated position via `onGeolocate` rather than acting on it
+ * directly -- what happens with a geolocated position (reverse-geocoding
+ * it, updating search state) isn't a map concern, just something the map's
+ * control happens to trigger.
+ *
+ * Takes `mapRef` as a parameter rather than creating and returning its own
+ * -- every other map hook needs the same instance, and `MapWrapper` is the
+ * single place that owns the ref and wires it into all of them. */
+export function useMapInstance(
+  mapRef: RefObject<mapboxgl.Map | null>,
+  containerId: string,
+  style: string,
+  initialCenter: [number, number],
+  onGeolocate: (coordinates: [number, number]) => void
+) {
+  const [selectedFeature, setSelectedFeature] = useState<GeoJSONFeature | null>(
+    null
+  )
+
+  useEffect(() => {
+    mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_ACCESS_TOKEN
+
+    mapRef.current = new mapboxgl.Map({
+      style,
+      container: containerId,
+      center: initialCenter,
+      zoom: INITIAL_ZOOM,
+    })
+
+    mapRef.current.on("load", () => {
+      mapRef.current?.resize()
+    })
+
+    const geolocate = new mapboxgl.GeolocateControl({
+      positionOptions: {
+        enableHighAccuracy: false,
+      },
+      fitBoundsOptions: { maxZoom: INITIAL_ZOOM },
+      trackUserLocation: false,
+    })
+
+    if (!mapRef.current.hasControl(geolocate)) {
+      mapRef.current.addControl(geolocate, "bottom-right")
+      geolocate.on("geolocate", (e) => {
+        onGeolocate([e.coords.longitude, e.coords.latitude])
+      })
+
+      // Only auto-center on the user's real location if permission was
+      // already granted in a previous visit — never surprise a first-time
+      // visitor with a location prompt before they've done anything. If
+      // permission is still undecided or denied, the geolocate control
+      // above remains available for the user to trigger explicitly.
+      // Some browsers (and this app's own automated preview environment)
+      // throw synchronously for unsupported permission queries rather
+      // than rejecting the returned promise, so this whole check is
+      // wrapped defensively.
+      try {
+        navigator.permissions
+          ?.query({ name: "geolocation" })
+          .then((status) => {
+            if (status.state === "granted") {
+              geolocate.trigger()
+            }
+          })
+          .catch(() => {
+            // Permission query unsupported/rejected — fall back to
+            // requiring an explicit button click.
+          })
+      } catch {
+        // Permissions API not available at all in this browser.
+      }
+    }
+
+    mapRef.current?.addInteraction("map-click", {
+      type: "click",
+      target: { layerId: "events" },
+      handler: () => {
+        if (selectedFeature) {
+          mapRef.current?.setFeatureState(selectedFeature, { selected: false })
+          setSelectedFeature(null)
+        }
+      },
+    })
+    mapRef.current?.addInteraction("places-mouseenter-interaction", {
+      type: "mouseenter",
+      target: { layerId: "events" },
+      handler: () => {
+        if (mapRef.current) {
+          mapRef.current.getCanvas().style.cursor = "pointer"
+        }
+      },
+    })
+    mapRef.current?.addInteraction("places-mouseleave-interaction", {
+      type: "mouseleave",
+      target: { layerId: "events" },
+      handler: () => {
+        if (mapRef.current) {
+          mapRef.current.getCanvas().style.cursor = ""
+        }
+      },
+    })
+
+    // Without this, React's Strict Mode double-invoking this effect in
+    // development (mount -> unmount -> remount) creates a second Map
+    // instance layered on the same container -- the first is orphaned but
+    // its canvas is never removed, so it silently sits on top of (and
+    // blocks) the real one. Harmless to call on a genuine unmount too,
+    // which in production essentially never happens (MapWrapper isn't
+    // routed away from), but is the correct lifecycle either way.
+    const map = mapRef.current
+    return () => {
+      map.remove()
+      if (mapRef.current === map) {
+        mapRef.current = null
+      }
+    }
+    // Intentionally run once: this creates the Mapbox instance itself.
+    // Re-running on every dependency change would tear down and recreate
+    // the map, not just update it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+}

--- a/apps/web/src/hooks/useResizeFix.ts
+++ b/apps/web/src/hooks/useResizeFix.ts
@@ -1,0 +1,34 @@
+import { useEffect, type RefObject } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+
+/** Debounced `resize()` call whenever `container` changes size.
+ *
+ * Not a call-on-every-tick observer: Mapbox recalculates its internal
+ * camera transform on each `resize()` call, and the drawer's open/close
+ * transition fires this observer continuously as its reserved width
+ * animates (~150ms). Resizing the GL canvas that often before it settles
+ * produces a visible zoom/scale glitch. Waiting for the container to go
+ * quiet avoids it — the canvas just stretches via CSS in the meantime,
+ * which is cheap and doesn't touch the camera. */
+export function useResizeFix(
+  mapRef: RefObject<MapboxMap | null>,
+  container: RefObject<HTMLDivElement | null>
+) {
+  useEffect(() => {
+    let settleTimeout: ReturnType<typeof setTimeout> | null = null
+    const resizeObserver = new ResizeObserver(() => {
+      if (settleTimeout) clearTimeout(settleTimeout)
+      settleTimeout = setTimeout(() => {
+        mapRef.current?.resize()
+      }, 200)
+    })
+    if (container.current) {
+      resizeObserver.observe(container.current)
+    }
+    return () => {
+      if (settleTimeout) clearTimeout(settleTimeout)
+      resizeObserver.disconnect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+}

--- a/apps/web/src/lib/mapbox.test.ts
+++ b/apps/web/src/lib/mapbox.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildEventFeatureCollection,
+  eventIconImageExpression,
+  resolveEventsByIds,
+} from "./mapbox"
+import type { EventResponse, EventsByDate } from "../hooks/eventsStream"
+
+function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
+  return {
+    id: "1",
+    name: "Test Event",
+    images: [],
+    dates: "2026-08-01T20:00:00Z",
+    source: "ticketmaster",
+    venue: {
+      name: "Test Venue",
+      location: { latitude: "43.65", longitude: "-70.25" },
+    },
+    ...overrides,
+  }
+}
+
+describe("buildEventFeatureCollection", () => {
+  it("returns an empty FeatureCollection for no events", () => {
+    expect(buildEventFeatureCollection({})).toEqual({
+      type: "FeatureCollection",
+      features: [],
+    })
+  })
+
+  it("builds a Point feature from an event with venue location", () => {
+    const event = makeEvent({
+      id: "e1",
+      name: "Big Show",
+      venue: {
+        name: "The Venue",
+        location: { latitude: "43.65", longitude: "-70.25" },
+      },
+    })
+    const result = buildEventFeatureCollection({ "2026-08-01": [event] })
+
+    expect(result.features).toHaveLength(1)
+    expect(result.features[0]).toEqual({
+      type: "Feature",
+      properties: {
+        description: "Big Show",
+        venue: "The Venue",
+        color: "#373630",
+        id: "e1",
+        selected: "false",
+      },
+      geometry: {
+        type: "Point",
+        coordinates: [-70.25, 43.65],
+      },
+    })
+  })
+
+  it("skips events with no venue", () => {
+    const event = makeEvent({ venue: null })
+    expect(buildEventFeatureCollection({ "2026-08-01": [event] })).toEqual({
+      type: "FeatureCollection",
+      features: [],
+    })
+  })
+
+  it("skips events with a venue but no location", () => {
+    const event = makeEvent({ venue: { name: "No Geo Venue" } })
+    expect(buildEventFeatureCollection({ "2026-08-01": [event] })).toEqual({
+      type: "FeatureCollection",
+      features: [],
+    })
+  })
+
+  it("includes events from every date bucket", () => {
+    const eventsByDate: EventsByDate = {
+      "2026-08-01": [makeEvent({ id: "a" })],
+      "2026-08-02": [makeEvent({ id: "b" })],
+    }
+    const result = buildEventFeatureCollection(eventsByDate)
+    const ids = result.features.map((f) => f.properties?.id)
+    expect(ids.sort()).toEqual(["a", "b"])
+  })
+})
+
+describe("eventIconImageExpression", () => {
+  it("matches a selected event by id", () => {
+    const expression = eventIconImageExpression([makeEvent({ id: "e1" })])
+    // ["case", ["in", ["get", "id"], ["literal", [...ids]]], "marker-yellow", ...]
+    expect(expression[1]).toEqual(["in", ["get", "id"], ["literal", ["e1"]]])
+    expect(expression[2]).toBe("marker-yellow")
+  })
+
+  it("matches by shared venue name for cluster highlighting", () => {
+    const expression = eventIconImageExpression([
+      makeEvent({ id: "e1", venue: { name: "Shared Venue" } }),
+    ])
+    expect(expression[3]).toEqual([
+      "in",
+      ["get", "clusterVenue"],
+      ["literal", ["Shared Venue"]],
+    ])
+  })
+
+  it("falls back to marker-red when nothing is selected", () => {
+    const expression = eventIconImageExpression([])
+    expect(expression[expression.length - 1]).toBe("marker-red")
+    expect(expression[1]).toEqual(["in", ["get", "id"], ["literal", []]])
+  })
+})
+
+describe("resolveEventsByIds", () => {
+  it("resolves a single matching event", () => {
+    const event = makeEvent({ id: "e1" })
+    const eventsByDate: EventsByDate = { "2026-08-01": [event] }
+    expect(resolveEventsByIds(eventsByDate, ["e1"])).toEqual([event])
+  })
+
+  it("resolves matching events across multiple date buckets", () => {
+    const a = makeEvent({ id: "a" })
+    const b = makeEvent({ id: "b" })
+    const c = makeEvent({ id: "c" })
+    const eventsByDate: EventsByDate = {
+      "2026-08-01": [a, c],
+      "2026-08-02": [b],
+    }
+    const result = resolveEventsByIds(eventsByDate, ["a", "b"])
+    expect(result.map((e) => e.id).sort()).toEqual(["a", "b"])
+  })
+
+  it("returns an empty array when no ids match", () => {
+    const eventsByDate: EventsByDate = {
+      "2026-08-01": [makeEvent({ id: "a" })],
+    }
+    expect(resolveEventsByIds(eventsByDate, ["nonexistent"])).toEqual([])
+  })
+
+  it("returns an empty array for an empty id list", () => {
+    const eventsByDate: EventsByDate = {
+      "2026-08-01": [makeEvent({ id: "a" })],
+    }
+    expect(resolveEventsByIds(eventsByDate, [])).toEqual([])
+  })
+})

--- a/apps/web/src/lib/mapbox.ts
+++ b/apps/web/src/lib/mapbox.ts
@@ -1,5 +1,7 @@
-import type { GeoJSONFeature } from "mapbox-gl"
+import type { ExpressionSpecification, GeoJSONFeature } from "mapbox-gl"
+import type { Feature, FeatureCollection } from "geojson"
 import type { Location } from "./types"
+import type { EventResponse, EventsByDate } from "../hooks/eventsStream"
 
 /**
  * Parses a Mapbox Geocoding v6 `place` feature (from /api/cities or
@@ -24,4 +26,92 @@ export function locationFromFeature(
     countryCode: context?.country?.country_code ?? "",
     coordinates,
   }
+}
+
+// ---------------------------------------------------------------------------
+// The "events" layer: a GeoJSON source built from `eventsByDate`, clustered
+// by venue, rendered as markers/cluster labels. `useEventLayer` (the only
+// caller) owns the imperative Mapbox side of this; the two functions below
+// are its pure core -- the actual data-shaping, testable without Mapbox.
+// ---------------------------------------------------------------------------
+
+/** Builds the GeoJSON `FeatureCollection` backing the "events" source from
+ * every currently-loaded event. Events with no venue location are skipped
+ * silently -- they have nothing to plot. */
+export function buildEventFeatureCollection(
+  eventsByDate: EventsByDate
+): FeatureCollection {
+  const dataSource: FeatureCollection = {
+    type: "FeatureCollection",
+    features: [],
+  }
+
+  Object.values(eventsByDate).forEach((events) => {
+    events.forEach((event) => {
+      const { venue } = event
+      if (!venue?.location) return
+
+      const [longitude, latitude] = [
+        parseFloat(venue.location.longitude ?? ""),
+        parseFloat(venue.location.latitude ?? ""),
+      ]
+
+      const feature: Feature = {
+        type: "Feature",
+        properties: {
+          description: event.name,
+          venue: venue.name,
+          color: "#373630",
+          id: event.id,
+          selected: "false",
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [longitude, latitude],
+        },
+      }
+      dataSource.features.push(feature)
+    })
+  })
+
+  return dataSource
+}
+
+/** The "events" layer's `icon-image` expression: yellow for the selected
+ * event(s) or any marker sharing a selected venue (so a cluster containing
+ * a selected show also highlights), red otherwise.
+ *
+ * Consolidates two expressions that had quietly drifted apart: layer
+ * creation matched *any* selected id (`"in"`), while the reactive
+ * selection-change update only ever matched `selectedEvents[0]`'s id
+ * (`"=="`) -- so a multi-event selection (e.g. from clicking a cluster)
+ * only highlighted one marker after the first update. This is the "in"
+ * behavior, used everywhere now. */
+export function eventIconImageExpression(
+  selectedEvents: EventResponse[]
+): ExpressionSpecification {
+  return [
+    "case",
+    ["in", ["get", "id"], ["literal", selectedEvents.map((e) => e.id)]],
+    "marker-yellow",
+    [
+      "in",
+      ["get", "clusterVenue"],
+      ["literal", selectedEvents.map((e) => e.venue?.name)],
+    ],
+    "marker-yellow",
+    "marker-red",
+  ] as unknown as ExpressionSpecification
+}
+
+/** Resolves Mapbox feature ids (from a click or `getClusterChildren`) back
+ * to the real `EventResponse`s they represent. */
+export function resolveEventsByIds(
+  eventsByDate: EventsByDate,
+  ids: readonly unknown[]
+): EventResponse[] {
+  return Object.values(eventsByDate).reduce<EventResponse[]>((acc, events) => {
+    acc.push(...events.filter((event) => ids.includes(event.id)))
+    return acc
+  }, [])
 }

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -3,9 +3,11 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useReducer,
   useRef,
+  useState,
 } from "react"
 
 import {
@@ -14,6 +16,8 @@ import {
   initialEventsState,
 } from "../reducers/events"
 import { type EventResponse } from "@/hooks/eventsStream"
+import { useSearchProvider } from "./searchProvider"
+import { dateRangeToApiParams } from "../lib/dates"
 
 // Search radii (miles) tried in order until one returns events. Lets
 // sparsely-served (e.g. rural) locations still find something instead of
@@ -186,6 +190,44 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
   )
 
   const radiusExpanded = searchRadius !== null && searchRadius > BASE_RADIUS
+
+  // Reactively (re-)runs the search whenever the selected location or date
+  // range changes. Lives here rather than in MapWrapper: neither
+  // searchProvider's state nor streamEvents/cancelStream are map-specific --
+  // this is just the two providers' own concerns meeting, and previously
+  // only met inside MapWrapper because that's where the effect was first
+  // written, not because the map needed to own it.
+  const { selectedCoordinates, dateRange } = useSearchProvider()
+  const [rendered, setRendered] = useState(false)
+  useEffect(() => {
+    // Marks first-mount completion so the search effect below skips its
+    // initial run; intentional, not a cascading-render risk here.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRendered(true)
+  }, [])
+
+  const { latitude, longitude, start, end } = {
+    latitude: selectedCoordinates[1],
+    longitude: selectedCoordinates[0],
+    ...dateRangeToApiParams(dateRange.start, dateRange.end),
+  }
+  useEffect(() => {
+    if (!rendered) return
+    // streamEvents dispatches synchronously (RESET_EVENTS/STREAM_STATUS)
+    // before its first await -- long-standing, intentional behavior
+    // (immediately marking the stream in-flight and clearing prior
+    // results), not something introduced by relocating this effect here.
+    // The lint rule can only see it now that the call site shares a file
+    // with streamEvents' own definition; it was equally true when this
+    // effect lived in MapWrapper, just invisible to static analysis
+    // across the context-consumer boundary.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void streamEvents({ latitude, longitude, start, end })
+
+    return () => {
+      cancelStream()
+    }
+  }, [latitude, longitude, start, end, streamEvents, cancelStream, rendered])
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Summary

Architecture-review deepening candidate #2: `MapWrapper.tsx` (462 lines, the most-changed file in the repo) bundled six unrelated concerns — Mapbox instance lifecycle, a resize-glitch workaround, event-selection camera control, search-boundary/fetch triggering, GeoJSON layer management, and cluster-click resolution — into one component, coordinated only via a shared `mapRef` with no internal seams.

- **Relocated search-boundary construction + `streamEvents`/`cancelStream` triggering into `eventsProvider.tsx`.** Neither concern touched Mapbox — it was just `searchProvider` and `eventsProvider` meeting, and only lived in `MapWrapper` because that's where the effect was first written.
- **`useMapInstance`**: Mapbox instance creation, geolocate control, cursor interactions. Reports geolocated coordinates via a callback instead of reverse-geocoding and updating search state itself.
- **`useResizeFix`**: the debounced `ResizeObserver` workaround, unchanged.
- **`useMapCamera`**: `flyToVenue`/`easeToLocation`/`fitToRadius` behind one interface — three call sites used to touch `mapRef.flyTo`/`easeTo`/`fitBounds` directly.
- **`useEventLayer`**: owns the "events" Mapbox layer end to end — its data (from `eventsByDate`) and its selection-driven icon styling (from `selectedEvents`), previously split across two effects that both independently touched the same layer.
- **`useClusterSelection`**: the click interaction, resolving clicked features back to real events.
- Extracted the pure cores into `lib/mapbox.ts` (`buildEventFeatureCollection`, `eventIconImageExpression`, `resolveEventsByIds`) — unit tested independently of Mapbox, which can't run outside a real browser/WebGL context.

**Two real, verified fixes found while consolidating:**
- The icon-highlight expression had quietly drifted into two different behaviors: layer creation matched *any* selected id (`"in"`), the reactive selection-change update only matched `selectedEvents[0]`'s id (`"=="`) — so a multi-event selection (e.g. from clicking a cluster) only highlighted one marker after the first update. Consolidated on the `"in"` behavior.
- `useMapInstance`'s mount effect never cleaned up the Mapbox instance on unmount, so React's Strict Mode double-invoke in development created a second `Map` layered on the same container — the first orphaned but its canvas never removed, silently blocking the real one. Added proper teardown; confirmed live (canvas count 2 → 1).

`MapWrapper.tsx`: 462 lines → ~125, and no longer touches the Mapbox API directly at all.

## Test plan
- [x] Full frontend suite: 86 tests pass (12 new, covering the extracted pure functions)
- [x] `lint` clean
- [x] `tsc -b && vite build` (the real type-check) succeeds
- [x] `prettier --check` clean
- [x] Live-verified in the browser: events stream and render in the drawer correctly (confirms the relocated search-triggering effect), zero console errors across all five new hooks executing every render, and directly confirmed the Strict Mode double-canvas fix (canvas count 2 → 1 after the `useMapInstance` cleanup fix)
- [ ] Full visual confirmation of map markers/clusters rendering was blocked by an unrelated environment limitation (this sandbox's browser only supports WebGL1; Mapbox GL JS v3 requires WebGL2) — confirmed this affects the *original*, unmodified file identically, so it's pre-existing and environment-specific, not a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)