### PR TITLE
Track map camera center/zoom (mapView)

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -5,6 +5,7 @@ import { useSearchProvider } from "./providers/searchProvider"
 import { useEventsContext } from "./providers/eventsProvider"
 import { useNavigateToLocation } from "./hooks/useNavigateToLocation"
 import { useMapInstance } from "./hooks/useMapInstance"
+import { useMapViewSync } from "./hooks/useMapViewSync"
 import { useResizeFix } from "./hooks/useResizeFix"
 import { useMapCamera } from "./hooks/useMapCamera"
 import { useEventLayer } from "./hooks/useEventLayer"
@@ -77,6 +78,7 @@ const MapWrapper = () => {
     handleGeolocate
   )
   useResizeFix(mapRef, mapContainer)
+  useMapViewSync(mapRef)
   const camera = useMapCamera(mapRef)
   useEventLayer(mapRef, eventsByDate, selectedEvents, selectEvents)
   useClusterSelection(mapRef, eventsByDate, selectEvents)

--- a/apps/web/src/hooks/useMapViewSync.ts
+++ b/apps/web/src/hooks/useMapViewSync.ts
@@ -1,0 +1,34 @@
+import { useEffect, type RefObject } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+import { useMapViewProvider } from "../providers/mapViewProvider"
+
+/** Records the map camera's settled position into mapViewProvider.
+ *
+ * Listens for "moveend" only, not continuous move/zoom frames -- Mapbox
+ * fires "moveend" once a pan, zoom, fly, or ease comes to rest, which
+ * covers zoom-only changes too (e.g. scroll-wheel zoom without panning),
+ * so a separate "zoomend" listener would be redundant. Keeping this off
+ * the high-frequency "move"/"zoom" events matters because it writes into
+ * Context, which re-renders every consumer on each update. */
+export function useMapViewSync(mapRef: RefObject<MapboxMap | null>) {
+  const { setMapView } = useMapViewProvider()
+
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map) return
+
+    const handleMoveEnd = () => {
+      const center = map.getCenter()
+      setMapView({
+        latitude: center.lat,
+        longitude: center.lng,
+        zoom: map.getZoom(),
+      })
+    }
+
+    map.on("moveend", handleMoveEnd)
+    return () => {
+      map.off("moveend", handleMoveEnd)
+    }
+  }, [mapRef, setMapView])
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -17,4 +17,13 @@ type Location = {
   coordinates: [number, number]
 }
 
-export type { Location }
+/** The map camera's current position -- distinct from `Location`/
+ * `selectedCoordinates`, which track the searched place rather than
+ * wherever the user has since panned or zoomed to. */
+type MapView = {
+  latitude: number
+  longitude: number
+  zoom: number
+}
+
+export type { Location, MapView }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "@/components/theme-provider.tsx"
 import { EventsProvider } from "./providers/eventsProvider"
 import { PlaylistProvider } from "./providers/playlistsProvider.tsx"
 import { SearchProvider } from "./providers/searchProvider.tsx"
