### PR TITLE
Read/write the map view to the URL for shareable location links

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import type { Map as MapboxMap } from "mapbox-gl"
 import type { GeoJSONFeature } from "mapbox-gl"
 import { useSearchProvider } from "./providers/searchProvider"
+import { useMapViewProvider } from "./providers/mapViewProvider"
 import { useEventsContext } from "./providers/eventsProvider"
 import { useNavigateToLocation } from "./hooks/useNavigateToLocation"
 import { useMapInstance } from "./hooks/useMapInstance"
@@ -18,6 +19,7 @@ import "./App.css"
 
 const MapWrapper = () => {
   const { selectedCoordinates, setSelectedLocation } = useSearchProvider()
+  const { mapView, isRestoredMapView } = useMapViewProvider()
   const navigateToLocation = useNavigateToLocation()
   const [rendered, setRendered] = useState(false)
   useEffect(() => {
@@ -26,6 +28,13 @@ const MapWrapper = () => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setRendered(true)
   }, [])
+
+  // A shared link or a remembered session already has a real camera
+  // position -- the mount-time ease-to-search-location below should fire
+  // for genuine location changes, but not once, initially, on top of a
+  // position we just restored. Ref (not state): this only needs to gate
+  // the first post-mount firing, never trigger a render itself.
+  const skipInitialEaseRef = useRef(isRestoredMapView)
 
   const {
     eventsByDate,
@@ -74,8 +83,11 @@ const MapWrapper = () => {
     mapRef,
     "map-container",
     theme,
-    selectedCoordinates,
-    handleGeolocate
+    isRestoredMapView
+      ? [mapView.longitude, mapView.latitude]
+      : selectedCoordinates,
+    handleGeolocate,
+    isRestoredMapView ? mapView.zoom : undefined
   )
   useResizeFix(mapRef, mapContainer)
   useMapViewSync(mapRef)
@@ -95,6 +107,10 @@ const MapWrapper = () => {
 
   useEffect(() => {
     if (!rendered) return
+    if (skipInitialEaseRef.current) {
+      skipInitialEaseRef.current = false
+      return
+    }
     camera.easeToLocation(selectedCoordinates)
   }, [selectedCoordinates, rendered, camera])
 

--- a/apps/web/src/hooks/useMapInstance.ts
+++ b/apps/web/src/hooks/useMapInstance.ts
@@ -20,7 +20,8 @@ export function useMapInstance(
   containerId: string,
   style: string,
   initialCenter: [number, number],
-  onGeolocate: (coordinates: [number, number]) => void
+  onGeolocate: (coordinates: [number, number]) => void,
+  initialZoom: number = INITIAL_ZOOM
 ) {
   const [selectedFeature, setSelectedFeature] = useState<GeoJSONFeature | null>(
     null
@@ -33,7 +34,7 @@ export function useMapInstance(
       style,
       container: containerId,
       center: initialCenter,
-      zoom: INITIAL_ZOOM,
+      zoom: initialZoom,
     })
 
     mapRef.current.on("load", () => {

--- a/apps/web/src/lib/mapViewUrl.ts
+++ b/apps/web/src/lib/mapViewUrl.ts
@@ -1,0 +1,52 @@
+import { z } from "zod"
+import type { MapView } from "./types"
+
+// Mapbox GL's supported zoom range -- matches what the map itself will
+// clamp to, so an out-of-range URL value is rejected here rather than
+// silently clamped by Mapbox later.
+const mapViewParamsSchema = z.object({
+  lat: z.coerce.number().min(-90).max(90),
+  lng: z.coerce.number().min(-180).max(180),
+  zoom: z.coerce.number().min(0).max(22),
+})
+
+/** Parses `lat`/`lng`/`zoom` out of a URL query string. All three must be
+ * present and valid -- a partial or malformed set is treated the same as
+ * absent, since there's no sensible way to fill in just one missing
+ * coordinate. */
+export function readMapViewFromSearch(search: string): MapView | undefined {
+  const params = new URLSearchParams(search)
+  const lat = params.get("lat")
+  const lng = params.get("lng")
+  const zoom = params.get("zoom")
+  if (lat === null || lng === null || zoom === null) return undefined
+
+  const result = mapViewParamsSchema.safeParse({ lat, lng, zoom })
+  if (!result.success) return undefined
+
+  return {
+    latitude: result.data.lat,
+    longitude: result.data.lng,
+    zoom: result.data.zoom,
+  }
+}
+
+/** Writes `mapView` into the current URL's query string via
+ * `history.replaceState` -- never `pushState`, so continuous panning
+ * doesn't turn the back button into a map-undo stack. Preserves any other
+ * query params already present rather than clobbering the whole string.
+ * Precision matches what Google Maps links carry: enough to reproduce the
+ * view, not enough to imply sub-meter accuracy. */
+export function writeMapViewToUrl(view: MapView) {
+  try {
+    const params = new URLSearchParams(window.location.search)
+    params.set("lat", view.latitude.toFixed(6))
+    params.set("lng", view.longitude.toFixed(6))
+    params.set("zoom", view.zoom.toFixed(2))
+
+    const url = `${window.location.pathname}?${params.toString()}${window.location.hash}`
+    window.history.replaceState(null, "", url)
+  } catch {
+    // window/history unavailable (e.g. a non-browser test environment).
+  }
+}

--- a/apps/web/src/providers/mapViewProvider.tsx
+++ b/apps/web/src/providers/mapViewProvider.tsx
@@ -2,6 +2,7 @@
 import * as React from "react"
 import type { MapView } from "../lib/types"
 import { DEFAULT_CENTER } from "./searchProvider"
+import { readMapViewFromSearch, writeMapViewToUrl } from "../lib/mapViewUrl"
 
 // Same zoom the camera already settles to after a search (see
 // useMapCamera's easeToLocation) -- keeps a first-ever visitor's default
@@ -47,6 +48,13 @@ function readStoredMapView(): MapView | undefined {
 type MapViewProviderState = {
   mapView: MapView
   setMapView: (view: MapView) => void
+  /** Whether the initial `mapView` came from a shared link or a
+   * remembered session, rather than the app's static default. Consumers
+   * use this to skip a first-load "ease in" animation that would
+   * otherwise fly away from a deep-linked/restored position back to the
+   * default search location. Reflects only the value at mount -- it does
+   * not change as the user navigates afterward. */
+  isRestoredMapView: boolean
 }
 
 type MapViewProviderProps = {
@@ -58,9 +66,22 @@ export const MapViewProviderContext = React.createContext<
 >(undefined)
 
 export function MapViewProvider({ children }: MapViewProviderProps) {
-  const [mapView, setMapView] = React.useState<MapView>(
-    () => readStoredMapView() ?? DEFAULT_MAP_VIEW
-  )
+  // Computed once, at mount, from the URL/localStorage. A ref would also
+  // work here but React forbids reading/writing ref values during render
+  // (only effects/handlers) -- useMemo with an empty dependency array
+  // gets the same "compute once" behavior without tripping that rule.
+  const initial = React.useMemo(() => {
+    const fromUrl = readMapViewFromSearch(window.location.search)
+    if (fromUrl) return { mapView: fromUrl, isRestoredMapView: true }
+
+    const fromStorage = readStoredMapView()
+    if (fromStorage) return { mapView: fromStorage, isRestoredMapView: true }
+
+    return { mapView: DEFAULT_MAP_VIEW, isRestoredMapView: false }
+  }, [])
+  const isRestoredMapView = initial.isRestoredMapView
+
+  const [mapView, setMapView] = React.useState<MapView>(initial.mapView)
 
   // Remember the last camera position so a returning visitor's map starts
   // roughly where they left it, mirroring searchProvider's coordinate
@@ -73,8 +94,21 @@ export function MapViewProvider({ children }: MapViewProviderProps) {
     }
   }, [mapView])
 
+  // Keeps the address bar shareable at all times, Google-Maps-style --
+  // never history.pushState, so panning doesn't turn the back button into
+  // a map-undo stack. See writeMapViewToUrl for why.
+  React.useEffect(() => {
+    writeMapViewToUrl(mapView)
+  }, [mapView])
+
   return (
-    <MapViewProviderContext value={{ mapView, setMapView }}>
+    <MapViewProviderContext
+      value={{
+        mapView,
+        setMapView,
+        isRestoredMapView,
+      }}
+    >
       {children}
     </MapViewProviderContext>
   )


### PR DESCRIPTION
Deep-linking, Google-Maps style: ?lat=&lng=&zoom= is read on load (via zod, mirroring the wire-boundary validation pattern) and kept live via history.replaceState as the camera moves -- never pushState, so panning doesn't turn the back button into a map-undo stack. Invalid or partial params fall through the same URL -> localStorage -> default precedence mapView already uses, and get corrected back into the address bar.

A restored view (from a link or a remembered session) now also seeds the map's actual initial camera position and skips the mount-time ease-to-search-location animation, so opening a shared link shows that location immediately instead of flying away from it back to the current search pin. The URL intentionally does not touch selectedCoordinates/the event search -- panning a shared map still doesn't search anything until "search this area" (next up) is clicked, consistent with why mapView and selectedCoordinates are separate.