### PR TITLE
Fix dead "switch to Explore tab on new events" behavior

### DIFF
--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -88,17 +88,11 @@ const DestinationIcon = ({
 }
 
 const DrawerWrapper = () => {
-  const { eventsByDate, selectedEvents } = useEventsContext()
+  const { eventsByDate, selectedEvents, isStreaming } = useEventsContext()
   const { isDrawerOpen, setIsDrawerOpen } = useDrawerProvider()
   const shouldReduceMotion = useReducedMotion()
 
   const [activeTab, setActiveTab] = useState<Key>("explore")
-  // FIXME: eventListRef is never attached to a DOM node, so the effect below
-  // that guards on `eventListRef.current` never runs — "switch to Explore
-  // tab on new events" is currently dead code, not working behavior. Left
-  // as-is for now; revisit as its own change rather than reviving it as a
-  // side effect of the date-scroll fix.
-  const eventListRef = useRef<HTMLDivElement>(null)
   const eventsScrollRef = useRef<HTMLDivElement>(null)
   const { topMostId, registerItem } = useTopMostVisibleInScrollContainer(
     eventsScrollRef,
@@ -130,10 +124,25 @@ const DrawerWrapper = () => {
     }
   }, [selectedEvents, setIsDrawerOpen])
 
+  // Switches to the Explore tab when a new search starts (e.g. the caller
+  // is on the Spotify/Apple Music tab, then moves the map or changes the
+  // date range) so the new results are actually visible rather than
+  // silently arriving behind unrelated tab content.
+  //
+  // Keyed off isStreaming's false->true transition, not eventsByDate:
+  // the backend streams results in one at a time (see
+  // eventsProvider.tsx's UPSERT_STREAMED_EVENT), so eventsByDate changes
+  // dozens of times over the course of a single search -- switching tabs
+  // on every one of those would be exactly the kind of repeated,
+  // twitchy interruption this behavior is meant to avoid, not cause.
+  const wasStreamingRef = useRef(isStreaming)
   useEffect(() => {
-    if (!eventListRef.current) return
-    handleDestinationTab("explore")
-  }, [eventsByDate, setIsDrawerOpen, handleDestinationTab])
+    const searchJustStarted = isStreaming && !wasStreamingRef.current
+    wasStreamingRef.current = isStreaming
+    if (searchJustStarted) {
+      handleDestinationTab("explore")
+    }
+  }, [isStreaming, handleDestinationTab])
 
   const isDesktop = useMediaQuery("(min-width: 768px)", {
     defaultValue: false,


### PR DESCRIPTION
Fixes #71.

## Summary
- `eventListRef` in `DrawerWrapper.tsx` was never attached to a DOM node in *any* commit since the file's introduction (checked back to the first "testing..." commit) -- the effect guarding on `eventListRef.current` always short-circuited, so the documented behavior ("switch to Explore tab on new events") was dead code, not working behavior, per the existing FIXME.
- Rather than just restoring a ref attachment (issue's option 1), reassessed the trigger itself (option 2): the original effect was keyed off `eventsByDate`, which changes **once per individual streamed event** -- the backend streams results one at a time (`eventsProvider.tsx`'s `UPSERT_STREAMED_EVENT`), so a single search can update `eventsByDate` dozens of times. Naively firing on every change would have repeatedly yanked the user back to Explore mid-search, not delivered the one-time "you started a new search" signal the feature is meant to be.
- Now keyed off `isStreaming`'s false→true transition instead, which fires exactly once per genuinely new search (location or date-range change) -- not per streamed event.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` (no new warnings) / `pnpm test` (112 passed) / `pnpm build`
- [x] Verified live: switching to the Spotify tab, then starting a new search (map location change) -- correctly snaps back to Explore.
- [x] Verified live: switching to the Spotify tab *during* an in-progress stream (dense Boston-area search, confirmed via network tab the stream was still active) -- correctly **stays** on Spotify across ~4s of continued `eventsByDate` updates, confirming the fix doesn't reintroduce the "yanked on every event" problem a naive `eventsByDate`-keyed fix would have.
- [x] No console errors during either scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)