### PR TITLE
Expose spotify_url alongside apple_music_url on matched artists

### DIFF
--- a/apps/api/.sqlx/query-5dbbdf15fc42caf8c51c564139d85398c1748d67eb20b9379680583876f0db3a.json
+++ b/apps/api/.sqlx/query-5dbbdf15fc42caf8c51c564139d85398c1748d67eb20b9379680583876f0db3a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        select\n            normalized_name,\n            display_name,\n            apple_music_id,\n            spotify_id,\n            artwork_url,\n            artwork_bg_color,\n            apple_music_url,\n            genres,\n            similar_artists as \"similar_artists: Json<Vec<SimilarArtist>>\"\n        from artists\n        where normalized_name = any($1) and matched_via is not null\n        ",
+  "query": "\n        select\n            normalized_name,\n            display_name,\n            apple_music_id,\n            spotify_id,\n            artwork_url,\n            artwork_bg_color,\n            apple_music_url,\n            spotify_url,\n            genres,\n            similar_artists as \"similar_artists: Json<Vec<SimilarArtist>>\"\n        from artists\n        where normalized_name = any($1) and matched_via is not null\n        ",
   "describe": {
     "columns": [
       {
@@ -40,11 +40,16 @@
       },
       {
         "ordinal": 7,
+        "name": "spotify_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
         "name": "genres",
         "type_info": "TextArray"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "similar_artists: Json<Vec<SimilarArtist>>",
         "type_info": "Jsonb"
       }
@@ -62,9 +67,10 @@
       true,
       true,
       true,
+      true,
       false,
       false
     ]
   },
-  "hash": "d1cad876942950eb9cde8db73f285f2d039acc6128cbfc6c76de4d6ed8d66d6c"
+  "hash": "5dbbdf15fc42caf8c51c564139d85398c1748d67eb20b9379680583876f0db3a"
 }

--- a/apps/api/src/artists/lookup.rs
+++ b/apps/api/src/artists/lookup.rs
@@ -22,6 +22,7 @@ struct EnrichmentRow {
     artwork_url: Option<String>,
     artwork_bg_color: Option<String>,
     apple_music_url: Option<String>,
+    spotify_url: Option<String>,
     genres: Vec<String>,
     similar_artists: Json<Vec<SimilarArtist>>,
 }
