### PR TITLE
Add a "search this area" button to re-search a panned-to location

### DIFF
--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -13,6 +13,7 @@ import { useEventLayer } from "./hooks/useEventLayer"
 import { useClusterSelection } from "./hooks/useClusterSelection"
 import { locationFromFeature } from "./lib/mapbox"
 import { DrawerWrapper } from "./Drawer/DrawerWrapper"
+import { SearchThisAreaButton } from "./SearchThisAreaButton"
 import { useIsMobile } from "./providers/Breakpoint"
 import "mapbox-gl/dist/mapbox-gl.css"
 import "./App.css"
@@ -29,12 +30,15 @@ const MapWrapper = () => {
     setRendered(true)
   }, [])
 
-  // A shared link or a remembered session already has a real camera
-  // position -- the mount-time ease-to-search-location below should fire
-  // for genuine location changes, but not once, initially, on top of a
-  // position we just restored. Ref (not state): this only needs to gate
-  // the first post-mount firing, never trigger a render itself.
-  const skipInitialEaseRef = useRef(isRestoredMapView)
+  // Suppresses the next firing of the ease-to-search-location effect
+  // below. Set from two places: (1) a shared link or remembered session
+  // already has a real camera position, so the very first post-mount
+  // firing shouldn't fly away from it back to the search location; (2) a
+  // "search this area" click deliberately sets selectedCoordinates to
+  // wherever the camera already is, and shouldn't yank the view to a
+  // hardcoded zoom in response to its own change. Ref, not state: only
+  // needs to gate the next effect firing, never trigger a render itself.
+  const skipNextEaseRef = useRef(isRestoredMapView)
 
   const {
     eventsByDate,
@@ -43,7 +47,16 @@ const MapWrapper = () => {
     isStreaming,
     searchRadius,
     radiusExpanded,
+    searchThisArea,
   } = useEventsContext()
+
+  const handleSearchThisArea = useCallback(
+    (coordinates: [number, number]) => {
+      skipNextEaseRef.current = true
+      searchThisArea(coordinates)
+    },
+    [searchThisArea]
+  )
 
   const mapRef = useRef<MapboxMap | null>(null)
   const mapContainer = useRef<HTMLDivElement | null>(null)
@@ -107,8 +120,8 @@ const MapWrapper = () => {
 
   useEffect(() => {
     if (!rendered) return
-    if (skipInitialEaseRef.current) {
-      skipInitialEaseRef.current = false
+    if (skipNextEaseRef.current) {
+      skipNextEaseRef.current = false
       return
     }
     camera.easeToLocation(selectedCoordinates)
@@ -127,6 +140,7 @@ const MapWrapper = () => {
       <div className="relative flex min-h-0 flex-1">
         {!useIsMobile() && <DrawerWrapper />}
         <div ref={mapContainer} id="map-container" className="h-full w-full" />
+        <SearchThisAreaButton onSearchThisArea={handleSearchThisArea} />
       </div>
     </>
   )

--- a/apps/web/src/SearchThisAreaButton.tsx
+++ b/apps/web/src/SearchThisAreaButton.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@workspace/ui/components/ui/Button"
+import { RefreshCw } from "lucide-react"
+import { useSearchProvider } from "./providers/searchProvider"
+import { useMapViewProvider } from "./providers/mapViewProvider"
+import { useEventsContext } from "./providers/eventsProvider"
+import { distanceMiles } from "./lib/geo"
+
+// How far the camera has to drift from the last search, relative to the
+// radius that search actually needed, before re-searching is worth
+// offering. Half the radius: close enough that the previous results
+// still mostly cover the visible area, far enough that a meaningful
+// chunk of what's on screen wasn't part of that search.
+const OFFER_THRESHOLD_RATIO = 0.5
+
+type SearchThisAreaButtonProps = {
+  /** Left to the caller (MapWrapper) rather than calling
+   * eventsProvider's searchThisArea directly -- MapWrapper also needs to
+   * know a search-this-area click happened, to suppress the camera's
+   * usual "ease to the search location" animation that would otherwise
+   * yank the view away from wherever the user just panned to. */
+  onSearchThisArea: (coordinates: [number, number]) => void
+}
+
+/** Google Maps' "search this area" button -- appears once the camera has
+ * panned away from the last searched location, and re-runs the search at
+ * the camera's current position on click. Deliberately keyed off
+ * distance from the *search* location (selectedCoordinates), not zoom:
+ * zooming in or out doesn't invalidate a radius-based search the way
+ * panning away from its center does. */
+export function SearchThisAreaButton({
+  onSearchThisArea,
+}: SearchThisAreaButtonProps) {
+  const { selectedCoordinates } = useSearchProvider()
+  const { mapView } = useMapViewProvider()
+  const { searchRadius, isStreaming } = useEventsContext()
+
+  if (searchRadius === null || isStreaming) return null
+
+  const cameraCoordinates: [number, number] = [
+    mapView.longitude,
+    mapView.latitude,
+  ]
+  const distance = distanceMiles(cameraCoordinates, selectedCoordinates)
+  const shouldOffer = distance > searchRadius * OFFER_THRESHOLD_RATIO
+
+  if (!shouldOffer) return null
+
+  return (
+    <Button
+      variant="secondary"
+      onPress={() => onSearchThisArea(cameraCoordinates)}
+      className="absolute top-4 left-1/2 z-10 -translate-x-1/2 gap-2 shadow-md"
+    >
+      <RefreshCw aria-hidden className="h-4 w-4" />
+      Search this area
+    </Button>
+  )
+}

--- a/apps/web/src/lib/geo.ts
+++ b/apps/web/src/lib/geo.ts
@@ -1,4 +1,23 @@
 const MILES_PER_DEGREE_LATITUDE = 69
+const EARTH_RADIUS_MILES = 3958.8
+
+/** Great-circle distance between two [lng, lat] points, in miles. */
+export function distanceMiles(
+  a: [number, number],
+  b: [number, number]
+): number {
+  const [lng1, lat1] = a
+  const [lng2, lat2] = b
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+
+  const dLat = toRad(lat2 - lat1)
+  const dLng = toRad(lng2 - lng1)
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
+
+  return 2 * EARTH_RADIUS_MILES * Math.asin(Math.min(1, Math.sqrt(h)))
+}
 
 /** Bounding box (west/south, east/north) for a circle of `radiusMiles`
  * around `center`. Approximate — fine for camera framing, not for

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -60,6 +60,11 @@ type StreamConcertsInput = {
   longitude: number
   start: string
   end: string
+  /** Radius tier (miles) to start widening from, skipping any smaller
+   * tiers that a previous nearby search already knows come up empty.
+   * Defaults to the smallest tier -- a genuinely new location has no such
+   * guarantee. */
+  startRadius?: number
 }
 
 type StreamConcertsParams = StreamConcertsInput & {
@@ -71,6 +76,12 @@ type EventsContextValue = EventsState & {
   cancelStream: () => void
   selectEvents: (events: EventResponse[]) => void
   resetEvents: () => void
+  /** Re-searches at `coordinates` starting from the last-successful radius
+   * tier rather than resetting to the smallest one -- for "search this
+   * area", where the user hasn't indicated local event density has
+   * changed, just their location. Unlike useNavigateToLocation, this
+   * doesn't reset the selected-location label or date range. */
+  searchThisArea: (coordinates: [number, number]) => void
   /** The radius (miles) the current/last search actually used. */
   searchRadius: number | null
   /** Whether searchRadius went beyond the base tier to find results. */
@@ -187,10 +198,13 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       dispatch({ type: "STREAM_STATUS", payload: { isStreaming: true } })
       setSearchRadius(null)
 
+      const startRadius = params.startRadius ?? BASE_RADIUS
+      const tiers = RADIUS_TIERS.filter((radius) => radius >= startRadius)
+
       try {
         let totalCount = 0
 
-        for (const radius of RADIUS_TIERS) {
+        for (const radius of tiers) {
           if (controller.signal.aborted) return
 
           const tierCount = await runStream(
@@ -230,7 +244,8 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
   // this is just the two providers' own concerns meeting, and previously
   // only met inside MapWrapper because that's where the effect was first
   // written, not because the map needed to own it.
-  const { selectedCoordinates, dateRange } = useSearchProvider()
+  const { selectedCoordinates, setSelectedCoordinates, dateRange } =
+    useSearchProvider()
   const [rendered, setRendered] = useState(false)
   useEffect(() => {
     // Marks first-mount completion so the search effect below skips its
@@ -239,6 +254,19 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
     setRendered(true)
   }, [])
 
+  // Set just before a "search this area" coordinate change, consumed by
+  // the reactive effect below on the render that change causes. A ref
+  // rather than state: it's read once, synchronously, by that effect --
+  // it never needs to itself trigger a render.
+  const startRadiusOverrideRef = useRef<number | null>(null)
+  const searchThisArea = useCallback(
+    (coordinates: [number, number]) => {
+      startRadiusOverrideRef.current = searchRadius ?? BASE_RADIUS
+      setSelectedCoordinates(coordinates)
+    },
+    [searchRadius, setSelectedCoordinates]
+  )
+
   const { latitude, longitude, start, end } = {
     latitude: selectedCoordinates[1],
     longitude: selectedCoordinates[0],
@@ -246,16 +274,10 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
   }
   useEffect(() => {
     if (!rendered) return
-    // streamEvents dispatches synchronously (RESET_EVENTS/STREAM_STATUS)
-    // before its first await -- long-standing, intentional behavior
-    // (immediately marking the stream in-flight and clearing prior
-    // results), not something introduced by relocating this effect here.
-    // The lint rule can only see it now that the call site shares a file
-    // with streamEvents' own definition; it was equally true when this
-    // effect lived in MapWrapper, just invisible to static analysis
-    // across the context-consumer boundary.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void streamEvents({ latitude, longitude, start, end })
+    const startRadius = startRadiusOverrideRef.current ?? BASE_RADIUS
+    startRadiusOverrideRef.current = null
+
+    void streamEvents({ latitude, longitude, start, end, startRadius })
 
     return () => {
       cancelStream()
@@ -269,6 +291,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       cancelStream,
       resetEvents,
       selectEvents,
+      searchThisArea,
       searchRadius,
       radiusExpanded,
     }),
@@ -278,6 +301,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       cancelStream,
       resetEvents,
       selectEvents,
+      searchThisArea,
       searchRadius,
       radiusExpanded,
     ]


### PR DESCRIPTION
Google-Maps-style: once the camera has drifted more than half the last search's radius away from selectedCoordinates, a button offers to search where the user actually panned to, instead of silently re-searching on every pan or requiring a brand new location search. Distance-only -- zooming alone doesn't invalidate a radius-based search the way moving away from its center does.

Clicking it re-searches from the last-successful radius tier rather than resetting to the smallest one (the user hasn't indicated local event density changed, just their location), and leaves the camera exactly where it is instead of easing it to the usual fixed zoom a brand new search would. The existing per-location stream-cancellation (abort + effect cleanup) already covers rapid successive re-searches, including this one, without further changes.