### PR TITLE
Close out remaining /finalize findings + re-theme --primary

### DIFF
--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -2,6 +2,7 @@ import type { AmArtistFull, ExternalLinks } from "./lib/types"
 import { Button } from "@workspace/ui/components/ui/Button"
 import { Link } from "@workspace/ui/components/ui/Link"
 import { AnimatePresence, motion, useReducedMotion } from "motion/react"
+import { MOTION_DURATION, MOTION_EASE } from "@workspace/ui/lib/motion"
 import { useCallback, useEffect, useState, useRef } from "react"
 import { ResponsiveImage } from "@workspace/ui/components/ui/ResponsiveImage"
 import {
@@ -154,8 +155,8 @@ const EventDetails = ({
             initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
-            className="sticky top-0 z-20 flex items-center justify-between gap-2 border-b border-slate-800/40 bg-slate-950/90 py-2 pe-14 ps-3 text-xs text-slate-100 backdrop-blur"
+            transition={{ duration: MOTION_DURATION.base, ease: MOTION_EASE.out }}
+            className="sticky top-0 z-sticky flex items-center justify-between gap-2 border-b border-slate-800/40 bg-slate-950/90 py-2 pe-14 ps-3 text-xs text-slate-100 backdrop-blur"
           >
             <div className="flex min-w-0 items-center">
               {/* bg-(--surface-secondary) is repeated under dark: because Button's
@@ -209,7 +210,7 @@ const EventDetails = ({
             initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+            transition={{ duration: MOTION_DURATION.base, ease: MOTION_EASE.out }}
           >
             <Button
               aria-label="Back to events"
@@ -230,7 +231,7 @@ const EventDetails = ({
             initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+            transition={{ duration: MOTION_DURATION.base, ease: MOTION_EASE.out }}
           >
             <Link
               variant="button"
@@ -385,7 +386,13 @@ export const ArtistCard: React.FC<ArtistCardProps> = ({
 
   return (
     <div
-      className="grid gap-4 p-4 text-slate-50 shadow-lg dark:text-(--color-text-secondary-600)"
+      // Shadows are close to invisible on a near-black surface (no contrast
+      // between a black-on-black shadow and the background it's cast on).
+      // Dark mode swaps the shadow for a border ring instead, per the
+      // shadow rule -- bgColor is a dynamic per-artist value, so a fixed
+      // neutral white-overlay ring (not a specific brand-hued border
+      // primitive) is the one that won't clash with it.
+      className="grid gap-4 p-4 text-slate-50 shadow-lg dark:border dark:border-white/10 dark:shadow-none dark:text-(--color-text-secondary-600)"
       style={{ backgroundColor: bgColor }}
     >
       {/* Artwork block with bgColor */}
@@ -549,7 +556,7 @@ const UpcomingEvents = (
     initial: { opacity: 0 },
     animate: { opacity: 1 },
     exit: { opacity: 0 },
-    transition: { duration: shouldReduceMotion ? 0 : 0.15 },
+    transition: { duration: shouldReduceMotion ? 0 : MOTION_DURATION.fast },
   }
 
   return (

--- a/packages/ui/src/components/ui/AlertDialog.tsx
+++ b/packages/ui/src/components/ui/AlertDialog.tsx
@@ -33,7 +33,7 @@ export function AlertDialog({
             className="text-xl font-semibold leading-6 my-0">
             {title}
           </Heading>
-          <div className={`w-6 h-6 absolute right-6 top-6 stroke-2 ${variant === 'destructive' ? 'text-red-500' : 'text-blue-500'}`}>
+          <div className={`w-6 h-6 absolute right-6 top-6 stroke-2 ${variant === 'destructive' ? 'text-red-500' : 'text-primary'}`}>
             {variant === 'destructive' ? <AlertCircleIcon aria-hidden /> : <InfoIcon aria-hidden />}
           </div>
           <p className="mt-3 text-neutral-500 dark:text-neutral-400">

--- a/packages/ui/src/components/ui/Button.tsx
+++ b/packages/ui/src/components/ui/Button.tsx
@@ -17,10 +17,12 @@ const button = tv({
   base: "relative inline-flex items-center justify-center gap-2 border border-transparent dark:border-white/10 h-9 box-border px-3.5 py-0 [&:has(>svg:only-child)]:px-0 [&:has(>svg:only-child)]:h-8 [&:has(>svg:only-child)]:w-8 font-sans text-sm text-center transition rounded-lg cursor-default [-webkit-tap-highlight-color:transparent]",
   variants: {
     variant: {
-      primary: "bg-blue-600 hover:bg-blue-700 pressed:bg-blue-800 text-white",
+      primary:
+        "bg-primary hover:bg-primary/90 pressed:bg-primary/80 text-primary-foreground",
       secondary:
         "border-black/10 bg-neutral-50 hover:bg-neutral-100 pressed:bg-neutral-200 text-neutral-800 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:pressed:bg-neutral-500 dark:text-neutral-100",
-      destructive: "bg-red-700 hover:bg-red-800 pressed:bg-red-900 text-white",
+      destructive:
+        "bg-destructive hover:bg-destructive/90 pressed:bg-destructive/80 text-white",
       quiet:
         "border-0 bg-transparent hover:bg-neutral-200 pressed:bg-neutral-300 text-neutral-800 dark:hover:bg-neutral-700 dark:pressed:bg-neutral-600 dark:text-neutral-100",
     },

--- a/packages/ui/src/components/ui/Calendar.tsx
+++ b/packages/ui/src/components/ui/Calendar.tsx
@@ -27,7 +27,7 @@ const cellStyles = tv({
     isSelected: {
       false:
         "text-neutral-900 dark:text-neutral-200 hover:bg-neutral-200 dark:hover:bg-neutral-700 pressed:bg-neutral-300 dark:pressed:bg-neutral-600",
-      true: "bg-blue-600 invalid:bg-red-600 text-white forced-colors:bg-[Highlight] forced-colors:invalid:bg-[Mark] forced-colors:text-[HighlightText]",
+      true: "bg-primary invalid:bg-red-600 text-primary-foreground forced-colors:bg-[Highlight] forced-colors:invalid:bg-[Mark] forced-colors:text-[HighlightText]",
     },
     isDisabled: {
       true: "text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",

--- a/packages/ui/src/components/ui/DateField.tsx
+++ b/packages/ui/src/components/ui/DateField.tsx
@@ -42,7 +42,7 @@ const segmentStyles = tv({
       true: 'text-neutral-200 dark:text-neutral-600 forced-colors:text-[GrayText]'
     },
     isFocused: {
-      true: 'bg-blue-600 text-white dark:text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]'
+      true: 'bg-primary text-primary-foreground forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]'
     }
   }
 });

--- a/packages/ui/src/components/ui/DropZone.tsx
+++ b/packages/ui/src/components/ui/DropZone.tsx
@@ -7,10 +7,10 @@ const dropZone = tv({
   base: "flex items-center justify-center p-8 min-h-24 w-[30%] font-sans text-base text-balance text-center rounded-lg border border-1 border-neutral-300 dark:border-neutral-800 bg-white dark:bg-neutral-900",
   variants: {
     isFocusVisible: {
-      true: "outline outline-2 -outline-offset-1 outline-blue-600 dark:outline-blue-500 forced-colors:outline-[Highlight]"
+      true: "outline outline-2 -outline-offset-1 outline-primary forced-colors:outline-[Highlight]"
     },
     isDropTarget: {
-      true: "bg-blue-200 dark:bg-blue-800 outline outline-2 -outline-offset-1 outline-blue-600 dark:outline-blue-500 forced-colors:outline-[Highlight]",
+      true: "bg-primary/20 outline outline-2 -outline-offset-1 outline-primary forced-colors:outline-[Highlight]",
     }
   }
 });

--- a/packages/ui/src/components/ui/GridList.tsx
+++ b/packages/ui/src/components/ui/GridList.tsx
@@ -40,7 +40,7 @@ const itemStyles = tv({
     isSelected: {
       false:
         "hover:bg-neutral-100 pressed:bg-neutral-100 dark:hover:bg-neutral-700/60 dark:pressed:bg-neutral-700/60",
-      true: "bg-blue-100 dark:bg-blue-700/30 hover:bg-blue-200 pressed:bg-blue-200 dark:hover:bg-blue-700/40 dark:pressed:bg-blue-700/40 border-y-blue-200 dark:border-y-blue-900 z-20",
+      true: "bg-primary/10 hover:bg-primary/20 pressed:bg-primary/20 border-y-primary/20 z-20",
     },
     isDisabled: {
       true: "text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText] z-10",

--- a/packages/ui/src/components/ui/Link.tsx
+++ b/packages/ui/src/components/ui/Link.tsx
@@ -17,11 +17,11 @@ const styles = tv({
   variants: {
     variant: {
       primary:
-        "text-blue-600 dark:text-blue-500 underline decoration-blue-600/60 hover:decoration-blue-600 dark:decoration-blue-500/60 dark:hover:decoration-blue-500",
+        "text-primary underline decoration-primary/60 hover:decoration-primary",
       secondary:
         "text-neutral-700 dark:text-neutral-300 underline decoration-neutral-700/50 hover:decoration-neutral-700 dark:decoration-neutral-300/70 dark:hover:decoration-neutral-300",
       button:
-        "relative inline-flex items-center justify-center gap-2 border border-transparent dark:border-white/10 h-9 box-border px-3.5 py-0 [&:has(>svg:only-child)]:px-0 [&:has(>svg:only-child)]:h-8 [&:has(>svg:only-child)]:w-8 font-sans text-sm text-center transition rounded-lg cursor-default [-webkit-tap-highlight-color:transparent] bg-blue-600 hover:bg-blue-700 pressed:bg-blue-800 text-white",
+        "relative inline-flex items-center justify-center gap-2 border border-transparent dark:border-white/10 h-9 box-border px-3.5 py-0 [&:has(>svg:only-child)]:px-0 [&:has(>svg:only-child)]:h-8 [&:has(>svg:only-child)]:w-8 font-sans text-sm text-center transition rounded-lg cursor-default [-webkit-tap-highlight-color:transparent] bg-primary hover:bg-primary/90 pressed:bg-primary/80 text-primary-foreground",
     },
   },
   defaultVariants: {

--- a/packages/ui/src/components/ui/ListBox.tsx
+++ b/packages/ui/src/components/ui/ListBox.tsx
@@ -44,7 +44,7 @@ export const itemStyles = tv({
     isSelected: {
       false:
         "text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 pressed:bg-neutral-100 dark:hover:bg-neutral-800 dark:pressed:bg-neutral-800 -outline-offset-2",
-      true: "bg-blue-600 text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] [&:has(+[data-selected])]:rounded-b-none [&+[data-selected]]:rounded-t-none -outline-offset-4 outline-white dark:outline-white forced-colors:outline-[HighlightText]",
+      true: "bg-primary text-primary-foreground forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] [&:has(+[data-selected])]:rounded-b-none [&+[data-selected]]:rounded-t-none -outline-offset-4 outline-white dark:outline-white forced-colors:outline-[HighlightText]",
     },
     isDisabled: {
       true: "text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
@@ -79,7 +79,7 @@ export const dropdownItemStyles = tv({
       true: "bg-neutral-100 dark:bg-neutral-800",
     },
     isFocused: {
-      true: "bg-blue-600 dark:bg-blue-600 text-white forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]",
+      true: "bg-primary text-primary-foreground forced-colors:bg-[Highlight] forced-colors:text-[HighlightText]",
     },
   },
   compoundVariants: [

--- a/packages/ui/src/components/ui/ProgressBar.tsx
+++ b/packages/ui/src/components/ui/ProgressBar.tsx
@@ -21,7 +21,7 @@ export function ProgressBar({ label, ...props }: ProgressBarProps) {
             <span className="text-sm text-neutral-600 dark:text-neutral-400">{valueText}</span>
           </div>
           <div className="max-w-full h-2 rounded-full bg-neutral-300 dark:bg-neutral-700 outline outline-1 -outline-offset-1 outline-transparent relative overflow-hidden">
-            <div className={`absolute top-0 h-full rounded-full bg-blue-500 forced-colors:bg-[Highlight] ${isIndeterminate ? 'left-full animate-in duration-1000 slide-in-from-left-[20rem] repeat-infinite ease-out' : 'left-0'}`} style={{ width: (isIndeterminate ? 40 : percentage) + '%' }} />
+            <div className={`absolute top-0 h-full rounded-full bg-primary forced-colors:bg-[Highlight] ${isIndeterminate ? 'left-full animate-in duration-1000 slide-in-from-left-[20rem] repeat-infinite ease-out' : 'left-0'}`} style={{ width: (isIndeterminate ? 40 : percentage) + '%' }} />
           </div>
         </>
       )}

--- a/packages/ui/src/components/ui/RangeCalendar.tsx
+++ b/packages/ui/src/components/ui/RangeCalendar.tsx
@@ -32,12 +32,12 @@ const cell = tv({
     selectionState: {
       none: "group-hover:bg-neutral-200 dark:group-hover:bg-neutral-700 group-pressed:bg-neutral-300 dark:group-pressed:bg-neutral-600",
       middle: [
-        "group-hover:bg-blue-200 dark:group-hover:bg-blue-900 forced-colors:group-hover:bg-[Highlight]",
+        "group-hover:bg-primary/20 forced-colors:group-hover:bg-[Highlight]",
         "group-invalid:group-hover:bg-red-200 dark:group-invalid:group-hover:bg-red-900 forced-colors:group-invalid:group-hover:bg-[Mark]",
-        "group-pressed:bg-blue-300 dark:group-pressed:bg-blue-800 forced-colors:group-pressed:bg-[Highlight] forced-colors:text-[HighlightText]",
+        "group-pressed:bg-primary/30 forced-colors:group-pressed:bg-[Highlight] forced-colors:text-[HighlightText]",
         "group-invalid:group-pressed:bg-red-300 dark:group-invalid:group-pressed:bg-red-800 forced-colors:group-invalid:group-pressed:bg-[Mark]",
       ],
-      cap: "bg-blue-600 group-invalid:bg-red-600 forced-colors:bg-[Highlight] forced-colors:group-invalid:bg-[Mark] text-white forced-colors:text-[HighlightText]",
+      cap: "bg-primary group-invalid:bg-red-600 forced-colors:bg-[Highlight] forced-colors:group-invalid:bg-[Mark] text-primary-foreground forced-colors:text-[HighlightText]",
     },
     isDisabled: {
       true: "text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]",
@@ -64,7 +64,7 @@ export function RangeCalendar<T extends DateValue>({
           {(date) => (
             <CalendarCell
               date={date}
-              className="group aspect-square w-[calc(100cqw/7)] cursor-default text-sm outline outline-0 [-webkit-tap-highlight-color:transparent] outside-month:text-neutral-300 selected:bg-blue-100 invalid:selected:bg-red-100 dark:selected:bg-blue-700/30 dark:invalid:selected:bg-red-700/30 forced-colors:selected:bg-[Highlight] forced-colors:invalid:selected:bg-[Mark] selection-start:rounded-s-full selection-end:rounded-e-full [td:first-child_&]:rounded-s-full [td:last-child_&]:rounded-e-full"
+              className="group aspect-square w-[calc(100cqw/7)] cursor-default text-sm outline outline-0 [-webkit-tap-highlight-color:transparent] outside-month:text-neutral-300 selected:bg-primary/10 invalid:selected:bg-red-100 dark:invalid:selected:bg-red-700/30 forced-colors:selected:bg-[Highlight] forced-colors:invalid:selected:bg-[Mark] selection-start:rounded-s-full selection-end:rounded-e-full [td:first-child_&]:rounded-s-full [td:last-child_&]:rounded-e-full"
             >
               {({
                 formattedDate,

--- a/packages/ui/src/components/ui/Slider.tsx
+++ b/packages/ui/src/components/ui/Slider.tsx
@@ -37,7 +37,7 @@ const fillStyles = tv({
         "h-(--size) w-[6px] bottom-(--start,0) ml-[50%] -translate-x-[50%]",
     },
     isDisabled: {
-      false: "bg-blue-500 forced-colors:bg-[Highlight]",
+      false: "bg-primary forced-colors:bg-[Highlight]",
       true: "bg-neutral-300 dark:bg-neutral-600 forced-colors:bg-[GrayText]",
     },
   },

--- a/packages/ui/src/components/ui/Table.tsx
+++ b/packages/ui/src/components/ui/Table.tsx
@@ -46,7 +46,7 @@ const columnStyles = tv({
 
 const resizerStyles = tv({
   extend: focusRing,
-  base: 'w-px px-[8px] translate-x-[8px] box-content py-1 h-5 bg-clip-content bg-neutral-400 dark:bg-neutral-500 forced-colors:bg-[ButtonBorder] cursor-col-resize rounded-xs resizing:bg-blue-600 forced-colors:resizing:bg-[Highlight] resizing:w-[2px] resizing:pl-[7px] -outline-offset-2'
+  base: 'w-px px-[8px] translate-x-[8px] box-content py-1 h-5 bg-clip-content bg-neutral-400 dark:bg-neutral-500 forced-colors:bg-[ButtonBorder] cursor-col-resize rounded-xs resizing:bg-primary forced-colors:resizing:bg-[Highlight] resizing:w-[2px] resizing:pl-[7px] -outline-offset-2'
 });
 
 export function Column(props: ColumnProps) {
@@ -106,7 +106,7 @@ export function TableBody<T extends object>(props: TableBodyProps<T>) {
 
 const rowStyles = tv({
   extend: focusRing,
-  base: 'group/row relative cursor-default select-none -outline-offset-2 text-neutral-900 disabled:text-neutral-300 dark:text-neutral-200 dark:disabled:text-neutral-600 text-sm hover:bg-neutral-100 pressed:bg-neutral-100 dark:hover:bg-neutral-800 dark:pressed:bg-neutral-800 selected:bg-blue-100 selected:hover:bg-blue-200 selected:pressed:bg-blue-200 dark:selected:bg-blue-700/30 dark:selected:hover:bg-blue-700/40 dark:selected:pressed:bg-blue-700/40 last:rounded-b-lg'
+  base: 'group/row relative cursor-default select-none -outline-offset-2 text-neutral-900 disabled:text-neutral-300 dark:text-neutral-200 dark:disabled:text-neutral-600 text-sm hover:bg-neutral-100 pressed:bg-neutral-100 dark:hover:bg-neutral-800 dark:pressed:bg-neutral-800 selected:bg-primary/10 selected:hover:bg-primary/20 selected:pressed:bg-primary/20 last:rounded-b-lg'
 });
 
 export function Row<T extends object>(

--- a/packages/ui/src/components/ui/TagGroup.tsx
+++ b/packages/ui/src/components/ui/TagGroup.tsx
@@ -41,7 +41,7 @@ const tagStyles = tv({
       true: 'pr-1'
     },
     isSelected: {
-      true: 'bg-blue-600 text-white border-transparent forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] forced-color-adjust-none'
+      true: 'bg-primary text-primary-foreground border-transparent forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] forced-color-adjust-none'
     },
     isDisabled: {
       true: 'bg-neutral-100 dark:bg-transparent dark:border-white/20 text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText]'

--- a/packages/ui/src/components/ui/Toast.tsx
+++ b/packages/ui/src/components/ui/Toast.tsx
@@ -41,13 +41,13 @@ export function MyToastRegion() {
     // The ToastRegion should be rendered at the root of your app.
     (<ToastRegion
       queue={queue}
-      className="fixed bottom-4 right-4 flex flex-col-reverse gap-2 rounded-lg outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-blue-600 focus-visible:outline-offset-2">
+      className="fixed bottom-4 right-4 flex flex-col-reverse gap-2 rounded-lg outline-none focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2">
       {({toast}) => (
         <MyToast toast={toast}>
           <ToastContent className="flex flex-col flex-1 min-w-0">
-            <Text slot="title" className="font-semibold text-white text-sm">{toast.content.title}</Text>
+            <Text slot="title" className="font-semibold text-primary-foreground text-sm">{toast.content.title}</Text>
             {toast.content.description && (
-              <Text slot="description" className="text-xs text-white">{toast.content.description}</Text>
+              <Text slot="description" className="text-xs text-primary-foreground">{toast.content.description}</Text>
             )}
           </ToastContent>
           <Button
@@ -69,7 +69,7 @@ export function MyToast(props: ToastProps<MyToastContent>) {
       style={{viewTransitionName: props.toast.key} as CSSProperties}
       className={composeTailwindRenderProps(
         props.className,
-        "flex items-center gap-4 bg-blue-600 px-4 py-3 rounded-lg outline-none forced-colors:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-blue-600 focus-visible:outline-offset-2 [view-transition-class:toast] font-sans w-[230px]"
+        "flex items-center gap-4 bg-primary px-4 py-3 rounded-lg outline-none forced-colors:outline focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2 [view-transition-class:toast] font-sans w-[230px]"
       )}
     />
   );

--- a/packages/ui/src/components/ui/Tree.tsx
+++ b/packages/ui/src/components/ui/Tree.tsx
@@ -19,7 +19,7 @@ const itemStyles = tv({
   variants: {
     isSelected: {
       false: 'hover:bg-neutral-100 pressed:bg-neutral-100 dark:hover:bg-neutral-800 dark:pressed:bg-neutral-800',
-      true: 'bg-blue-100 dark:bg-blue-700/30 hover:bg-blue-200 pressed:bg-blue-200 dark:hover:bg-blue-700/40 dark:pressed:bg-blue-700/40 border-y-blue-200 dark:border-y-blue-900 z-20'
+      true: 'bg-primary/10 hover:bg-primary/20 pressed:bg-primary/20 border-y-primary/20 z-20'
     },
     isDisabled: {
       true: 'text-neutral-300 dark:text-neutral-600 forced-colors:text-[GrayText] z-10'

--- a/packages/ui/src/lib/motion.ts
+++ b/packages/ui/src/lib/motion.ts
@@ -1,0 +1,19 @@
+/** Shared motion tokens for `motion/react` `transition` props -- durations
+ * are in seconds (what motion/react's API expects), not the ms-based CSS
+ * scale. Centralizes the values already duplicated across EventDetails.tsx
+ * instead of each new animated component re-deriving its own duration/
+ * easing pair. Grown from what's actually in use, not a speculative full
+ * scale -- add a step here when a real second use case needs it. */
+
+export const MOTION_DURATION = {
+  /** Small utility crossfades -- e.g. swapping loading/error/loaded
+   * content in a list. */
+  fast: 0.15,
+  /** Small UI appearing/disappearing -- toggles, sticky headers, controls. */
+  base: 0.2,
+} as const
+
+export const MOTION_EASE = {
+  /** Entrances, most UI. cubic-bezier(0.22, 1, 0.36, 1). */
+  out: [0.22, 1, 0.36, 1],
+} as const

--- a/packages/ui/src/lib/react-aria-utils.ts
+++ b/packages/ui/src/lib/react-aria-utils.ts
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge';
 import { tv } from 'tailwind-variants';
 
 export const focusRing = tv({
-  base: 'outline outline-blue-600 dark:outline-blue-500 forced-colors:outline-[Highlight] outline-offset-2',
+  base: 'outline outline-primary forced-colors:outline-[Highlight] outline-offset-2',
   variants: {
     isFocusVisible: {
       false: 'outline-0',

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -11,6 +11,22 @@
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
 
+/* Semantic z-index scale -- generates z-dropdown / z-sticky / etc.
+   utilities. Only the tiers that coordinate meaning *across* components
+   (a sticky header needs to out-rank normal content app-wide, a toast
+   needs to out-rank a modal) get a name here. Small, purely-local
+   stacking within a single component (e.g. a gradient sitting behind its
+   own title) doesn't need one -- that relationship is already clear from
+   the two elements sitting next to each other in the same file. */
+@theme {
+    --z-index-dropdown: 10;
+    --z-index-sticky: 20;
+    --z-index-modal-backdrop: 30;
+    --z-index-modal: 40;
+    --z-index-toast: 50;
+    --z-index-tooltip: 60;
+}
+
 @theme inline {
     --font-heading: var(--font-sans);
     --color-sidebar-ring: var(--sidebar-ring);
@@ -55,14 +71,27 @@
 }
 
 :root {
+    /* Lets native form controls (checkboxes, scrollbars, date pickers)
+       render themselves correctly for whichever mode is actually active,
+       instead of defaulting to light chrome inside a dark page. */
+    color-scheme: light dark;
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);
     --card: oklch(1 0 0);
     --card-foreground: oklch(0.145 0 0);
     --popover: oklch(1 0 0);
     --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
+    /* --primary is the one shadcn slot that's genuinely "the brand action
+       color" -- wired to the same toasted-almond ramp as --accent-bg, so
+       Button/Link's "primary" variant and the rest of the app's CTAs are
+       finally the same color instead of two unrelated systems. Its
+       foreground is the same ivory-100 already used as --text-on-accent.
+       --secondary/--accent stay neutral on purpose: per Component Craft
+       convention, secondary = outline/neutral so the branded primary
+       stands out. Making secondary branded too would flatten that
+       hierarchy, not fix a gap -- neutral is correct here. */
+    --primary: var(--color-toasted-almond-600);
+    --primary-foreground: var(--color-ivory-100);
     --secondary: oklch(0.97 0 0);
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
@@ -87,6 +116,13 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
+}
+
+/* Symmetric with .dark below: pins native controls to light rendering
+   once the user has explicitly picked light, rather than leaving :root's
+   light-dark to keep following OS preference. */
+.light {
+    color-scheme: light;
 }
 
 .dark {
@@ -117,14 +153,19 @@
        bg-popover anywhere in either package). --destructive/--border/
        --ring already function correctly as conventional red/neutral
        chrome and don't need brand hue. */
+    /* Pins native controls to dark rendering once .dark is explicitly
+       applied, rather than leaving it to :root's light-dark (which would
+       otherwise follow OS preference even after the user has picked a
+       mode -- the transition rule says the explicit toggle wins). */
+    color-scheme: dark;
     --background: var(--color-bg-dark-900);
     --foreground: var(--color-text-primary-dark-200);
     --card: oklch(0.205 0 0);
     --card-foreground: oklch(0.985 0 0);
     --popover: oklch(0.205 0 0);
     --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
+    --primary: var(--color-toasted-almond-dark-600);
+    --primary-foreground: var(--color-text-primary-dark-600);
     --secondary: oklch(0.269 0 0);
     --secondary-foreground: oklch(0.985 0 0);
     --muted: var(--color-surface-dark-800);


### PR DESCRIPTION
## Summary

Works through the last of the `/finalize` Major findings and the one remaining open decision from this project's design-system work.

### Contained fixes
- **`color-scheme: light dark`** declared on `:root`, with explicit `.light`/`.dark` pins so native controls respect the user's explicit toggle rather than following OS preference once a mode is picked.
- **`ArtistCard`'s `shadow-lg` → border ring in dark mode** — a shadow is close to invisible on a near-black surface. `bgColor` is a dynamic per-artist value, so a fixed neutral white-overlay ring (not a brand-hued border primitive) is the one that won't clash with it.

### Token establishment
- **`packages/ui/src/lib/motion.ts`** (`MOTION_DURATION`, `MOTION_EASE`) — centralizes the duration/easing pairs already duplicated 4× across `EventDetails.tsx`'s `motion/react` transitions.
- **Semantic z-index scale** (`z-dropdown`/`z-sticky`/`z-modal-backdrop`/`z-modal`/`z-toast`/`z-tooltip`) in `globals.css`. Wired the one genuine semantic fit (the sticky header → `z-sticky`); left `EventDetails`' purely-local internal stacking alone.

### `--primary` re-theme (the open decision, deferred twice, now resolved)
- `--primary`/`--primary-foreground` now reference the same `toasted-almond` ramp as `--accent-bg`, in both light and dark — `Button`/`Link`'s "primary" variant and the rest of the app's CTAs are finally one color system.
- `--secondary`/`--accent` deliberately stay neutral — per Component Craft convention, secondary = outline/neutral so the branded primary stands out; making secondary branded too would flatten that hierarchy, not fix a gap.
- Updated every real, live-in-the-app consumer (`Button`, `Link`, the shared `focusRing` used by `Field`/`AlertDialog`/everything else), and — since "full re-theme" was the explicit choice — every unused-but-shared library component with a blue "selected/active" state: `TagGroup`, `RangeCalendar`, `Table`, `Tree`, `GridList`, `DropZone`, `Toast`, `ListBox`, `Calendar`, `Slider`, `ProgressBar`, `DateField`. Left validation/status red and `TagGroup`'s user-selectable "blue" tag color alone — conventional, not brand mismatches.

### Caught mid-verification, not part of the plan
A real bug in the test-harness pattern used throughout this project's session history, not the product itself: `apps/web/src/App.css` (the file with all the brand primitive ramps) is only ever loaded via `MapWrapper.tsx`, which `AppWrapper.tsx` imports through `React.lazy()` — so any harness rendering a component directly instead of the full `<App/>` never triggers that side-effect import, and every custom color variable silently resolves to nothing. Every earlier "the CSS variable is empty" moment was this, not a caching bug. Fixed for future verification by having the harness import `App.css` directly.

## Test plan

- [x] `tsc -b --noEmit` passes for both `apps/web` and `packages/ui`
- [x] `eslint` clean on every changed file
- [x] Verified live via harnesses:
  - `Button` (all 4 variants) and `Link` (primary/button variants) in both light and dark
  - Focus ring color
  - `AlertDialog`'s info and destructive variants side by side (destructive correctly stays red)
  - `EventDetails.tsx` rendered alongside all of the above, confirming its own explicit token overrides still hold after the shared-component changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)