### PR TITLE
Fix cross-source dedup's UTC-day bug in events::reconcile

### DIFF
--- a/apps/api/src/artists/lookup.rs
+++ b/apps/api/src/artists/lookup.rs
@@ -232,6 +232,7 @@ mod tests {
             images: vec![],
             dates: None,
             dates_pretty: None,
+            local_calendar_day: None,
             classifications: None,
             performers: Some(names.iter().map(|n| performer(Some(n))).collect()),
             url: None,

--- a/apps/api/src/events/mod.rs
+++ b/apps/api/src/events/mod.rs
@@ -115,6 +115,7 @@ mod tests {
             images: vec![],
             dates: None,
             dates_pretty: None,
+            local_calendar_day: None,
             classifications: None,
             performers: Some(vec![Performer {
                 name: Some(name.to_string()),
@@ -243,6 +244,7 @@ mod tests {
             images: vec![],
             dates: Some("2026-08-01T20:00:00Z".to_string()),
             dates_pretty: None,
+            local_calendar_day: None,
             classifications: None,
             performers: Some(vec![Performer {
                 name: Some("Artist".to_string()),
@@ -287,6 +289,7 @@ mod tests {
             images: vec![],
             dates: Some("2026-08-01T20:00:00Z".to_string()),
             dates_pretty: None,
+            local_calendar_day: None,
             classifications: None,
             performers: None,
             url: None,

--- a/apps/api/src/events/reconcile.rs
+++ b/apps/api/src/events/reconcile.rs
@@ -137,14 +137,19 @@ fn performer_names_overlap(a: &EventResponse, b: &EventResponse) -> bool {
     }
 }
 
-/// The calendar-day portion of `event.dates` (both sources' dates are UTC
-/// ISO 8601 strings, so a plain string split is enough — no timezone math
-/// needed to compare "same day").
+/// The venue-local calendar day this event falls on, sourced from each
+/// provider's own local-time field (see `events::types::EventResponse::local_calendar_day`).
+///
+/// Deliberately NOT derived from `event.dates` — that's UTC, and for an
+/// evening show in any US timezone, splitting a UTC timestamp on `T` yields
+/// a day that's one ahead of the actual local day the show is on.
+/// Confirmed live against both providers (see the plan/PR this shipped
+/// with): a real PredictHQ concert with `start: "2026-11-04T04:00:00Z"` /
+/// `start_local: "2026-11-03T20:00:00"`, and real Ticketmaster evening
+/// events where `dates.start.dateTime` lands on the next UTC day relative
+/// to `dates.start.localDate`.
 fn calendar_day(event: &EventResponse) -> Option<&str> {
-    event
-        .dates
-        .as_deref()
-        .map(|d| d.split('T').next().unwrap_or(d))
+    event.local_calendar_day.as_deref()
 }
 
 /// When both sides have structured performer data, require at least one
@@ -196,6 +201,12 @@ mod tests {
             images: vec![],
             dates: Some(date.to_string()),
             dates_pretty: None,
+            // Mirrors the pre-fix naive `split('T')` behavior so existing
+            // fixtures above (which pass a single UTC `dates` string and
+            // expect it to double as the calendar day) keep working
+            // unchanged; tests that need to exercise a UTC/local-day
+            // mismatch override this field explicitly afterward.
+            local_calendar_day: Some(date.split('T').next().unwrap_or(date).to_string()),
             classifications: None,
             performers: None,
             url: None,
@@ -468,6 +479,27 @@ mod tests {
 
         assert!(enrichments.is_empty());
         assert_eq!(new_events.len(), 1);
+    }
+
+    #[test]
+    fn matches_via_local_calendar_day_even_when_utc_dates_disagree() {
+        // The confirmed-live bug this regression-tests: Ticketmaster's
+        // fallback path (no `dateTime`, bare `localDate` only) doesn't
+        // cross midnight, while PredictHQ's `start` (always UTC) does for
+        // an evening show -- so the old naive `split('T')` on `dates` saw
+        // "2026-10-23" vs "2026-10-24" and never matched, even though both
+        // sources agree the show is on the venue-local day of 2026-10-23.
+        let mut tm = event("tm-1", "State Theatre", "2026-10-23"); // TM's local-date-only fallback
+        tm.local_calendar_day = Some("2026-10-23".to_string());
+
+        let mut phq = phq_event("phq-1", "State Theatre", "2026-10-24T03:00:00Z", 60); // PHQ's UTC start, crossed midnight
+        phq.local_calendar_day = Some("2026-10-23".to_string());
+
+        let (enrichments, new_events) = reconcile_predicthq_events(&[tm], vec![phq]);
+
+        assert_eq!(enrichments.len(), 1);
+        assert_eq!(enrichments[0].id, "tm-1");
+        assert!(new_events.is_empty());
     }
 
     #[test]

--- a/apps/api/src/events/types.rs
+++ b/apps/api/src/events/types.rs
@@ -27,6 +27,13 @@ pub struct EventResponse {
     pub dates: Option<String>,
     #[serde(rename = "datesPretty")]
     pub dates_pretty: Option<String>,
+    /// The venue-local calendar day this event falls on, sourced from each
+    /// provider's own local-time field (Ticketmaster's `dates.start.localDate`,
+    /// PredictHQ's `start_local`) rather than derived from `dates` (UTC) --
+    /// used only for cross-source dedup matching (`events::reconcile`), not
+    /// sent to the frontend. See `events::reconcile::calendar_day`.
+    #[serde(skip_serializing)]
+    pub local_calendar_day: Option<String>,
     pub classifications: Option<Vec<Classification>>,
     pub performers: Option<Vec<Performer>>,
     pub url: Option<String>,

--- a/apps/api/src/predicthq/artwork.rs
+++ b/apps/api/src/predicthq/artwork.rs
@@ -128,6 +128,7 @@ mod tests {
             images: vec![],
             dates: Some("2026-08-09T23:00:00Z".to_string()),
             dates_pretty: None,
+            local_calendar_day: Some("2026-08-09".to_string()),
             classifications: None,
             performers: performer.map(|name| {
                 vec![Performer {

--- a/apps/api/src/predicthq/client.rs
+++ b/apps/api/src/predicthq/client.rs
@@ -34,6 +34,11 @@ pub(crate) struct PredictHqEvent {
     #[serde(default)]
     pub(crate) entities: Vec<PredictHqEntity>,
     pub(crate) start: String,
+    /// Venue-local wall-clock start time, no UTC offset (e.g.
+    /// `"2026-11-03T20:00:00"` for an 8pm local show) — used to derive the
+    /// correct local calendar day for cross-source dedup, since `start` is
+    /// UTC and can land on the next calendar day for evening shows.
+    pub(crate) start_local: Option<String>,
     pub(crate) geo: Option<PredictHqGeo>,
     pub(crate) phq_labels: Option<Vec<PhqLabel>>,
 }

--- a/apps/api/src/predicthq/mod.rs
+++ b/apps/api/src/predicthq/mod.rs
@@ -63,6 +63,7 @@ mod tests {
             images: vec![],
             dates: None,
             dates_pretty: None,
+            local_calendar_day: None,
             classifications: None,
             performers: performer.map(|name| {
                 vec![Performer {

--- a/apps/api/src/predicthq/normalize.rs
+++ b/apps/api/src/predicthq/normalize.rs
@@ -63,6 +63,19 @@ pub(crate) fn normalize_predicthq_event(e: PredictHqEvent) -> EventResponse {
         .map(|dt| dt.with_timezone(&Local).format("%B %d").to_string())
         .ok();
 
+    // `start_local` is the venue-local wall clock with no UTC offset, so its
+    // date portion is already the correct local calendar day -- no
+    // timezone math needed. Falls back to `start`'s (UTC) date portion on
+    // the rare event missing `start_local`, matching this codebase's
+    // existing graceful-degradation style.
+    let local_calendar_day = e
+        .start_local
+        .as_deref()
+        .unwrap_or(&e.start)
+        .split('T')
+        .next()
+        .map(|d| d.to_string());
+
     EventResponse {
         // PredictHQ and Ticketmaster ids are both opaque alphanumeric
         // strings from unrelated generators, but the collision risk costs
@@ -73,6 +86,7 @@ pub(crate) fn normalize_predicthq_event(e: PredictHqEvent) -> EventResponse {
         images: vec![],
         dates: Some(e.start),
         dates_pretty,
+        local_calendar_day,
         classifications: Some(build_classifications(e.phq_labels.as_deref())),
         performers,
         url: None,
@@ -158,6 +172,7 @@ mod tests {
             phq_attendance: Some(300),
             entities: vec![],
             start: "2026-08-09T23:00:00Z".to_string(),
+            start_local: Some("2026-08-09T19:00:00".to_string()),
             geo: None,
             phq_labels: None,
         }

--- a/apps/api/src/ticketmaster_stream/normalize.rs
+++ b/apps/api/src/ticketmaster_stream/normalize.rs
@@ -19,6 +19,17 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
         }
     });
 
+    // `local_date` is already the venue-local calendar day, no timezone math
+    // needed. Falls back to `dates`'s (UTC) date portion on the rare event
+    // missing `local_date` too, matching this codebase's existing
+    // graceful-degradation style.
+    let local_calendar_day = e.dates.start.local_date.clone().or_else(|| {
+        dates
+            .as_deref()
+            .and_then(|d| d.split('T').next())
+            .map(str::to_string)
+    });
+
     let venue = e
         .embedded
         .as_ref()
@@ -56,6 +67,7 @@ pub(crate) fn normalize_event(e: TmEvent) -> EventResponse {
         images: e.images,
         dates,
         dates_pretty,
+        local_calendar_day,
         classifications: e.classifications,
         performers,
         price_ranges: e.price_ranges,

--- a/apps/web/CONTEXT.md
+++ b/apps/web/CONTEXT.md
@@ -6,4 +6,4 @@ React/Vite frontend for Gigeo — the map/search UI, event drawer, and Spotify/A
 
 **LocalDay**:
 The calendar day an event or search boundary falls on in the viewer's own timezone. Represented as a `YYYY-MM-DD` string. Owned by `lib/dates.ts` (`eventDateKey`, `dateRangeToApiParams`). Assumes the viewer's timezone approximates the venue's — the app has no reliable source for the venue's actual timezone.
-_Avoid_: CalendarDay (the backend's `reconcile.rs` has a `calendar_day` function that means the *UTC* day, a different concept used for cross-source event matching — don't conflate the two), UTC day.
+_Avoid_: CalendarDay (the backend's `reconcile.rs` has a `calendar_day` function that means the venue-*local* day, sourced from each provider's own local-time field (Ticketmaster's `localDate`, PredictHQ's `start_local`) — a different concept, used only for cross-source event matching, that happens to share a name with LocalDay above. Still don't conflate the two: CalendarDay is backend-only and never sent to the frontend), UTC day.


### PR DESCRIPTION
## Summary
- `reconcile.rs`'s `calendar_day()` derived the "same day" comparison for cross-source (Ticketmaster/PredictHQ) event dedup by splitting `event.dates` (always UTC) on `T`. For any evening show in a US timezone, that yields a calendar day one ahead of the actual venue-local day the show is on — confirmed live against both real APIs:
  - PredictHQ: `start: "2026-11-04T04:00:00Z"`, `start_local: "2026-11-03T20:00:00"` (8pm Nov 3rd local).
  - Ticketmaster: `dates.start.dateTime` lands on the next UTC day relative to `dates.start.localDate` on every real evening show sampled.
- Both sources usually take the UTC-timestamp path, so this mostly self-cancelled in practice — but Ticketmaster's own `dateTime`-less fallback (bare `localDate`) breaks that symmetry, causing real same-show pairs to fail to match.
- **No timezone-conversion math or new dependency needed** — both providers already send the correct local calendar day as a plain string next to the UTC one. This PR captures PredictHQ's `start_local` (not previously parsed at all) and uses Ticketmaster's already-parsed `local_date` (parsed but previously unused for dedup), computing a new `EventResponse.local_calendar_day` field (`#[serde(skip_serializing)]` — backend-only, not sent to the frontend) that `calendar_day()` now reads directly instead of splitting `dates`.
- Also corrects the stale `CalendarDay` glossary entry in `apps/web/CONTEXT.md`, which incorrectly described the old (buggy) UTC-day behavior as intentional.
- Scope: backend-only, narrowly targeted at cross-source dedup. `EventResponse.dates`/`dates_pretty` (display/sorting) and the frontend's `LocalDay` concept are untouched. `dedupe_key()` (same-source duplicate detection) is unaffected — it compares an event's own raw value against itself, no cross-source ambiguity involved.

## Test plan
- [x] New regression test `matches_via_local_calendar_day_even_when_utc_dates_disagree` directly reproduces the confirmed asymmetric-fallback bug (Ticketmaster's local-date-only fallback vs. PredictHQ's UTC-crossed `start`) and confirms they now match.
- [x] `cargo check --all-targets`
- [x] `cargo test --lib` (114 passed, 4 ignored)
- [x] `cargo fmt`
- [x] `cargo clippy --bins --tests -- -D clippy::all` (CI's exact invocation)
- No live-API verification needed beyond what's already confirmed above — this is a pure logic fix using data both providers already send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)