### PR TITLE
Make the event filter real, and add For You filtering by matched artist/genre

### DIFF
--- a/apps/web/src/Drawer/EventsDrawer.tsx
+++ b/apps/web/src/Drawer/EventsDrawer.tsx
@@ -16,9 +16,25 @@ export const EventsDrawer = ({
 }: {
   registerItem: RegisterItem
 }) => {
-  const { eventsByDate, isStreaming, searchRadius, radiusExpanded } =
-    useEventsContext()
-  const entries = Object.entries(eventsByDate).sort()
+  const {
+    eventsByDate,
+    visibleEventsByDate,
+    isStreaming,
+    searchRadius,
+    radiusExpanded,
+    activeClassifications,
+    activeForYouArtists,
+    activeForYouGenres,
+  } = useEventsContext()
+  const entries = Object.entries(visibleEventsByDate).sort()
+  const hasActiveFilters =
+    activeClassifications.size > 0 ||
+    activeForYouArtists.size > 0 ||
+    activeForYouGenres.size > 0
+  const filteredEverythingOut =
+    hasActiveFilters &&
+    !entries.length &&
+    Object.keys(eventsByDate).length > 0
 
   if (!entries.length && isStreaming) {
     return (
@@ -67,9 +83,11 @@ export const EventsDrawer = ({
       ) : (
         <div className="flex h-full w-full items-center justify-center p-6 text-center">
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            {radiusExpanded && searchRadius
-              ? `No events found within ${searchRadius}mi. Try searching for a different location, or adjusting the calendar date range.`
-              : "No events found. Try searching for a different location, or adjusting the calendar date range."}
+            {filteredEverythingOut
+              ? "No events match the selected filters. Try clearing a filter."
+              : radiusExpanded && searchRadius
+                ? `No events found within ${searchRadius}mi. Try searching for a different location, or adjusting the calendar date range.`
+                : "No events found. Try searching for a different location, or adjusting the calendar date range."}
           </p>
         </div>
       )}
@@ -84,9 +102,10 @@ export const EventsDrawerHeader = ({
   topMostId: string | null
   onSelect: (date: string) => void
 }) => {
-  const { eventsByDate, searchRadius, radiusExpanded } = useEventsContext()
+  const { visibleEventsByDate, searchRadius, radiusExpanded } =
+    useEventsContext()
   const { selectedLocation } = useSearchProvider()
-  const entries = Object.entries(eventsByDate).sort()
+  const entries = Object.entries(visibleEventsByDate).sort()
 
   return (
     <>

--- a/apps/web/src/EventFilter.tsx
+++ b/apps/web/src/EventFilter.tsx
@@ -3,21 +3,42 @@ import { Dialog } from "@workspace/ui/components/ui/Dialog"
 import { Button } from "@workspace/ui/components/ui/Button"
 import { Tooltip } from "@workspace/ui/components/ui/Tooltip"
 import { Popover } from "@workspace/ui/components/ui/Popover"
-import { useEventsContext } from "./providers/eventsProvider"
+import {
+  useEventsContext,
+  matchedPerformerGenres,
+} from "./providers/eventsProvider"
 import { type Classification } from "./lib/types"
-import { useState } from "react"
 import { FilterIcon } from "lucide-react"
 import { DialogTrigger, Heading, TooltipTrigger } from "react-aria-components"
 
+const toKeySet = (keys: "all" | Set<Key>) =>
+  keys === "all" ? new Set<string>() : new Set([...keys].map(String))
+
 const EventFilter = () => {
-  const [selected, setSelected] = useState<Set<Key>>(new Set())
+  const {
+    eventsByDate,
+    activeClassifications,
+    setActiveClassifications,
+    activeForYouArtists,
+    setActiveForYouArtists,
+    activeForYouGenres,
+    setActiveForYouGenres,
+  } = useEventsContext()
+
+  const totalSelected =
+    activeClassifications.size +
+    activeForYouArtists.size +
+    activeForYouGenres.size
 
   const clearFilters = () => {
-    setSelected(new Set())
+    setActiveClassifications(new Set())
+    setActiveForYouArtists(new Set())
+    setActiveForYouGenres(new Set())
   }
-  const { eventsByDate } = useEventsContext()
-  const classifications = Object.values(eventsByDate)
-    .flat()
+
+  const allEvents = Object.values(eventsByDate).flat()
+
+  const classifications = allEvents
     .flatMap((e) => e.classifications || [])
     .reduce(
       (
@@ -37,6 +58,33 @@ const EventFilter = () => {
       },
       {}
     )
+
+  // "For You" tag options are scoped to currently-matched events only --
+  // this is a personalization filter, not a general performer/genre
+  // browser (see Phase 1 plan). Empty when nothing's matched (not
+  // connected, or no match in the current search results).
+  const matchedEvents = allEvents.filter((e) => e.matchedArtist)
+
+  const matchedArtists = matchedEvents.reduce(
+    (acc: Record<string, number>, e) => {
+      const name = e.matchedArtist!
+      acc[name] = (acc[name] ?? 0) + 1
+      return acc
+    },
+    {}
+  )
+
+  const matchedGenres = matchedEvents
+    .flatMap(matchedPerformerGenres)
+    .reduce((acc: Record<string, number>, genre) => {
+      acc[genre] = (acc[genre] ?? 0) + 1
+      return acc
+    }, {})
+
+  const hasForYouOptions =
+    Object.keys(matchedArtists).length > 0 ||
+    Object.keys(matchedGenres).length > 0
+
   return (
     <>
       <DialogTrigger>
@@ -47,9 +95,9 @@ const EventFilter = () => {
             className="relative !h-9 !w-9 shrink-0 max-md:before:absolute max-md:before:-inset-1 max-md:before:content-['']"
           >
             <FilterIcon aria-hidden className="block h-5 w-5 shrink-0" />
-            {selected.size > 0 && (
+            {totalSelected > 0 && (
               <div className="absolute -top-2 -right-2 aspect-square h-4 rounded-full bg-(--accent-bg) text-xs text-(--text-on-accent)">
-                {selected.size}
+                {totalSelected}
               </div>
             )}
           </Button>
@@ -60,7 +108,7 @@ const EventFilter = () => {
             <Heading slot="title" className="m-0 mb-2 text-lg font-semibold">
               Filters
             </Heading>
-            {selected.size > 0 && (
+            {totalSelected > 0 && (
               <Button
                 onPress={clearFilters}
                 variant="secondary"
@@ -72,9 +120,9 @@ const EventFilter = () => {
             <div className="flex flex-col gap-4">
               <TagGroup
                 selectionMode="multiple"
-                selectedKeys={selected}
+                selectedKeys={activeClassifications}
                 onSelectionChange={(keys) =>
-                  setSelected(keys === "all" ? new Set() : new Set(keys))
+                  setActiveClassifications(toKeySet(keys))
                 }
                 escapeKeyBehavior="none"
               >
@@ -88,13 +136,72 @@ const EventFilter = () => {
                   ))}
                 </TagList>
               </TagGroup>
+
+              {hasForYouOptions && (
+                <div className="flex flex-col gap-2">
+                  <Heading className="text-xs font-semibold text-muted-foreground uppercase">
+                    For You
+                  </Heading>
+                  {Object.keys(matchedArtists).length > 0 && (
+                    <TagGroup
+                      aria-label="Filter by matched artist"
+                      selectionMode="multiple"
+                      selectedKeys={activeForYouArtists}
+                      onSelectionChange={(keys) =>
+                        setActiveForYouArtists(toKeySet(keys))
+                      }
+                      escapeKeyBehavior="none"
+                    >
+                      <TagList>
+                        {Object.entries(matchedArtists).map(
+                          ([name, count]) => (
+                            <Tag
+                              key={name}
+                              id={name}
+                              textValue={name}
+                            >{`${name} - ${count}`}</Tag>
+                          )
+                        )}
+                      </TagList>
+                    </TagGroup>
+                  )}
+                  {Object.keys(matchedGenres).length > 0 && (
+                    <TagGroup
+                      aria-label="Filter by matched genre"
+                      selectionMode="multiple"
+                      selectedKeys={activeForYouGenres}
+                      onSelectionChange={(keys) =>
+                        setActiveForYouGenres(toKeySet(keys))
+                      }
+                      escapeKeyBehavior="none"
+                    >
+                      <TagList>
+                        {Object.entries(matchedGenres).map(
+                          ([genre, count]) => (
+                            <Tag
+                              key={genre}
+                              id={genre}
+                              textValue={genre}
+                            >{`${genre} - ${count}`}</Tag>
+                          )
+                        )}
+                      </TagList>
+                    </TagGroup>
+                  )}
+                </div>
+              )}
             </div>
           </Dialog>
         </Popover>
       </DialogTrigger>
-      {selected.size > 0 && (
+      {totalSelected > 0 && (
         <p className="text-xs text-muted-foreground">
-          Filtering by: {[...selected].join(", ")}
+          Filtering by:{" "}
+          {[
+            ...activeClassifications,
+            ...activeForYouArtists,
+            ...activeForYouGenres,
+          ].join(", ")}
         </p>
       )}
     </>

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -41,7 +41,7 @@ const MapWrapper = () => {
   const skipNextEaseRef = useRef(isRestoredMapView)
 
   const {
-    eventsByDate,
+    visibleEventsByDate,
     selectEvents,
     selectedEvents,
     isStreaming,
@@ -120,8 +120,8 @@ const MapWrapper = () => {
   useResizeFix(mapRef, mapContainer)
   useMapViewSync(mapRef)
   const camera = useMapCamera(mapRef)
-  useEventLayer(mapRef, eventsByDate, selectedEvents, selectEvents)
-  useClusterSelection(mapRef, eventsByDate, selectEvents)
+  useEventLayer(mapRef, visibleEventsByDate, selectedEvents, selectEvents)
+  useClusterSelection(mapRef, visibleEventsByDate, selectEvents)
 
   useEffect(() => {
     // Only flies when there's a selected event with a venue location --

--- a/apps/web/src/providers/eventsProvider.test.ts
+++ b/apps/web/src/providers/eventsProvider.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest"
+import {
+  matchedPerformerGenres,
+  matchesClassificationFilter,
+  matchesForYouFilter,
+} from "./eventsProvider"
+import type { EventResponse } from "../hooks/eventsStream"
+
+function makeEvent(overrides: Partial<EventResponse> = {}): EventResponse {
+  return {
+    id: "1",
+    name: "Test Event",
+    images: [],
+    dates: "2026-08-01T20:00:00Z",
+    source: "ticketmaster",
+    ...overrides,
+  }
+}
+
+describe("matchesClassificationFilter", () => {
+  it("passes everything when no classification is active", () => {
+    expect(matchesClassificationFilter(makeEvent(), new Set())).toBe(true)
+  })
+
+  it("matches when a primary classification's segment name is active", () => {
+    const event = makeEvent({
+      classifications: [
+        { primary: true, segment: { id: "KZ1", name: "Music" } },
+      ],
+    })
+    expect(matchesClassificationFilter(event, new Set(["Music"]))).toBe(true)
+  })
+
+  it("doesn't match a non-primary classification even if the name is active", () => {
+    const event = makeEvent({
+      classifications: [
+        { primary: false, segment: { id: "KZ1", name: "Music" } },
+      ],
+    })
+    expect(matchesClassificationFilter(event, new Set(["Music"]))).toBe(false)
+  })
+
+  it("doesn't match when the active set has a different segment name", () => {
+    const event = makeEvent({
+      classifications: [
+        { primary: true, segment: { id: "KZ1", name: "Music" } },
+      ],
+    })
+    expect(matchesClassificationFilter(event, new Set(["Sports"]))).toBe(
+      false
+    )
+  })
+})
+
+describe("matchedPerformerGenres", () => {
+  it("returns an empty array when the event has no matchedArtist", () => {
+    expect(matchedPerformerGenres(makeEvent())).toEqual([])
+  })
+
+  it("returns the matched performer's enrichment genres", () => {
+    const event = makeEvent({
+      matchedArtist: "Role Model",
+      performers: [
+        {
+          name: "Role Model",
+          enrichment: {
+            name: "Role Model",
+            id: "am-1",
+            genres: ["Pop", "Indie"],
+            similar_artists: [],
+          },
+        },
+      ],
+    })
+    expect(matchedPerformerGenres(event)).toEqual(["Pop", "Indie"])
+  })
+
+  it("returns an empty array when the matched performer has no enrichment yet", () => {
+    const event = makeEvent({
+      matchedArtist: "Role Model",
+      performers: [{ name: "Role Model" }],
+    })
+    expect(matchedPerformerGenres(event)).toEqual([])
+  })
+
+  it("returns an empty array when no performer name matches matchedArtist", () => {
+    const event = makeEvent({
+      matchedArtist: "Role Model",
+      performers: [{ name: "Someone Else" }],
+    })
+    expect(matchedPerformerGenres(event)).toEqual([])
+  })
+})
+
+describe("matchesForYouFilter", () => {
+  it("passes everything when no For You filter is active", () => {
+    expect(matchesForYouFilter(makeEvent(), new Set(), new Set())).toBe(true)
+  })
+
+  it("excludes an unmatched event once a For You filter is active", () => {
+    expect(
+      matchesForYouFilter(makeEvent(), new Set(["Role Model"]), new Set())
+    ).toBe(false)
+  })
+
+  it("matches on the selected artist", () => {
+    const event = makeEvent({ matchedArtist: "Role Model" })
+    expect(
+      matchesForYouFilter(event, new Set(["Role Model"]), new Set())
+    ).toBe(true)
+  })
+
+  it("doesn't match a different selected artist", () => {
+    const event = makeEvent({ matchedArtist: "Role Model" })
+    expect(
+      matchesForYouFilter(event, new Set(["Someone Else"]), new Set())
+    ).toBe(false)
+  })
+
+  it("matches on a selected genre from the matched performer's enrichment", () => {
+    const event = makeEvent({
+      matchedArtist: "Role Model",
+      performers: [
+        {
+          name: "Role Model",
+          enrichment: {
+            name: "Role Model",
+            id: "am-1",
+            genres: ["Pop"],
+            similar_artists: [],
+          },
+        },
+      ],
+    })
+    expect(matchesForYouFilter(event, new Set(), new Set(["Pop"]))).toBe(true)
+  })
+
+  it("doesn't match a selected genre the matched performer doesn't have", () => {
+    const event = makeEvent({
+      matchedArtist: "Role Model",
+      performers: [
+        {
+          name: "Role Model",
+          enrichment: {
+            name: "Role Model",
+            id: "am-1",
+            genres: ["Pop"],
+            similar_artists: [],
+          },
+        },
+      ],
+    })
+    expect(matchesForYouFilter(event, new Set(), new Set(["Rock"]))).toBe(
+      false
+    )
+  })
+})

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -19,6 +19,7 @@ import {
   eventResponseSchema,
   type EventResponse,
 } from "@/hooks/eventsStreamSchema"
+import { type EventsByDate } from "@/hooks/eventsStream"
 import { useSearchProvider } from "./searchProvider"
 import { dateRangeToApiParams } from "../lib/dates"
 
@@ -47,6 +48,42 @@ function parseStreamedEvent(raw: string) {
   }
 
   return result.data
+}
+
+/** The genres of the performer that triggered `event.matchedArtist`, read
+ * off that performer's already-attached canonical-artist enrichment (see
+ * `apps/api/src/artists/lookup.rs`) rather than any personalization-
+ * specific data -- there isn't any, the "for you" match pipeline only ever
+ * tracks a name. Empty when unmatched, or when that performer's
+ * enrichment hasn't resolved yet (best-effort, same as everywhere else
+ * `enrichment` is read). */
+export function matchedPerformerGenres(event: EventResponse): string[] {
+  if (!event.matchedArtist) return []
+  const performer = event.performers?.find(
+    (p) => p.name === event.matchedArtist
+  )
+  return performer?.enrichment?.genres ?? []
+}
+
+export function matchesClassificationFilter(
+  event: EventResponse,
+  active: Set<string>
+): boolean {
+  if (active.size === 0) return true
+  return (event.classifications ?? []).some(
+    (c) => c.primary && c.segment?.name && active.has(c.segment.name)
+  )
+}
+
+export function matchesForYouFilter(
+  event: EventResponse,
+  activeArtists: Set<string>,
+  activeGenres: Set<string>
+): boolean {
+  if (activeArtists.size === 0 && activeGenres.size === 0) return true
+  if (!event.matchedArtist) return false
+  if (activeArtists.has(event.matchedArtist)) return true
+  return matchedPerformerGenres(event).some((g) => activeGenres.has(g))
 }
 
 // Search radii (miles) tried in order until one returns events. Lets
@@ -86,6 +123,17 @@ type EventsContextValue = EventsState & {
   searchRadius: number | null
   /** Whether searchRadius went beyond the base tier to find results. */
   radiusExpanded: boolean
+  /** `eventsByDate` narrowed by the active filters (classification + For
+   * You) -- what list/map rendering should consume. `eventsByDate` itself
+   * stays the raw, unfiltered set so filter-option counts don't shrink as
+   * more filters get applied. */
+  visibleEventsByDate: EventsByDate
+  activeClassifications: Set<string>
+  setActiveClassifications: (classifications: Set<string>) => void
+  activeForYouArtists: Set<string>
+  setActiveForYouArtists: (artists: Set<string>) => void
+  activeForYouGenres: Set<string>
+  setActiveForYouGenres: (genres: Set<string>) => void
 }
 
 function buildConcertStreamUrl(params: StreamConcertsParams) {
@@ -104,6 +152,40 @@ const EventsContext = createContext<EventsContextValue | null>(null)
 export function EventsProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(eventsReducer, initialEventsState)
   const abortRef = useRef<AbortController | null>(null)
+  const [activeClassifications, setActiveClassifications] = useState<
+    Set<string>
+  >(new Set())
+  const [activeForYouArtists, setActiveForYouArtists] = useState<Set<string>>(
+    new Set()
+  )
+  const [activeForYouGenres, setActiveForYouGenres] = useState<Set<string>>(
+    new Set()
+  )
+  const visibleEventsByDate = useMemo(() => {
+    if (
+      activeClassifications.size === 0 &&
+      activeForYouArtists.size === 0 &&
+      activeForYouGenres.size === 0
+    ) {
+      return state.eventsByDate
+    }
+
+    const result: EventsByDate = {}
+    for (const [date, events] of Object.entries(state.eventsByDate)) {
+      const filtered = events.filter(
+        (event) =>
+          matchesClassificationFilter(event, activeClassifications) &&
+          matchesForYouFilter(event, activeForYouArtists, activeForYouGenres)
+      )
+      if (filtered.length) result[date] = filtered
+    }
+    return result
+  }, [
+    state.eventsByDate,
+    activeClassifications,
+    activeForYouArtists,
+    activeForYouGenres,
+  ])
   const [searchRadius, setSearchRadius] = React.useState<number | null>(null)
 
   const cancelStream = useCallback(() => {
@@ -294,6 +376,13 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       searchThisArea,
       searchRadius,
       radiusExpanded,
+      visibleEventsByDate,
+      activeClassifications,
+      setActiveClassifications,
+      activeForYouArtists,
+      setActiveForYouArtists,
+      activeForYouGenres,
+      setActiveForYouGenres,
     }),
     [
       state,
@@ -304,6 +393,10 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
       searchThisArea,
       searchRadius,
       radiusExpanded,
+      visibleEventsByDate,
+      activeClassifications,
+      activeForYouArtists,
+      activeForYouGenres,
     ]
   )
 


### PR DESCRIPTION
## Summary

Closes #69 (Phase 1 of the roadmap from #68/#70/#71).

Extends the existing "For You" match badge into an actual filter, plus filtering by the matched artist's genre.

- **The genre data this issue anticipated needing already exists.** #69 expected adding a `genres` field to Spotify's client plus an Apple Music equivalent as real new work. It's already there, via a completely different initiative: the canonical artist model (ADR-0001) attaches `enrichment.genres` to every performer on the wire, and `event.matchedArtist` already identifies which performer to read it from. **This phase is frontend-only — no backend changes.**
- **Bigger discovery along the way: the pre-existing classification filter didn't filter anything.** `EventFilter.tsx` tracked a `selected` Set entirely in local state that nothing read — `EventsDrawer.tsx` and `MapWrapper.tsx` both rendered straight from `eventsByDate`, unfiltered. Confirmed with the user and fixed as part of this work, since shipping a second, equally-inert filter section next to the first one didn't make sense.

## What changed

- `providers/eventsProvider.tsx`: filter state (`activeClassifications`/`activeForYouArtists`/`activeForYouGenres`) lifted into the provider, mirroring the existing `selectedEvents` pattern. New derived `visibleEventsByDate` (OR within a facet, AND across facets, empty facet = pass-through) alongside the existing raw `eventsByDate` (kept raw so filter-option counts don't shrink as more filters get selected). New `matchedPerformerGenres`/`matchesClassificationFilter`/`matchesForYouFilter` helpers, exported for testing.
- `EventFilter.tsx`: reads/writes filter state from context instead of local `useState`. New "For You" section below the existing classification tags — matched-artist and matched-genre `TagGroup`s, scoped to currently-loaded events with a match (this is a personalization filter, not a general performer/genre browser).
- `Drawer/EventsDrawer.tsx` / `MapWrapper.tsx`: both switched from `eventsByDate` to `visibleEventsByDate`, so filtering now applies consistently across the event list, the date slider, and the map pins — previously only the list would have reflected a working filter, leaving map pins out of sync. Added a distinct "no events match your filters" empty state, separate from "no events found."
- `providers/eventsProvider.test.ts` (new): direct unit tests for the three filter predicates, covering classification match/mismatch/non-primary, For You artist match, For You genre match via enrichment, and the empty-filter pass-through case.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` / `pnpm test` (web) — clean, 112/112 tests pass (14 new)
- [x] Browser: confirmed the Filters popover reflects live context state and shows the correct classification count; confirmed tag selection correctly updates context state (`aria-selected` flips through the new wiring)
- [x] Unit tests directly exercise the filter logic (match/no-match/artist/genre/classification) — added because automated browser clicks were unreliable for interactive verification in this environment; the pure predicate tests are the stronger signal here
- [ ] Visual confirmation of the "For You" section itself — not verifiable in this session, needs a connected account with a real matched event in the loaded results

🤖 Generated with [Claude Code](https://claude.com/claude-code)