### PR TITLE
Wire up the unused shadcn token layer to the brand palette

### DIFF
--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -1,7 +1,19 @@
 @import "tailwindcss";
 @plugin "tailwindcss-react-aria-components";
 
-@theme {
+/* `static` forces every variable below to always emit as a real CSS
+   custom property. Required for cross-package references specifically:
+   packages/ui/src/styles/globals.css now references some of these
+   primitives via plain var() (wiring up its dark-mode tokens), but that
+   file is its own separate Tailwind compilation -- a var() reference
+   from a different entry point's CSS doesn't count as "usage" for this
+   file's own tree-shaking, so an otherwise-unreferenced-in-this-file
+   primitive (e.g. one only used from globals.css, never as a literal
+   utility class anywhere) gets silently dropped without `static`.
+   Confirmed empirically: --color-surface-dark-800 resolved to nothing
+   in the browser until this was added, despite the reference in
+   globals.css looking correct. */
+@theme static {
   --color-jet-black-50: oklch(96.05% 0.005 258.32);
   --color-jet-black-100: oklch(92.23% 0.008 241.67);
   --color-jet-black-200: oklch(84.3% 0.016 241.81);

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -90,8 +90,35 @@
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
+    /* --background/--foreground/--muted/--muted-foreground below are wired
+       to apps/web/src/App.css's brand primitives instead of achromatic
+       (zero-chroma) Tailwind defaults -- these four are the ones with a
+       real, live consumer today: --background/--foreground via the
+       `body { @apply bg-background text-foreground }` base-layer rule
+       below, --muted-foreground via 13+ `text-muted-foreground` call
+       sites. That base-layer body rule was the actual root cause of the
+       achromatic dark-canvas finding from /finalize's Pass 3 -- every
+       page's dark-mode background came from here.
+
+       --color-bg-dark-900 / --color-text-primary-dark-200 / etc. are
+       defined in apps/web/src/App.css, not this file -- packages/ui is
+       coupled to that app's brand palette here. Fine today (apps/web is
+       this package's only consumer, per CONTEXT-MAP.md), but revisit if
+       packages/ui ever needs to be app-agnostic.
+
+       --primary/--secondary/--accent/--card/--popover/--destructive/
+       --border/--input/--ring and light mode are deliberately untouched:
+       --primary and --secondary have ambiguous, mixed existing usage
+       (sometimes heading text, sometimes a real accent/selected-state
+       tint) that a value change could visibly break without a review of
+       each call site -- that's the larger "re-theme the shared library"
+       migration already explicitly deferred, not this fix. --card/
+       --popover have zero live consumers (confirmed: no bg-card/
+       bg-popover anywhere in either package). --destructive/--border/
+       --ring already function correctly as conventional red/neutral
+       chrome and don't need brand hue. */
+    --background: var(--color-bg-dark-900);
+    --foreground: var(--color-text-primary-dark-200);
     --card: oklch(0.205 0 0);
     --card-foreground: oklch(0.985 0 0);
     --popover: oklch(0.205 0 0);
@@ -100,8 +127,8 @@
     --primary-foreground: oklch(0.205 0 0);
     --secondary: oklch(0.269 0 0);
     --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
+    --muted: var(--color-surface-dark-800);
+    --muted-foreground: var(--color-text-secondary-dark-400);
     --accent: oklch(0.269 0 0);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);


### PR DESCRIPTION
## Summary

Resolves the Major finding from `/finalize`'s Pass 3 (achromatic dark canvas) by wiring the four shadcn semantic tokens that have real, live consumers to the brand palette instead of generic achromatic Tailwind defaults, in `packages/ui/src/styles/globals.css`:

| Token | Consumer (confirmed via grep) | Before → After (dark mode) |
|---|---|---|
| `--background` | `body { @apply bg-background }` — root cause of the achromatic-canvas finding | `oklch(0.145 0 0)` (zero chroma) → `var(--color-bg-dark-900)` |
| `--foreground` | `body { @apply text-foreground }` | `oklch(0.985 0 0)` → `var(--color-text-primary-dark-200)` |
| `--muted-foreground` | 13 `text-muted-foreground` call sites | `oklch(0.708 0 0)` → `var(--color-text-secondary-dark-400)` |
| `--muted` | none today; fixed anyway, same semantic pair | `oklch(0.269 0 0)` → `var(--color-surface-dark-800)` |

Light mode is untouched — it already matched the app's established visual design.

**Deliberately left alone**: `--primary`/`--secondary` (mixed, ambiguous existing usage — sometimes heading text, sometimes a real accent tint — repointing risks a visible surprise across files this change didn't review; that's the bigger "re-theme the shared library" migration already explicitly deferred earlier); `--card`/`--popover` (zero live consumers anywhere in either package); `--destructive`/`--border`/`--input`/`--ring` (already correct conventional red/neutral chrome); `--chart-*`/`--sidebar-*` (zero usage — no chart or sidebar component exists in the app).

**Also**: adds `@theme static` to `apps/web/src/App.css`'s primitive block. Needed for a real cross-package Tailwind v4 tree-shaking edge case caught during verification — `packages/ui/globals.css` and `apps/web/App.css` are two independent Tailwind compilations, so a cross-file `var()` reference doesn't count as "usage" for the defining file's own tree-shaking. `--color-surface-dark-800` resolved to nothing until this was added, despite the reference being correct.

## Test plan

- [x] `tsc -b --noEmit` passes
- [x] Verified live via a clean dev-server restart (not a cache-busted re-import — ruling out a stale-cache false signal specifically):
  - dark mode: `--background`/`--foreground`/`--muted`/`--muted-foreground` all resolve to the intended branded values; body background now has real chroma (`0.008` vs. the old `0`)
  - light mode: unchanged (`oklch(1 0 0)` bg, `oklch(0.145 0 0)` text)
  - `--primary`/`--card`/`--destructive` confirmed unchanged, as intended
  - no CSS build errors in dev server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)