### PR TITLE
Always look up Spotify alongside Apple Music, backfill existing matches

### DIFF
--- a/apps/api/.sqlx/query-98b135233d5716add54ae406562cea970d6664c012246bb4419d4dd5e088b2cd.json
+++ b/apps/api/.sqlx/query-98b135233d5716add54ae406562cea970d6664c012246bb4419d4dd5e088b2cd.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        select normalized_name, display_name\n        from artists\n        where matched_via::text = 'apple_music' and spotify_url is null\n        order by normalized_name\n        limit $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "normalized_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "98b135233d5716add54ae406562cea970d6664c012246bb4419d4dd5e088b2cd"
+}

--- a/apps/api/.sqlx/query-f3f9696fb9778ccf875990b71a4033fae2abde1a93f31cddaf68b9cef108df8d.json
+++ b/apps/api/.sqlx/query-f3f9696fb9778ccf875990b71a4033fae2abde1a93f31cddaf68b9cef108df8d.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        update artists\n        set spotify_id = $2, spotify_url = $3, last_attempted_at = now()\n        where normalized_name = $1 and spotify_id is null\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f3f9696fb9778ccf875990b71a4033fae2abde1a93f31cddaf68b9cef108df8d"
+}

--- a/apps/api/src/artists/db.rs
+++ b/apps/api/src/artists/db.rs
@@ -158,6 +158,43 @@ pub(super) async fn touch_last_attempted(
     .map(|_| ())
 }
 
+/// Narrowly attaches a Spotify identity to an already-matched row without
+/// touching Apple identity/artwork/genres/similar_artists — the write path
+/// for the one-off Spotify backfill (see `spotify_backfill`), for a row
+/// that was matched via Apple Music before Spotify was looked up alongside
+/// it too. Guarded by `where spotify_id is null`: unlike
+/// `upsert_matched`'s unconditional `spotify_url = excluded.spotify_url`,
+/// this must never clobber a value another path already wrote (e.g. an
+/// overlapping backfill run). Deliberately doesn't touch
+/// `enrichment_refreshed_at` — that drives the dynamic-field-freshness
+/// check in `worker::resolve_one`, and bumping it here would silently push
+/// out this row's next genre/similar-artist refresh as a side effect of an
+/// unrelated write.
+///
+/// Only consumed by the `#[cfg(test)]`-gated `spotify_backfill` tool today,
+/// so a plain non-test build sees no caller.
+#[allow(dead_code)]
+pub(super) async fn attach_spotify(
+    pool: &PgPool,
+    normalized_name: &str,
+    spotify_id: &str,
+    spotify_url: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        update artists
+        set spotify_id = $2, spotify_url = $3, last_attempted_at = now()
+        where normalized_name = $1 and spotify_id is null
+        "#,
+        normalized_name,
+        spotify_id,
+        spotify_url,
+    )
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
 /// Refreshes only the fields expected to go stale on their own (genres,
 /// similar artists) for an already-matched row — identity and artwork are
 /// left untouched, per ADR-0001.

--- a/apps/api/src/artists/mod.rs
+++ b/apps/api/src/artists/mod.rs
@@ -12,13 +12,17 @@
 //! a given artist won't have enrichment for it yet; every request after
 //! does.
 //!
-//! Provider priority is Apple Music first (verified exact-normalized-name
-//! match against catalog search), Spotify as fallback only when Apple has
-//! no verified match — mirrors the priority already established by
+//! Both Apple Music and Spotify are always looked up (verified
+//! exact-normalized-name match against each provider's own catalog
+//! search), concurrently — but Apple Music wins identity/display fields
+//! whenever it has a match (display_name, artwork, genres,
+//! similar_artists), mirroring the priority already established by
 //! `crate::apple_music::artwork_cache` and `crate::spotify::top_artists`.
-//! Similar/related artists only ever come from Apple Music's
-//! `similar-artists` view (Spotify deprecated its own for new API access —
-//! see `crate::spotify::top_artists` module docs), so an artist that only
+//! A Spotify match found alongside an Apple one only ever contributes its
+//! own id/listen link on top — see `worker::resolve_fresh`. Similar/
+//! related artists only ever come from Apple Music's `similar-artists`
+//! view (Spotify deprecated its own for new API access — see
+//! `crate::spotify::top_artists` module docs), so an artist that only
 //! Spotify could verify simply has no similar-artists list.
 
 mod cleaning;