+import { MapViewProvider } from "./providers/mapViewProvider.tsx"
 import { DrawerProvider } from "./providers/drawerProvider.tsx"
 
 createRoot(document.getElementById("root")!).render(
@@ -15,11 +16,13 @@ createRoot(document.getElementById("root")!).render(
       <BreakpointProvider>
         <DrawerProvider>
           <SearchProvider>
-            <EventsProvider>
-              <PlaylistProvider>
-                <App />
-              </PlaylistProvider>
-            </EventsProvider>
+            <MapViewProvider>
+              <EventsProvider>
+                <PlaylistProvider>
+                  <App />
+                </PlaylistProvider>
+              </EventsProvider>
+            </MapViewProvider>
           </SearchProvider>
         </DrawerProvider>
       </BreakpointProvider>

--- a/apps/web/src/providers/mapViewProvider.tsx
+++ b/apps/web/src/providers/mapViewProvider.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from "react"
+import type { MapView } from "../lib/types"
+import { DEFAULT_CENTER } from "./searchProvider"
+
+// Same zoom the camera already settles to after a search (see
+// useMapCamera's easeToLocation) -- keeps a first-ever visitor's default
+// mapView consistent with what they'd see once the map finishes easing in.
+const DEFAULT_ZOOM = 12
+
+const DEFAULT_MAP_VIEW: MapView = {
+  latitude: DEFAULT_CENTER[1],
+  longitude: DEFAULT_CENTER[0],
+  zoom: DEFAULT_ZOOM,
+}
+
+const MAP_VIEW_STORAGE_KEY = "gigeo:lastMapView"
+
+function readStoredMapView(): MapView | undefined {
+  try {
+    const raw = localStorage.getItem(MAP_VIEW_STORAGE_KEY)
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw)
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof parsed.latitude === "number" &&
+      typeof parsed.longitude === "number" &&
+      typeof parsed.zoom === "number" &&
+      Number.isFinite(parsed.latitude) &&
+      Number.isFinite(parsed.longitude) &&
+      Number.isFinite(parsed.zoom)
+    ) {
+      return {
+        latitude: parsed.latitude,
+        longitude: parsed.longitude,
+        zoom: parsed.zoom,
+      }
+    }
+  } catch {
+    // localStorage unavailable (e.g. private browsing) or malformed value —
+    // fall through to the default.
+  }
+  return undefined
+}
+
+type MapViewProviderState = {
+  mapView: MapView
+  setMapView: (view: MapView) => void
+}
+
+type MapViewProviderProps = {
+  children: React.ReactNode
+}
+
+export const MapViewProviderContext = React.createContext<
+  MapViewProviderState | undefined
+>(undefined)
+
+export function MapViewProvider({ children }: MapViewProviderProps) {
+  const [mapView, setMapView] = React.useState<MapView>(
+    () => readStoredMapView() ?? DEFAULT_MAP_VIEW
+  )
+
+  // Remember the last camera position so a returning visitor's map starts
+  // roughly where they left it, mirroring searchProvider's coordinate
+  // persistence.
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(MAP_VIEW_STORAGE_KEY, JSON.stringify(mapView))
+    } catch {
+      // Ignore — localStorage may be unavailable (e.g. private browsing).
+    }
+  }, [mapView])
+
+  return (
+    <MapViewProviderContext value={{ mapView, setMapView }}>
+      {children}
+    </MapViewProviderContext>
+  )
+}
+
+export const useMapViewProvider = () => {
+  const context = React.useContext(MapViewProviderContext)
+
+  if (context === undefined) {
+    throw new Error("useMapViewProvider must be used within a MapViewProvider")
+  }
+
+  return context
+}

--- a/apps/web/src/providers/searchProvider.tsx
+++ b/apps/web/src/providers/searchProvider.tsx
@@ -11,7 +11,8 @@ import type { Location } from "../lib/types"
 // Geographic center of the contiguous US — used only when there's no
 // remembered location and geolocation permission hasn't already been
 // granted. Previously this defaulted to the middle of the Atlantic.
-const DEFAULT_CENTER: [number, number] = [-98.5795, 39.8283]
+// Exported so mapViewProvider can fall back to the same point.
+export const DEFAULT_CENTER: [number, number] = [-98.5795, 39.8283]
 
 const COORDINATES_STORAGE_KEY = "gigeo:lastCoordinates"
 const LOCATION_STORAGE_KEY = "gigeo:lastLocation"


### PR DESCRIPTION
## Summary
- First of a 3-part change to store the map's current geographic center point (lat/lng/zoom) like Google Maps, enabling shareable location links and a future "search this area" refetch action.
- Adds `mapViewProvider` tracking `{ latitude, longitude, zoom }`, kept deliberately separate from `selectedCoordinates` (the committed search pin) — panning/zooming the camera doesn't change what location events are fetched for.
- Updates only on Mapbox's `moveend` (covers pan and zoom-only changes) to avoid re-rendering Context consumers on every drag frame.
- Persists to `localStorage` under `gigeo:lastMapView`, mirroring the existing `gigeo:lastCoordinates` pattern, so a returning visitor's camera starts roughly where they left it.

## Follow-ups (separate PRs)
1. Read `lat`/`lng`/`zoom` from the URL on load + live `history.replaceState` sync for shareable links.
2. A "search this area" button: shows once the camera has panned far enough from the last search (relative to the last-successful search radius), re-fetches from that radius tier on click, and cancels the superseded in-flight event stream.

## Test plan
- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` passes
- [ ] Manual verification in a browser with real `VITE_MAPBOX_ACCESS_TOKEN`/style env vars and the API running (not available in this sandbox — confirmed the app mounts without provider/import errors, but couldn't render the live map to exercise `moveend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)