### PR TITLE
Fix mobile drawer responsiveness and dark/light-mode tab contrast

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -158,7 +158,7 @@ const DrawerWrapper = () => {
     >
       <DrawerClose
         aria-label="Close drawer"
-        className="absolute top-3 right-3 z-20 max-md:before:absolute max-md:before:-inset-1.5 max-md:before:content-['']"
+        className="absolute top-3 right-3 z-20 touch-manipulation max-md:before:absolute max-md:before:-inset-1.5 max-md:before:content-['']"
         variant="quiet"
         onClick={() => setIsDrawerOpen(false)}
       >
@@ -168,12 +168,19 @@ const DrawerWrapper = () => {
       {!isDesktop && (
         <TabList
           aria-label="Content sections"
-          className="flex shrink-0 items-center justify-center gap-1.5 border-b border-black/10 px-3 pt-1 pr-14 pb-2 dark:border-white/10"
+          className="flex shrink-0 items-center justify-center gap-1 border-b border-black/10 px-2 pt-1 pr-12 pb-2 dark:border-white/10"
         >
           {destinationTabs.map(({ id, label }) => (
-            <Tab key={id} id={id} className="gap-1.5 px-3 py-3.5">
+            <Tab
+              key={id}
+              id={id}
+              aria-label={label}
+              className="touch-manipulation gap-1.5 px-2 py-3.5"
+            >
               <DestinationIcon id={id} size={16} />
-              <span className="text-xs font-medium">{label}</span>
+              <span className="hidden text-xs font-medium min-[375px]:inline">
+                {label}
+              </span>
             </Tab>
           ))}
         </TabList>
@@ -238,7 +245,7 @@ const DrawerWrapper = () => {
               key={id}
               id={id}
               aria-label={label}
-              className="w-16 flex-col gap-1 rounded-lg px-2 py-2"
+              className="w-16 touch-manipulation flex-col gap-1 rounded-lg px-2 py-2"
             >
               <DestinationIcon id={id} size={20} />
               <span className="text-[10px] leading-none font-medium">

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -165,7 +165,19 @@ const DrawerContent = ({
                 : "h-full"
             )}
           >
-            <div className="relative bottom-0 left-0 z-15 flex h-full min-h-0 flex-col">
+            <div
+              className={twMerge(
+                "relative bottom-0 left-0 z-15 flex h-full min-h-0 flex-col",
+                // The sheet's own background still reaches the true bottom
+                // edge (no change there) — this keeps its *content* clear
+                // of the home indicator / gesture bar on notched phones.
+                // (Set here, not on the <Dialog> above: DrawerRoot clones
+                // Dialog with its own className via cloneElement, which
+                // replaces rather than merges, so anything added there
+                // never reaches the DOM.)
+                side === "bottom" && "pb-[env(safe-area-inset-bottom)]"
+              )}
+            >
               {notch && side === "bottom" && (
                 <div
                   className="notch absolute top-0 left-[50%] z-15 mx-auto my-2 my-2.5 h-1.5 w-10 shrink-0 translate-x-[-50%] touch-pan-y rounded-full bg-gray-400"

--- a/packages/ui/src/components/ui/Tabs.tsx
+++ b/packages/ui/src/components/ui/Tabs.tsx
@@ -63,7 +63,26 @@ export function TabList<T extends object>(props: TabListProps<T>) {
 
 const tabProps = tv({
   extend: focusRing,
-  base: "group relative flex items-center cursor-default rounded-full px-3 py-1.5 text-sm font-medium transition forced-color-adjust-none [-webkit-tap-highlight-color:transparent]",
+  // `isolate` scopes the SelectionIndicator's mix-blend-difference below to
+  // just this tab's own stacking context. Without it, the blend composites
+  // against whatever's behind the tab in the page's shared stacking context
+  // instead of just this tab's own icon/label — on a dark background that
+  // reads as a solid-black circle with the icon and label blended away
+  // entirely, rather than the intended inverted-color pill.
+  //
+  // `selected:text-white` forces the icon/label to a known, fixed color
+  // before the blend runs. The indicator's own background is always white
+  // and, blended against the transparent space around the icon/label, always
+  // composites out to white too — so the indicator itself never varies by
+  // theme. Left to inherit the normal (theme-dependent) text color, the
+  // difference-blend is far weaker in light mode: OKLCH's perceptually-even
+  // lightness scale isn't linear in sRGB, so light mode's dark text (~35/255)
+  // blends to a washed-out light gray (~220/255) against the white pill,
+  // while dark mode's light text (~250/255) happens to blend to strong
+  // near-black — the same trick, but only reliably readable in one theme.
+  // Pinning to white first makes every theme diff from the same value dark
+  // mode already gets for free: near-maximum, near-black marks on the pill.
+  base: "group relative isolate flex items-center cursor-default rounded-full px-3 py-1.5 text-sm font-medium transition selected:text-white forced-color-adjust-none [-webkit-tap-highlight-color:transparent]",
   variants: {
     isDisabled: {
       true: "text-neutral-200 dark:text-neutral-600 forced-colors:text-[GrayText] selected:text-white dark:selected:text-neutral-500 forced-colors:selected:text-[HighlightText] selected:bg-neutral-200 dark:selected:bg-neutral-600 forced-colors:selected:bg-[GrayText]",


### PR DESCRIPTION
## Summary

**Responsive pass on `DrawerWrapper.tsx`** (mobile-first, from a `/ui-craft:adapt` audit):
- `touch-manipulation` on the close button and destination tabs
- Fixed a genuine horizontal-overflow bug on the 320px mobile tab bar — the three destination tabs plus the reserved close-button space didn't actually fit; reduced padding/gaps so they do (verified `scrollWidth === clientWidth` after)
- Destination tab labels now hide below 375px and reappear at/above it, giving narrow phones breathing room while `aria-label` keeps the accessible name intact either way
- The mobile bottom-sheet drawer now respects `env(safe-area-inset-bottom)`, so its content doesn't sit under the home indicator / gesture bar on notched phones

**Tab selection-indicator contrast** — two related but distinct bugs, found while auditing the above and root-caused with a full debugging pass:
- **Dark mode**: the selected tab rendered as a solid black circle with the icon/label fully invisible. The `mix-blend-difference` `SelectionIndicator` had no `isolation: isolate`, so the blend composited against the page's shared stacking context instead of just the tab's own content. Fixed by scoping the blend with `isolate`.
- **Light mode**: even after the fix above, the selected tab's icon/label were washed out and hard to read. OKLCH's perceptually-even lightness scale isn't linear in sRGB, so the same difference-blend trick that works well in dark mode (near-white text diffs to near-black marks) produces weak contrast in light mode (near-black text only diffs to a light gray). Fixed by pinning selected-tab content to white before the blend runs, so both themes get the same strong contrast dark mode was already getting by coincidence.

## Test plan

- [x] `npm run typecheck` clean for `web` and `@workspace/ui`
- [x] `npm run lint` clean for both workspaces
- [x] `apps/web` vitest suite passes (86/86)
- [x] Verified live in-browser: 320px tab bar no longer overflows, touch targets and safe-area CSS confirmed via computed styles, selected-tab contrast confirmed correct in both light and dark mode on fresh reloads (desktop rail + mobile bottom bar), no regression to the previously-correct dark-mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)