@@ -26,6 +30,8 @@ mod db;
 mod lookup;
 #[cfg(test)]
 mod matching_eval;
+#[cfg(test)]
+mod spotify_backfill;
 mod worker;
 
 pub(crate) use lookup::attach_enrichment;

--- a/apps/api/src/artists/spotify_backfill.rs
+++ b/apps/api/src/artists/spotify_backfill.rs
@@ -1,0 +1,154 @@
+//! One-off backfill: attaches a Spotify identity to artists that were
+//! matched via Apple Music before `worker::resolve_fresh` started looking
+//! Spotify up alongside Apple Music too. Without this, those rows would
+//! only pick up a Spotify listen link whenever their dynamic-field refresh
+//! cycle happens to fire next, up to 30 days out (see
+//! `worker::DYNAMIC_FIELD_TTL`).
+//!
+//! Writes real data to `artists` (via `db::attach_spotify`, which never
+//! overwrites an existing `spotify_id`) using the real Spotify API, so like
+//! `matching_eval` this needs a real `DATABASE_URL` plus working Spotify
+//! credentials and is `#[ignore]`d, run explicitly:
+//!
+//!   cargo test --lib artists::spotify_backfill -- --ignored --nocapture
+//!
+//! Safe to interrupt and re-run at any point: the selection query only
+//! pulls rows still missing `spotify_url`, and `attach_spotify`'s own
+//! `where spotify_id is null` guard makes even an overlapping write a
+//! no-op — no separate progress-tracking needed.
+
+use futures::StreamExt;
+use reqwest::Client;
+use sqlx::PgPool;
+
+use super::db;
+use super::worker::try_spotify_match;
+use crate::auth::{ClientCredentialsManager, SpotifyCredentials};
+use crate::db::AppDatabase;
+use crate::spotify::client::SpotifyClient;
+
+/// Caps the number of candidate rows processed in one run — unset means
+/// the full backlog. Useful for a small sanity-check run before committing
+/// to the whole backlog:
+///   BACKFILL_LIMIT=25 cargo test --lib artists::spotify_backfill -- --ignored --nocapture
+fn backfill_limit() -> i64 {
+    std::env::var("BACKFILL_LIMIT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(i64::MAX)
+}
+
+/// Same bounded-concurrency convention as
+/// `worker::MAX_CONCURRENT_ENRICHMENTS` — a polite ceiling on concurrent
+/// requests against Spotify.
+const MAX_CONCURRENT: usize = 4;
+
+struct BackfillTarget {
+    normalized_name: String,
+    display_name: String,
+}
+
+async fn fetch_targets(pool: &PgPool, limit: i64) -> Vec<BackfillTarget> {
+    sqlx::query_as!(
+        BackfillTarget,
+        r#"
+        select normalized_name, display_name
+        from artists
+        where matched_via::text = 'apple_music' and spotify_url is null
+        order by normalized_name
+        limit $1
+        "#,
+        limit
+    )
+    .fetch_all(pool)
+    .await
+    .expect("failed to fetch backfill targets")
+}
+
+enum BackfillOutcome {
+    Found { name: String },
+    NotFound { name: String },
+    DbError { name: String, error: String },
+}
+
+async fn backfill_one(
+    spotify: &SpotifyClient,
+    cc_manager: &ClientCredentialsManager,
+    pool: &PgPool,
+    target: BackfillTarget,
+) -> BackfillOutcome {
+    let Some(artist) = try_spotify_match(spotify, cc_manager, &target.display_name).await else {
+        return BackfillOutcome::NotFound {
+            name: target.display_name,
+        };
+    };
+
+    let result = db::attach_spotify(
+        pool,
+        &target.normalized_name,
+        &artist.id,
+        artist.external_urls.spotify.as_deref(),
+    )
+    .await;
+
+    match result {
+        Ok(()) => BackfillOutcome::Found {
+            name: target.display_name,
+        },
+        Err(err) => BackfillOutcome::DbError {
+            name: target.display_name,
+            error: err.to_string(),
+        },
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn backfill_spotify_for_apple_matched_artists() {
+    let _ = dotenvy::dotenv();
+
+    let database_url =
+        std::env::var("DATABASE_URL").expect("DATABASE_URL must be set to run this backfill");
+    let db = AppDatabase::new(&database_url)
+        .await
+        .expect("failed to connect to database");
+
+    let http = Client::new();
+    let spotify_creds = SpotifyCredentials::from_env();
+    let cc_manager = ClientCredentialsManager::new(spotify_creds, http.clone());
+    let spotify = SpotifyClient::new(http);
+
+    let targets = fetch_targets(&db.pool, backfill_limit()).await;
+    let total = targets.len();
+    println!("backfilling spotify identity for {total} apple_music-matched artists");
+
+    let outcomes: Vec<BackfillOutcome> = futures::stream::iter(targets)
+        .map(|target| async { backfill_one(&spotify, &cc_manager, &db.pool, target).await })
+        .buffer_unordered(MAX_CONCURRENT)
+        .collect()
+        .await;
+
+    let mut found = Vec::new();
+    let mut not_found = Vec::new();
+    let mut errors = Vec::new();
+    for outcome in outcomes {
+        match outcome {
+            BackfillOutcome::Found { name } => found.push(name),
+            BackfillOutcome::NotFound { name } => not_found.push(name),
+            BackfillOutcome::DbError { name, error } => errors.push((name, error)),
+        }
+    }
+
+    println!(
+        "attempted={total} found={} not_found={} errors={}",
+        found.len(),
+        not_found.len(),
+        errors.len()
+    );
+    if !not_found.is_empty() {
+        println!("not found: {not_found:?}");
+    }
+    if !errors.is_empty() {
+        println!("errors: {errors:?}");
+    }
+}

--- a/apps/api/src/artists/worker.rs
+++ b/apps/api/src/artists/worker.rs
@@ -7,7 +7,8 @@ use super::cleaning;
 use super::db::{self, MatchedArtist};
 use super::{ArtistCandidate, SimilarArtist};
 use crate::apple_music::client::ArtistAttributes;
-use crate::spotify::client::{Artist as SpotifyArtist, normalize_artist_name};
+use crate::auth::ClientCredentialsManager;
+use crate::spotify::client::{Artist as SpotifyArtist, SpotifyClient, normalize_artist_name};
 use crate::state::AppState;
 
 /// Apple Music's own artwork template resolved to a real photo size for an
@@ -113,7 +114,18 @@ async fn resolve_one(state: &AppState, candidate: ArtistCandidate) {
 }
 
 async fn resolve_fresh(state: &AppState, candidate: &ArtistCandidate, normalized: &str) {
-    if let Some((apple_music_id, attrs)) = try_apple_music_match(state, &candidate.name).await {
+    // Both providers are always attempted now, concurrently -- independent
+    // read-only lookups, so there's no reason to serialize them. Apple
+    // Music still wins identity/display fields when it has a match
+    // (display_name, artwork, genres, similar_artists -- see module docs /
+    // ADR-0001 on why); a Spotify match found alongside it only ever
+    // contributes spotify_id/spotify_url on top.
+    let (apple_match, spotify_match) = tokio::join!(
+        try_apple_music_match(state, &candidate.name),
+        try_spotify_match(&state.spotify, &state.cc_manager, &candidate.name),
+    );
+
+    if let Some((apple_music_id, attrs)) = apple_match {
         let similar = fetch_similar_artists(state, &apple_music_id).await;
         let artwork_url = attrs
             .artwork
@@ -127,13 +139,15 @@ async fn resolve_fresh(state: &AppState, candidate: &ArtistCandidate, normalized
                 normalized_name: normalized,
                 display_name: &attrs.name,
                 apple_music_id: Some(&apple_music_id),
-                spotify_id: None,
+                spotify_id: spotify_match.as_ref().map(|a| a.id.as_str()),
                 ticketmaster_attraction_id: candidate.ticketmaster_attraction_id.as_deref(),
                 matched_via: "apple_music",
                 artwork_url: artwork_url.as_deref(),
                 artwork_bg_color: artwork_bg_color.as_deref(),
                 apple_music_url: attrs.url.as_deref(),
-                spotify_url: None,
+                spotify_url: spotify_match
+                    .as_ref()
+                    .and_then(|a| a.external_urls.spotify.as_deref()),
                 genres: &attrs.genre_names,
                 similar_artists: &similar,
             },
@@ -146,7 +160,7 @@ async fn resolve_fresh(state: &AppState, candidate: &ArtistCandidate, normalized
         return;
     }
 
-    if let Some(artist) = try_spotify_match(state, &candidate.name).await {
+    if let Some(artist) = spotify_match {
         let artwork_url = artist.images.first().map(|i| i.url.as_str());
         let result = db::upsert_matched(
             &state.db.pool,
@@ -305,18 +319,24 @@ async fn try_apple_music_match(state: &AppState, name: &str) -> Option<(String, 
 }
 
 /// Verified Spotify catalog search, under the same name-match rule as
-/// `try_apple_music_match`. Only called when Apple Music had no verified
-/// match for this name.
-async fn try_spotify_match(state: &AppState, name: &str) -> Option<SpotifyArtist> {
-    let token = state.cc_manager.get_token().await.ok()?;
+/// `try_apple_music_match`. Always attempted alongside Apple Music (see
+/// `resolve_fresh`) rather than only as a fallback — takes `SpotifyClient`/
+/// `ClientCredentialsManager` directly rather than `&AppState` so it's
+/// reusable outside a live request (see `spotify_backfill`, which has no
+/// need for the rest of `AppState`'s fields).
+pub(super) async fn try_spotify_match(
+    spotify: &SpotifyClient,
+    cc_manager: &ClientCredentialsManager,
+    name: &str,
+) -> Option<SpotifyArtist> {
+    let token = cc_manager.get_token().await.ok()?;
 
     for variant in name_variants(name) {
         let normalized = normalize_artist_name(&variant);
         if normalized.is_empty() {
             continue;
         }
-        let Ok(candidates) = state
-            .spotify
+        let Ok(candidates) = spotify
             .search_artist(&token.access_token, &variant, MAX_SEARCH_CANDIDATES)
             .await
         else {


### PR DESCRIPTION
## Summary
- `worker.rs`'s `resolve_fresh()` only looked up Spotify as a fallback when Apple Music found no match, so an artist matched via Apple Music (96.5% of the corpus: 1,522/1,577 real rows, confirmed via `psql`) never got a Spotify identity looked up at all -- `spotify_id`/`spotify_url` stayed `NULL` forever, since nothing ever revisits an already-matched row's identity.
- Both providers are now always attempted, concurrently via `tokio::join!` -- Apple Music still wins identity/display fields (display_name, artwork, genres, similar_artists) when it has a match; a Spotify match found alongside it only ever contributes `spotify_id`/`spotify_url` on top.
- `try_spotify_match`'s signature is narrowed from `&AppState` to just `&SpotifyClient` + `&ClientCredentialsManager` -- lets a one-off backfill tool (`spotify_backfill.rs`, following `matching_eval.rs`'s `#[cfg(test)]`/`#[ignore]` convention) reuse it directly without faking the other ~11 unrelated fields of `AppState`.
- New narrow `db::attach_spotify` update (mirrors `refresh_dynamic`'s shape) attaches a Spotify identity to an already-matched row without touching Apple identity/artwork/genres, guarded by `where spotify_id is null` so it can never clobber a value another path already wrote.
- Ran the backfill against the live DB: **1,469/1,522** existing Apple-matched artists now have a Spotify identity attached, **zero errors**, rather than waiting on the natural 30-day dynamic-field refresh cycle. The 53 not-found are plausible genuine misses (short/generic names, DJ handles) under the existing exact-match discipline.
- No frontend changes needed -- PR #81 already renders `spotify_url` alongside `apple_music_url` whenever it's present.

## Test plan
- [x] `cargo check --tests` / `cargo fmt` / `cargo test --lib` (107 passed) / `cargo clippy --bins --tests -- -D clippy::all` -- no new warnings
- [x] `cargo sqlx prepare -- --all-targets`, confirmed only the 2 new queries added, zero deletions
- [x] Backfill dry run (`BACKFILL_LIMIT=25`): 25/25 found, DB count confirmed to match
- [x] Full backfill run: 1,444/1,497 found, 0 errors; combined with the dry run, DB count went from 0 -> 1,469 matching Apple-matched rows with a non-null `spotify_url`, exactly matching the reported totals
- [x] Verified the `resolve_fresh` code path independently of the backfill: triggered a fresh search (Denver, CO) and confirmed via `psql` that every newly-matched artist has both `apple_music_id`/`apple_music_url` and `spotify_id`/`spotify_url` populated in the same insert
- [x] Verified via the live app's own `/api/concerts/stream` fetch that real artists (Portugal. The Man, Train, Nicky Romero, Elephante) now carry both `apple_music_url` and `spotify_url` in the exact response the frontend consumes -- the rendering component itself is unchanged from PR #81's already-verified visual check
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)