### PR TITLE
Gate canonical-artist matching to Music-classified events

### DIFF
--- a/apps/api/src/events/mod.rs
+++ b/apps/api/src/events/mod.rs
@@ -55,6 +55,37 @@ fn find_matching_performer(
     })
 }
 
+/// Gates which events feed canonical-artist matching (see
+/// `crate::artists::spawn_enrichment`) — Sports/Arts & Theatre/Film events
+/// regularly have their own real Apple Music/Spotify catalog entries (a
+/// stage musical's cast recording, a team's warmup playlist) that
+/// exact-name matching happily "succeeds" against, producing artist
+/// enrichment (genres, similar artists, artwork) that makes no sense for
+/// what's actually a play or a rodeo. Confirmed live: "The Rocky Horror
+/// Show" matched an Apple Music cast-recording page under this exact
+/// failure mode.
+///
+/// Defaults to `true` (attempt the match) whenever there's no primary
+/// classification to check — missing metadata shouldn't cost a real music
+/// event its enrichment. PredictHQ-sourced events always pass this: their
+/// classification's segment is unconditionally `"Music"` (see
+/// `predicthq::normalize::build_classifications`), so this only has a real
+/// effect on the unscoped Ticketmaster fetch (PredictHQ's own fetch is
+/// already `category=concerts`-scoped at the API level).
+pub(crate) fn is_music_classified(event: &EventResponse) -> bool {
+    let Some(classifications) = &event.classifications else {
+        return true;
+    };
+    let primary = classifications.iter().find(|c| c.primary == Some(true));
+    match primary {
+        None => true,
+        Some(c) => c
+            .segment
+            .as_ref()
+            .is_some_and(|s| s.name.eq_ignore_ascii_case("music")),
+    }
+}
+
 pub(crate) fn dedupe_key(event: &EventResponse) -> String {
     let venue_name = event.venue.as_ref().and_then(|v| v.name.clone());
     let performer_id = event
@@ -74,7 +105,7 @@ pub(crate) fn dedupe_key(event: &EventResponse) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use types::{Source, VenueResponse};
+    use types::{Classification, Segment, Source, VenueResponse};
 
     fn event_with_performer(name: &str) -> EventResponse {
         EventResponse {
@@ -283,5 +314,56 @@ mod tests {
         other.id = "2".to_string();
 
         assert_ne!(dedupe_key(&base), dedupe_key(&other));
+    }
+
+    fn classification(primary: bool, segment_name: &str) -> Classification {
+        Classification {
+            primary: Some(primary),
+            segment: Some(Segment {
+                id: "id".to_string(),
+                name: segment_name.to_string(),
+            }),
+            genre: None,
+            sub_genre: None,
+            sub_type: None,
+            family: Some(false),
+        }
+    }
+
+    #[test]
+    fn is_music_classified_true_with_no_classifications_at_all() {
+        let event = event_with_performer("Artist");
+        assert!(is_music_classified(&event));
+    }
+
+    #[test]
+    fn is_music_classified_true_with_primary_music_segment() {
+        let mut event = event_with_performer("Artist");
+        event.classifications = Some(vec![classification(true, "Music")]);
+        assert!(is_music_classified(&event));
+    }
+
+    #[test]
+    fn is_music_classified_false_with_primary_non_music_segment() {
+        let mut event = event_with_performer("The Rocky Horror Show");
+        event.classifications = Some(vec![classification(true, "Arts & Theatre")]);
+        assert!(!is_music_classified(&event));
+    }
+
+    #[test]
+    fn is_music_classified_true_when_no_classification_is_flagged_primary() {
+        let mut event = event_with_performer("Artist");
+        event.classifications = Some(vec![classification(false, "Sports")]);
+        assert!(is_music_classified(&event));
+    }
+
+    #[test]
+    fn is_music_classified_ignores_non_primary_entries() {
+        let mut event = event_with_performer("Artist");
+        event.classifications = Some(vec![
+            classification(false, "Comedy"),
+            classification(true, "Music"),
+        ]);
+        assert!(is_music_classified(&event));
     }
 }

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -205,6 +205,7 @@ pub async fn get_concerts_tm_stream(
         // it.
         let mut artist_candidates: Vec<crate::artists::ArtistCandidate> = ticketmaster_events
             .iter()
+            .filter(|event| crate::events::is_music_classified(event))
             .flat_map(|event| event.performers.iter().flatten())
             .filter_map(|performer| {
                 performer.name.clone().map(|name| crate::artists::ArtistCandidate {
@@ -282,14 +283,19 @@ pub async fn get_concerts_tm_stream(
             // falls back to the event's own title for the ~28% of
             // PredictHQ events with no structured performer entity at
             // all, same as the image backfill above.
-            artist_candidates.extend(new_events.iter().flat_map(|event| {
-                crate::predicthq::performer_search_names(event)
-                    .into_iter()
-                    .map(|name| crate::artists::ArtistCandidate {
-                        name,
-                        ticketmaster_attraction_id: None,
-                    })
-            }));
+            artist_candidates.extend(
+                new_events
+                    .iter()
+                    .filter(|event| crate::events::is_music_classified(event))
+                    .flat_map(|event| {
+                        crate::predicthq::performer_search_names(event)
+                            .into_iter()
+                            .map(|name| crate::artists::ArtistCandidate {
+                                name,
+                                ticketmaster_attraction_id: None,
+                            })
+                    }),
+            );
 
             crate::artists::attach_enrichment(&mut new_events, &state.db.pool).await;
 


### PR DESCRIPTION
## Summary

Sports/Arts & Theatre/Film events regularly have their own real Apple Music/Spotify catalog entries (a stage musical's cast recording, a team's warmup playlist) that exact-name artist matching happily "succeeds" against, producing artist enrichment (genres, similar artists, artwork) that makes no sense for what's actually a play or a rodeo.

This is one of two findings from building an offline eval harness (`apps/api/src/artists/matching_eval.rs`, not part of this PR — separate follow-up) to test candidate improvements to canonical-artist matching against the real unmatched-artist corpus in the live DB, ahead of a broader "improve matching/deduping" initiative.

**Confirmed both directions against real data:**
- The eval harness turned up "The Rocky Horror Show" matching an Apple Music cast-recording page as if it were a musical artist.
- A live Ticketmaster lookup confirms "Hamilton (Touring)" is classified `Arts & Theatre`, not `Music` — exactly the case this gate excludes.

## What changed

- `events::is_music_classified()`: gates which events feed `crate::artists::spawn_enrichment`. Defaults to `true` (attempt the match) whenever there's no primary classification to check, so missing metadata never costs a real music event its enrichment.
- Applied as a filter in both places `ticketmaster_stream::mod` collects artist candidates (the Ticketmaster event path and the PredictHQ-reconciled-new-events path).
- PredictHQ's own classifications are unconditionally `"Music"` already (see `predicthq::normalize::build_classifications`), so in practice this only changes behavior for the unscoped Ticketmaster fetch — PredictHQ's own fetch is already `category=concerts`-scoped at the API level.

## Test plan

- [x] `cargo check`/`test`/`fmt`/`clippy` — clean, 99/99 lib tests pass (5 new, covering: no classifications at all, primary Music, primary non-Music, no classification flagged primary, non-primary entries ignored)
- [x] Verified live against Ticketmaster that a real Arts & Theatre event ("Hamilton (Touring)") is excluded by this gate as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)