@@ -99,6 +100,7 @@ async fn fetch_rows(
             artwork_url,
             artwork_bg_color,
             apple_music_url,
+            spotify_url,
             genres,
             similar_artists as "similar_artists: Json<Vec<SimilarArtist>>"
         from artists
@@ -126,6 +128,7 @@ fn to_response(row: &EnrichmentRow) -> ArtistEnrichment {
         name: row.display_name.clone(),
         id,
         apple_music_url: row.apple_music_url.clone(),
+        spotify_url: row.spotify_url.clone(),
         artwork,
         genres: row.genres.clone(),
         similar_artists: row
@@ -159,6 +162,7 @@ mod tests {
             artwork_url: Some("https://example.com/art.jpg".to_string()),
             artwork_bg_color: Some("abcdef".to_string()),
             apple_music_url: Some("https://music.apple.com/artist/1".to_string()),
+            spotify_url: None,
             genres: vec!["Pop".to_string()],
             similar_artists: Json(vec![SimilarArtist {
                 name: "Similar Artist".to_string(),
@@ -190,6 +194,22 @@ mod tests {
         let mut r = row("role model");
         r.artwork_url = None;
         assert!(to_response(&r).artwork.is_none());
+    }
+
+    #[test]
+    fn to_response_maps_spotify_url_when_present() {
+        let mut r = row("role model");
+        r.spotify_url = Some("https://open.spotify.com/artist/1".to_string());
+        assert_eq!(
+            to_response(&r).spotify_url.as_deref(),
+            Some("https://open.spotify.com/artist/1")
+        );
+    }
+
+    #[test]
+    fn to_response_leaves_spotify_url_none_when_absent() {
+        let r = row("role model");
+        assert!(to_response(&r).spotify_url.is_none());
     }
 
     #[test]

--- a/apps/api/src/events/types.rs
+++ b/apps/api/src/events/types.rs
@@ -89,6 +89,11 @@ pub struct ArtistEnrichment {
     pub name: String,
     pub id: String,
     pub apple_music_url: Option<String>,
+    /// `None` for an artist matched via Apple Music with no Spotify
+    /// identity recorded (`try_apple_music_match` never looks Spotify up
+    /// once Apple already verified a match — see `artists::worker`), not
+    /// necessarily an artist Spotify itself has no page for.
+    pub spotify_url: Option<String>,
     pub artwork: Option<ArtistArtwork>,
     pub genres: Vec<String>,
     pub similar_artists: Vec<SimilarArtistResponse>,

--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react"
 import WikiLogo from "@/assets/wikipedia-w-brands-solid-full.svg"
 import IgLogo from "@/assets/instagram.svg"
+import SpotifyLogo from "@/assets/Primary_Logo_Green_CMYK.svg"
 import { ReactSVG } from "react-svg"
 import "react-social-icons/instagram"
 import type { EventResponse } from "./hooks/eventsStream"
@@ -390,7 +391,7 @@ export const ArtistCard: React.FC<ArtistCardProps> = ({
   onRetryFutureEvents,
   artworkSize = 200,
 }) => {
-  const { name, genres = [], artwork, apple_music_url } = artist
+  const { name, genres = [], artwork, apple_music_url, spotify_url } = artist
 
   // A canonical artist matched via Spotify (rather than Apple Music) can
   // legitimately have no artwork at all -- render the card without an
@@ -452,6 +453,7 @@ export const ArtistCard: React.FC<ArtistCardProps> = ({
             {apple_music_url && (
               <ExternalLink url={apple_music_url} label="Apple Music" />
             )}
+            {spotify_url && <ExternalLink url={spotify_url} label="Spotify" />}
           </ul>
         </div>
       </div>
@@ -504,6 +506,12 @@ const ExternalLink = ({ url, label }: { url: string; label: string }) => {
           />
         ) : label === "Apple Music" ? (
           <MusicIcon aria-hidden className="me-[4px] h-[24px] w-[24px]" />
+        ) : label === "Spotify" ? (
+          <ReactSVG
+            className="me-[4px] h-[24px] w-[24px]"
+            src={SpotifyLogo}
+            beforeInjection={(svg) => svg.setAttribute("aria-hidden", "true")}
+          />
         ) : (
           <GlobeIcon aria-hidden className="me-[4px] h-[24px] w-[24px]" />
         )}

--- a/apps/web/src/hooks/eventsStreamSchema.test.ts
+++ b/apps/web/src/hooks/eventsStreamSchema.test.ts
@@ -92,6 +92,7 @@ describe("eventResponseSchema", () => {
               name: "Role Model",
               id: "sp-1",
               apple_music_url: null,
+              spotify_url: "https://open.spotify.com/artist/sp-1",
               artwork: null,
               genres: ["Pop"],
               similar_artists: [],
@@ -105,6 +106,10 @@ describe("eventResponseSchema", () => {
       const performer = result.data.performers?.[0]
       expect(performer?.enrichment?.artwork).toBeUndefined()
       expect(performer?.enrichment?.genres).toEqual(["Pop"])
+      expect(performer?.enrichment?.apple_music_url).toBeUndefined()
+      expect(performer?.enrichment?.spotify_url).toBe(
+        "https://open.spotify.com/artist/sp-1"
+      )
     }
   })
 

--- a/apps/web/src/hooks/eventsStreamSchema.ts
+++ b/apps/web/src/hooks/eventsStreamSchema.ts
@@ -61,7 +61,16 @@ const amArtistSchema = z.object({
   artwork: optional(amArtworkSchema),
 })
 
+/** `spotify_url` is on the *full* schema, not `amArtistSchema` above --
+ * similar artists only ever come from Apple Music's similar-artists view
+ * (see apps/api/src/artists/worker.rs module docs), so they never carry
+ * one. Also asymmetric with `apple_music_url`: an artist matched via Apple
+ * Music (the common case) never gets a Spotify lookup at all, so
+ * `spotify_url` being absent doesn't mean Spotify has no page for them --
+ * see apps/api/src/events/types.rs's `ArtistEnrichment::spotify_url` doc
+ * comment. */
 const amArtistFullSchema = amArtistSchema.extend({
+  spotify_url: optional(z.string()),
   genres: z.array(z.string()),
   similar_artists: z.array(amArtistSchema),
 })


### PR DESCRIPTION
## Summary
- `ArtistEnrichment` only ever surfaced `apple_music_url` -- a holdover from when enrichment was Apple-only (Phase 0, before Spotify fallback matching existed).
- `worker.rs` has persisted `spotify_url` to the DB for a while (any artist matched via Spotify fallback, i.e. Apple Music had no verified match), but the read path (`lookup.rs`) never selected the column and the response type had no field for it -- an artist matched only via Spotify rendered with **no music-service link at all**, even though the link was sitting unused in the database.
- Backend: add `spotify_url` to `ArtistEnrichment`, thread it through `EnrichmentRow`/the SQL select/`to_response()` in `lookup.rs`.
- Frontend: parse `spotify_url` on the full artist schema (not the similar-artist schema -- similar artists only ever come from Apple Music's similar-artists view, so they never carry one) and render it via `ExternalLink` using the existing official Spotify logo asset (`Primary_Logo_Green_CMYK.svg`, the same one `PlaylistButtons.tsx` already uses).
- No wire/schema breaking change -- purely additive field, both links can now render independently based on which provider actually matched.

## Test plan
- [x] New backend unit tests: `to_response_maps_spotify_url_when_present`, `to_response_leaves_spotify_url_none_when_absent`
- [x] New frontend assertions in `eventsStreamSchema.test.ts` confirming `spotify_url` parses through while `apple_music_url` stays absent for a Spotify-only match
- [x] `cargo check` / `cargo test --lib` / `cargo fmt` / `cargo clippy --bins --tests -- -D clippy::all`
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm build`
- [x] Verified live end-to-end in the browser against a real Spotify-only-matched artist (Hiroe, SOMERGLOOM 2 Day Pass, Somerville MA) -- Spotify link renders with the correct logo and href, no Apple Music link shown. Confirmed no regression on Apple-Music-matched artists in the same event (Junius, Dropdead, Final Gasp, Severed Boy, etc.) -- still show only Apple Music as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)