### PR TITLE
Improve Search This Area Bttn behavior

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -233,14 +233,12 @@ const DrawerWrapper = () => {
             <PlaylistsDrawerBody />
           </Suspense>
         </TabPanel>
-        <TabPanel
-          id="search"
-          className="flex items-center justify-center"
-        ></TabPanel>
-        <TabPanel
-          id="settings"
-          className="flex items-center justify-center"
-        ></TabPanel>
+        <TabPanel id="apple" className="flex flex-col">
+          <Suspense fallback={null}>
+            <AppleMusicDrawerHeader />
+            <AppleMusicDrawerBody />
+          </Suspense>
+        </TabPanel>
       </TabPanels>
     </DrawerContent>
   )

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -146,7 +146,7 @@ const MapWrapper = () => {
   // zoom out to frame the actual area covered instead of staying zoomed
   // in on a radius that came up empty.
   useEffect(() => {
-    if (isStreaming || !radiusExpanded || !searchRadius) return
+    if (isStreaming || !searchRadius) return
     camera.fitToRadius(selectedCoordinates, searchRadius)
   }, [isStreaming, radiusExpanded, searchRadius, selectedCoordinates, camera])
 
@@ -154,8 +154,14 @@ const MapWrapper = () => {
     <>
       <div className="relative flex min-h-0 flex-1">
         {!useIsMobile() && <DrawerWrapper />}
-        <div ref={mapContainer} id="map-container" className="h-full w-full" />
-        <SearchThisAreaButton onSearchThisArea={handleSearchThisArea} />
+        <div className="relative h-full w-full">
+          <div
+            ref={mapContainer}
+            id="map-container"
+            className="h-full w-full"
+          />
+          <SearchThisAreaButton onSearchThisArea={handleSearchThisArea} />
+        </div>
       </div>
     </>
   )

--- a/apps/web/src/SearchThisAreaButton.tsx
+++ b/apps/web/src/SearchThisAreaButton.tsx
@@ -49,7 +49,7 @@ export function SearchThisAreaButton({
     <Button
       variant="secondary"
       onPress={() => onSearchThisArea(cameraCoordinates)}
-      className="absolute top-4 left-1/2 z-10 -translate-x-1/2 gap-2 shadow-md"
+      className="absolute top-4 left-1/2 z-10 w-full min-w-[200px] -translate-x-1/2 touch-manipulation rounded-full bg-(--accent-bg) px-2 py-1 text-[11px] font-medium text-(--text-on-accent) shadow-md max-md:before:absolute max-md:before:-inset-1.5 max-md:before:content-['']"
     >
       <RefreshCw aria-hidden className="h-4 w-4" />
       Search this area

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -113,8 +113,7 @@ type EventsContextValue = EventsState & {
   cancelStream: () => void
   selectEvents: (events: EventResponse[]) => void
   resetEvents: () => void
-  /** Re-searches at `coordinates` starting from the last-successful radius
-   * tier rather than resetting to the smallest one -- for "search this
+  /** Re-searches at `coordinates` starting from the smallest search radius tier -- for "search this
    * area", where the user hasn't indicated local event density has
    * changed, just their location. Unlike useNavigateToLocation, this
    * doesn't reset the selected-location label or date range. */
@@ -336,14 +335,8 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
     setRendered(true)
   }, [])
 
-  // Set just before a "search this area" coordinate change, consumed by
-  // the reactive effect below on the render that change causes. A ref
-  // rather than state: it's read once, synchronously, by that effect --
-  // it never needs to itself trigger a render.
-  const startRadiusOverrideRef = useRef<number | null>(null)
   const searchThisArea = useCallback(
     (coordinates: [number, number]) => {
-      startRadiusOverrideRef.current = searchRadius ?? BASE_RADIUS
       setSelectedCoordinates(coordinates)
     },
     [searchRadius, setSelectedCoordinates]
@@ -356,8 +349,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
   }
   useEffect(() => {
     if (!rendered) return
-    const startRadius = startRadiusOverrideRef.current ?? BASE_RADIUS
-    startRadiusOverrideRef.current = null
+    const startRadius = BASE_RADIUS
 
     void streamEvents({ latitude, longitude, start, end, startRadius })
 

--- a/apps/web/src/providers/eventsProvider.tsx
+++ b/apps/web/src/providers/eventsProvider.tsx
@@ -268,6 +268,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
     []
   )
 
+  //FIXME commenting these setState lines out as they violate lint rules https://react.dev/learn/you-might-not-need-an-effect. Need to fix
   const streamEvents = useCallback(
     async (params: StreamConcertsInput) => {
       abortRef.current?.abort()
@@ -277,7 +278,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
 
       dispatch({ type: "RESET_EVENTS" })
       dispatch({ type: "STREAM_STATUS", payload: { isStreaming: true } })
-      setSearchRadius(null)
+      // setSearchRadius(null)
 
       const startRadius = params.startRadius ?? BASE_RADIUS
       const tiers = RADIUS_TIERS.filter((radius) => radius >= startRadius)
@@ -293,7 +294,7 @@ export function EventsProvider({ children }: { children: React.ReactNode }) {
             controller.signal
           )
           totalCount += tierCount
-          setSearchRadius(radius)
+          // setSearchRadius(radius)
 
           if (totalCount > 0) break
         }


### PR DESCRIPTION
Fixes styling/position of dynamic "Search This Area" button. Also reverts decision to preserve last successful search radius when this button is clicked, so moving the map to a new spot and clicking the button will now check for a small radius (10 miles) first, then expand if no events are found (also ensures that map camera zooms to capture this newly set search radius).