### PR TITLE
Point matching_eval at the shared cleaning module

### DIFF
--- a/apps/api/src/artists/matching_eval.rs
+++ b/apps/api/src/artists/matching_eval.rs
@@ -45,6 +45,8 @@ use crate::auth::{ClientCredentialsManager, SpotifyCredentials};
 use crate::db::AppDatabase;
 use crate::spotify::client::{SpotifyClient, normalize_artist_name};
 
+use super::cleaning::billing_variants;
+
 /// Sample sizes default to a quick run (large enough to be a meaningful
 /// signal, small enough to finish in a couple minutes) but are
 /// overridable via env var for a full-corpus run:
@@ -97,89 +99,6 @@ struct MatchOutcome {
     /// Only set for the regression pass -- the id already stored in
     /// `artists` for this name, to compare against `matched_id`.
     previously_matched_id: Option<String>,
-}
-
-/// Splits obviously-multi-artist billing ("Zedd, Ganja White Night,
-/// Crankdat...") and strips a handful of trailing qualifiers real
-/// Ticketmaster/PredictHQ titles carry that no catalog entry ever would
-/// ("Luh Tyler - Destined For Greatness Tour", "Casey Donahew in
-/// Deshler"). Ordered most-specific-first (the original name is always
-/// tried first by the caller) so a match on a less-mangled variant is
-/// always preferred.
-fn billing_variants(name: &str) -> Vec<String> {
-    let mut variants = Vec::new();
-
-    let stripped = strip_known_suffixes(name);
-    if stripped != name {
-        variants.push(stripped.clone());
-    }
-
-    let first_billed = first_billed_segment(&stripped);
-    if first_billed != stripped {
-        variants.push(first_billed.clone());
-    }
-    let first_billed_of_original = first_billed_segment(name);
-    if first_billed_of_original != name && !variants.contains(&first_billed_of_original) {
-        variants.push(first_billed_of_original);
-    }
-
-    variants.retain(|v| !v.trim().is_empty());
-    variants.dedup();
-    variants
-}
-
-/// Takes the first segment of an obvious multi-artist billing string.
-/// Deliberately conservative about what counts as a separator -- "&" and
-/// "/" appear inside plenty of single-artist names (e.g. "Earth, Wind &
-/// Fire", "AC/DC"), so only split on separators that are unambiguous
-/// multi-act billing markers in practice.
-fn first_billed_segment(name: &str) -> String {
-    for sep in [
-        ", ",
-        " w/ ",
-        " with special guest ",
-        " feat. ",
-        " featuring ",
-    ] {
-        if let Some((first, _)) = name.split_once(sep) {
-            return first.trim().to_string();
-        }
-    }
-    name.trim().to_string()
-}
-
-/// Strips trailing qualifiers that describe the *event*, not the artist:
-/// a dash-separated tour name, a trailing parenthetical, or a trailing
-/// "in <City>" / "at <Venue>" qualifier.
-fn strip_known_suffixes(name: &str) -> String {
-    let mut s = name.trim();
-
-    if let Some(idx) = s.rfind('(')
-        && s.ends_with(')')
-    {
-        s = s[..idx].trim();
-    }
-
-    if let Some((before, _)) = s.split_once(" - ") {
-        s = before.trim();
-    }
-
-    for marker in [" in ", " at "] {
-        if let Some(idx) = s.rfind(marker) {
-            let tail = &s[idx + marker.len()..];
-            // Only strip when the tail looks like a bare place name (short,
-            // title-cased words) -- not, say, "Cheap Trick in Concert" or a
-            // real band name that happens to contain " in ".
-            let looks_like_place = tail.split_whitespace().count() <= 3
-                && tail.chars().next().is_some_and(|c| c.is_uppercase())
-                && !tail.eq_ignore_ascii_case("concert");
-            if looks_like_place {
-                s = s[..idx].trim();
-            }
-        }
-    }
-
-    s.to_string()
 }
 
 struct Providers {
@@ -510,73 +429,4 @@ async fn eval_matching_strategies() {
     )
     .expect("failed to write report");
     println!("full report written to {out_path}");
-}
-
-#[cfg(test)]
-mod unit_tests {
-    use super::*;
-
-    #[test]
-    fn first_billed_segment_splits_comma_separated_billing() {
-        assert_eq!(
-            first_billed_segment("Zedd, Ganja White Night, Crankdat"),
-            "Zedd"
-        );
-    }
-
-    #[test]
-    fn first_billed_segment_leaves_ampersand_names_alone() {
-        assert_eq!(first_billed_segment("Earth, Wind & Fire"), "Earth");
-    }
-
-    #[test]
-    fn first_billed_segment_splits_w_slash_billing() {
-        assert_eq!(
-            first_billed_segment("Myles Smith w/ Jonah Kagen"),
-            "Myles Smith"
-        );
-    }
-
-    #[test]
-    fn first_billed_segment_leaves_single_artist_names_alone() {
-        assert_eq!(
-            first_billed_segment("Vicki Burns Quintet"),
-            "Vicki Burns Quintet"
-        );
-    }
-
-    #[test]
-    fn strip_known_suffixes_removes_dash_separated_tour_name() {
-        assert_eq!(
-            strip_known_suffixes("Luh Tyler - Destined For Greatness Tour"),
-            "Luh Tyler"
-        );
-    }
-
-    #[test]
-    fn strip_known_suffixes_removes_trailing_in_city() {
-        assert_eq!(
-            strip_known_suffixes("Casey Donahew in Deshler"),
-            "Casey Donahew"
-        );
-    }
-
-    #[test]
-    fn strip_known_suffixes_leaves_in_concert_alone() {
-        assert_eq!(
-            strip_known_suffixes("Cheap Trick in Concert"),
-            "Cheap Trick in Concert"
-        );
-    }
-
-    #[test]
-    fn strip_known_suffixes_removes_trailing_parenthetical() {
-        assert_eq!(strip_known_suffixes("Joe Hart (US)"), "Joe Hart");
-    }
-
-    #[test]
-    fn billing_variants_combines_suffix_strip_and_split() {
-        let variants = billing_variants("Zedd, Ganja White Night, Crankdat in Magna");
-        assert!(variants.contains(&"Zedd".to_string()));
-    }
 }


### PR DESCRIPTION
## Summary
- `matching_eval.rs` had its own copies of `billing_variants`/`first_billed_segment`/`strip_known_suffixes`, left over from before `artists::cleaning` existed (extracted in #78).
- Now that #77 and #78 are both merged, import from the shared module instead of duplicating it, and drop the eval harness's own unit tests that exactly duplicated `cleaning`'s coverage.
- No behavior change — same logic, one source of truth.

## Test plan
- [x] `cargo check --tests`
- [x] `cargo test --lib artists::` (26 passed, 1 ignored — the live-API eval test)
- [x] `cargo fmt`
- [x] `cargo clippy --bins --tests -- -D clippy::all` (CI's exact invocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)