### PR TITLE
Fix critical and high-impact UI audit findings

### DIFF
--- a/apps/web/src/DateSlider.tsx
+++ b/apps/web/src/DateSlider.tsx
@@ -56,7 +56,7 @@ const DateSlider = ({
                     type="button"
                     aria-current={isActive ? "date" : undefined}
                     className={
-                      "box-border min-w-14 cursor-pointer rounded-xl p-2 text-center text-xs leading-none transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-(--color-ivory-600) focus-visible:ring-offset-1 " +
+                      "box-border min-w-14 cursor-pointer rounded-xl p-2 max-md:py-2.5! text-center text-xs leading-none transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-(--color-ivory-600) focus-visible:ring-offset-1 " +
                       (isActive
                         ? "bg-(--color-ivory-600)"
                         : "bg-slate-400 hover:bg-slate-500 dark:bg-(--color-surface-dark-400) dark:hover:bg-(--color-surface-dark-300)")

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -1,6 +1,6 @@
 import { EventDetails } from "../EventDetails"
 import { XIcon } from "lucide-react"
-import { motion } from "motion/react"
+import { motion, useReducedMotion } from "motion/react"
 import {
   DrawerBody,
   DrawerContent,
@@ -78,6 +78,7 @@ const DestinationIcon = ({
 const DrawerWrapper = () => {
   const { eventsByDate, selectedEvents } = useEventsContext()
   const { isDrawerOpen, setIsDrawerOpen } = useDrawerProvider()
+  const shouldReduceMotion = useReducedMotion()
 
   const [activeTab, setActiveTab] = useState<Key>("explore")
   // FIXME: eventListRef is never attached to a DOM node, so the effect below
@@ -157,7 +158,7 @@ const DrawerWrapper = () => {
     >
       <DrawerClose
         aria-label="Close drawer"
-        className="absolute top-3 right-3 z-20"
+        className="absolute top-3 right-3 z-20 max-md:before:absolute max-md:before:-inset-1.5 max-md:before:content-['']"
         variant="quiet"
         onClick={() => setIsDrawerOpen(false)}
       >
@@ -170,7 +171,7 @@ const DrawerWrapper = () => {
           className="flex shrink-0 items-center justify-center gap-1.5 border-b border-black/10 px-3 pt-1 pr-14 pb-2 dark:border-white/10"
         >
           {destinationTabs.map(({ id, label }) => (
-            <Tab key={id} id={id} className="gap-1.5 px-3">
+            <Tab key={id} id={id} className="gap-1.5 px-3 py-3.5">
               <DestinationIcon id={id} size={16} />
               <span className="text-xs font-medium">{label}</span>
             </Tab>
@@ -253,7 +254,7 @@ const DrawerWrapper = () => {
           className="h-full shrink-0 overflow-hidden"
           initial={false}
           animate={{ width: isDrawerOpen ? desktopDrawerWidth : "0rem" }}
-          transition={DRAWER_TRANSITION}
+          transition={shouldReduceMotion ? { duration: 0 } : DRAWER_TRANSITION}
         >
           {drawerContent}
         </motion.div>

--- a/apps/web/src/EventCard.tsx
+++ b/apps/web/src/EventCard.tsx
@@ -51,7 +51,7 @@ const EventCard = ({
           alt={event.name}
         />
       </div>
-      <div className="flex h-auto flex-3 flex-col justify-between gap-2 p-3">
+      <div className="flex h-auto min-w-0 flex-3 flex-col justify-between gap-2 p-3">
         <div className="flex flex-col items-start gap-1">
           <h3 className="leading-tight font-semibold text-black dark:text-(--color-primary-dark-900)">
             {event.name}

--- a/apps/web/src/EventFilter.tsx
+++ b/apps/web/src/EventFilter.tsx
@@ -44,7 +44,7 @@ const EventFilter = () => {
           <Button
             aria-label="Filters"
             variant="secondary"
-            className="relative !h-9 !w-9 shrink-0"
+            className="relative !h-9 !w-9 shrink-0 max-md:before:absolute max-md:before:-inset-1 max-md:before:content-['']"
           >
             <FilterIcon aria-hidden className="block h-5 w-5 shrink-0" />
             {selected.size > 0 && (

--- a/apps/web/src/Search.tsx
+++ b/apps/web/src/Search.tsx
@@ -34,19 +34,47 @@ const Search = () => {
 
   const [searchTerm, setSearchTerm] = useState("")
   const [places, setPlaces] = useState<GeoJSONFeature[]>([])
+  const [isSuggestionsOpen, setIsSuggestionsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const listRef = useRef<HTMLUListElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
 
   const debounceValue = useDebounce(searchTerm, 500)
+  const isOpen = isSuggestionsOpen && places.length > 1
+  const listboxId = "typeahead-listbox"
+  const activeOptionId =
+    activeIndex !== null ? `typeahead-option-${activeIndex}` : undefined
 
   useEffect(() => {
     setInputRef(inputRef.current)
+    // TextField's props type doesn't recognize `role`, so the combobox role
+    // (there's no dedicated `<input type="combobox">`) is set imperatively.
+    inputRef.current?.setAttribute("role", "combobox")
   }, [setInputRef])
+
+  // react-aria-components' TextField/useTextField owns `aria-expanded` and
+  // `aria-activedescendant` internally and drops them if passed as JSX
+  // props (unlike `aria-controls`/`aria-autocomplete`, which pass through
+  // fine) — so they're kept in sync on the DOM node directly instead.
+  useEffect(() => {
+    const el = inputRef.current
+    if (!el) return
+    el.setAttribute("aria-expanded", String(isOpen))
+    if (isOpen && activeOptionId) {
+      el.setAttribute("aria-activedescendant", activeOptionId)
+    } else {
+      el.removeAttribute("aria-activedescendant")
+    }
+  }, [isOpen, activeOptionId])
 
   useEffect(() => {
     fetch(`/api/cities?q=${debounceValue}`)
       .then((resp) => resp.json())
-      .then((r) => setPlaces(r.features))
+      .then((r) => {
+        setPlaces(r.features)
+        setActiveIndex(null)
+        setIsSuggestionsOpen(true)
+      })
   }, [debounceValue])
 
   const updateSearchTerm = (e: string) => {
@@ -55,15 +83,43 @@ const Search = () => {
     }
     setSearchTerm(e)
   }
-  const listboxId = "typeahead-listbox"
 
   const selectPlace = (place: GeoJSONFeature) => {
     if (place.geometry.type === "GeometryCollection") return
     const coordinates = place.geometry.coordinates as [number, number]
     const location = locationFromFeature(place)
     setPlaces([place])
+    setIsSuggestionsOpen(false)
+    setActiveIndex(null)
     navigateToLocation([coordinates[0], coordinates[1]], location)
     setIsDrawerOpen(true)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) return
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault()
+        setActiveIndex((i) => (i === null ? 0 : (i + 1) % places.length))
+        break
+      case "ArrowUp":
+        e.preventDefault()
+        setActiveIndex((i) =>
+          i === null ? places.length - 1 : (i - 1 + places.length) % places.length
+        )
+        break
+      case "Enter":
+        if (activeIndex !== null) {
+          e.preventDefault()
+          selectPlace(places[activeIndex])
+        }
+        break
+      case "Escape":
+        e.preventDefault()
+        setIsSuggestionsOpen(false)
+        setActiveIndex(null)
+        break
+    }
   }
 
   return (
@@ -75,11 +131,16 @@ const Search = () => {
           type="text"
           autoComplete="off"
           aria-label="Search for a city"
+          aria-autocomplete="list"
+          aria-controls={listboxId}
           name="search"
           value={selectedLocation ? selectedLocation.fullAddress : searchTerm}
           placeholder="Search for a city"
           className="block w-full grow border-r-1 border-gray-300 p-0 text-base text-gray-900 outline-none placeholder:text-gray-400 focus:outline-none [&>input]:border-none"
           onChange={(e) => updateSearchTerm(e)}
+          onKeyDown={handleKeyDown}
+          onFocus={() => places.length > 1 && setIsSuggestionsOpen(true)}
+          onBlur={() => setIsSuggestionsOpen(false)}
         />
         <DateRangePicker
           aria-label="Select timeframe"
@@ -88,7 +149,7 @@ const Search = () => {
           className="[&>div]:border-none"
         />
       </div>
-      {places.length > 1 && (
+      {isOpen && (
         <ul
           ref={listRef}
           id={listboxId}
@@ -100,9 +161,13 @@ const Search = () => {
               key={option.id}
               id={`typeahead-option-${index}`}
               role="option"
+              aria-selected={index === activeIndex}
               tabIndex={-1}
-              className={`flex w-full cursor-pointer items-center px-3 py-1.5`}
+              className={`flex w-full cursor-pointer items-center px-3 py-1.5 ${
+                index === activeIndex ? "bg-gray-100" : ""
+              }`}
               onMouseDown={(e) => e.preventDefault()}
+              onMouseEnter={() => setActiveIndex(index)}
               onClick={() => selectPlace(option)}
             >
               {option.properties?.full_address}

--- a/packages/ui/src/components/ui/DateRangePicker.tsx
+++ b/packages/ui/src/components/ui/DateRangePicker.tsx
@@ -48,6 +48,12 @@ export function DateRangePicker<T extends DateValue>({
 
   const start = props.value?.start
   const end = props.value?.end
+  const triggerLabel =
+    start && end
+      ? isSameDay(start, end)
+        ? monthDayFormat.format(start.toDate(getLocalTimeZone()))
+        : `${monthDayFormat.format(start.toDate(getLocalTimeZone()))} to ${monthDayFormat.format(end.toDate(getLocalTimeZone()))}`
+      : "Select dates"
   return (
     <AriaDateRangePicker
       {...props}
@@ -57,8 +63,11 @@ export function DateRangePicker<T extends DateValue>({
       )}
     >
       {label && <Label>{label}</Label>}
-      <FieldGroup className="disabled:cursor-default">
-        <FieldButton className="mr-1 w-full cursor-pointer outline-offset-0">
+      <FieldGroup className="disabled:cursor-default max-md:h-11! max-md:items-stretch!">
+        <FieldButton
+          aria-label={triggerLabel}
+          className="mr-1 w-full cursor-pointer outline-offset-0"
+        >
           <div className="flex w-fit flex-1 items-center overflow-x-auto overflow-y-clip [scrollbar-width:none]">
             {start && (
               <span className="w-max ps-3 pe-2 text-sm">

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { AnimatePresence, motion, useDragControls } from "motion/react"
+import {
+  AnimatePresence,
+  motion,
+  useDragControls,
+  useReducedMotion,
+} from "motion/react"
 import { use, Children, cloneElement } from "react"
 import type { Ref } from "react"
 import type {
@@ -59,6 +64,11 @@ const DrawerContent = ({
 }: DrawerContentProps) => {
   const state = use(OverlayTriggerStateContext)!
   const dragControls = useDragControls()
+  const shouldReduceMotion = useReducedMotion()
+  const offscreen = {
+    x: side === "left" ? "-100%" : side === "right" ? "100%" : 0,
+    y: side === "top" ? "-100%" : side === "bottom" ? "100%" : 0,
+  }
   return (
     <AnimatePresence>
       {(props?.isOpen || state?.isOpen) && (
@@ -91,15 +101,9 @@ const DrawerContent = ({
               ].join(" "),
             className
           )}
-          animate={{ x: 0, y: 0 }}
-          initial={{
-            x: side === "left" ? "-100%" : side === "right" ? "100%" : 0,
-            y: side === "top" ? "-100%" : side === "bottom" ? "100%" : 0,
-          }}
-          exit={{
-            x: side === "left" ? "-100%" : side === "right" ? "100%" : 0,
-            y: side === "top" ? "-100%" : side === "bottom" ? "100%" : 0,
-          }}
+          animate={{ x: 0, y: 0, opacity: 1 }}
+          initial={shouldReduceMotion ? { opacity: 0 } : { ...offscreen, opacity: 1 }}
+          exit={shouldReduceMotion ? { opacity: 0 } : { ...offscreen, opacity: 1 }}
           drag={side === "left" || side === "right" ? "x" : "y"}
           whileDrag={{ cursor: "grabbing" }}
           dragConstraints={{


### PR DESCRIPTION
## Summary

Fixes from a `/ui-craft:audit` pass (a11y, performance, responsive) of the map/search surface.

**Critical**
- Location search typeahead was entirely mouse-only — no combobox semantics, no keyboard nav, and it never closed on Escape or click-outside. Now a proper combobox: `role="combobox"`, `aria-expanded`/`aria-activedescendant` (kept in sync via effect, since react-aria-components' `TextField` silently drops those two as JSX props), arrow-key roving highlight, Enter to select, Escape/blur to close.
- The date-range trigger's accessible name was always just `"Calendar"`, regardless of the selected range — screen reader users got no indication of the actual dates. It now gets an explicit `aria-label` built from the formatted range (`"August 3 to August 10"`).
- `prefers-reduced-motion` was never checked anywhere in the codebase, despite the drawer's slide/width transitions. Both are now gated behind `useReducedMotion()` with an opacity-only fallback. (Mapbox's `flyTo`/`easeTo` camera moves turned out to already respect the OS preference by default — no change needed there.)

**High-impact**
- `EventCard`'s venue/address text was hard-clipped mid-word instead of truncating with an ellipsis — its flex-3 text column was missing `min-w-0`, the classic Tailwind flex-truncation gotcha.
- Mobile touch targets across the drawer header (close button, filters, date-range trigger, day pills, destination tabs) measured 28–40px, under the 44px floor. Fixed with a mix of invisible hit-area expansion (where there was clipping-safe margin around the element) and real padding/height increases scoped to `max-md:` (where an ancestor's `overflow-hidden`/`overflow-clip` would have swallowed an invisible expansion).

A third finding — a missing cleanup function on the map's init effect, causing a duplicate Mapbox instance under StrictMode — had already been fixed independently in d0c63ab before this branch was cut, so no change was needed for it here.

## Test plan

- [x] `npm run typecheck` clean for both `web` and `@workspace/ui`
- [x] `npm run lint` clean for both workspaces
- [x] `apps/web` vitest suite passes (86/86)
- [x] Verified live in-browser: combobox keyboard flow (type → arrow → enter → select; escape/click-outside closes), date-range button's computed accessible name, drawer open/close with reduced-motion CSS branch confirmed via computed styles, all five touch targets measured ≥44px (or ≥44px effective hit area) at 375px, no visual regressions at 375/768/1280px or in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)