### PR TITLE
Fix three mobile-friendliness gaps

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>vite-monorepo</title>
   </head>
   <body>

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -8,7 +8,7 @@ import {
   DrawerClose,
 } from "@workspace/ui/components/ui/Drawer"
 import { useEventsContext } from "../providers/eventsProvider"
-import { useMediaQuery } from "usehooks-ts"
+import { useIsMobile } from "../providers/Breakpoint"
 import { useEffect, useCallback, useRef, useState, lazy, Suspense } from "react"
 import { VenueDetails } from "../VenueDetails"
 import { EventsDrawer, EventsDrawerHeader } from "./EventsDrawer"
@@ -144,10 +144,7 @@ const DrawerWrapper = () => {
     }
   }, [isStreaming, handleDestinationTab])
 
-  const isDesktop = useMediaQuery("(min-width: 768px)", {
-    defaultValue: false,
-    initializeWithValue: false,
-  })
+  const isDesktop = !useIsMobile()
 
   const entries = Object.entries(eventsByDate).sort()
   // A single group means selectedEvents is either one event, or several

--- a/apps/web/src/Search.tsx
+++ b/apps/web/src/Search.tsx
@@ -127,23 +127,34 @@ const Search = () => {
   return (
     <div className="relative w-full p-4 sm:max-w-lg">
       <div className="relative flex h-fit max-h-[80px] w-full items-center overflow-hidden rounded-xl border-1 border-gray-300 bg-white">
-        <TextField
-          id="search"
-          ref={inputRef}
-          type="text"
-          autoComplete="off"
-          aria-label="Search for a city"
-          aria-autocomplete="list"
-          aria-controls={listboxId}
-          name="search"
-          value={selectedLocation ? selectedLocation.fullAddress : searchTerm}
-          placeholder="Search for a city"
-          className="block w-full grow border-r-1 border-gray-300 p-0 text-base text-gray-900 outline-none placeholder:text-gray-400 focus:outline-none [&>input]:border-none"
-          onChange={(e) => updateSearchTerm(e)}
-          onKeyDown={handleKeyDown}
-          onFocus={() => places.length > 1 && setIsSuggestionsOpen(true)}
-          onBlur={() => setIsSuggestionsOpen(false)}
-        />
+        {/* TextField doesn't forward arbitrary input attributes like
+            `title` down to the underlying <input> -- wrapping it in a
+            `contents` span (removed from the box model entirely, so it
+            can't affect the flex layout) is the least invasive way to
+            make the full, possibly-truncated value discoverable on
+            hover/long-press without touching the shared component. */}
+        <span
+          title={selectedLocation ? selectedLocation.fullAddress : searchTerm}
+          className="contents"
+        >
+          <TextField
+            id="search"
+            ref={inputRef}
+            type="text"
+            autoComplete="off"
+            aria-label="Search for a city"
+            aria-autocomplete="list"
+            aria-controls={listboxId}
+            name="search"
+            value={selectedLocation ? selectedLocation.fullAddress : searchTerm}
+            placeholder="Search for a city"
+            className="block w-full grow border-r-1 border-gray-300 p-0 text-base text-gray-900 outline-none placeholder:text-gray-400 focus:outline-none [&>input]:border-none"
+            onChange={(e) => updateSearchTerm(e)}
+            onKeyDown={handleKeyDown}
+            onFocus={() => places.length > 1 && setIsSuggestionsOpen(true)}
+            onBlur={() => setIsSuggestionsOpen(false)}
+          />
+        </span>
         <DateRangePicker
           aria-label="Select timeframe"
           value={dateRange}


### PR DESCRIPTION
## Summary
Scoped out of a grilling session on mobile-friendliness -- three concrete gaps found and fixed, not a full audit (the app already has real mobile investment: a breakpoint system, a prior UI audit that fixed touch targets/contrast/reduced-motion, drawer-specific mobile fixes).

- **Breakpoint duplication**: `DrawerWrapper.tsx` had its own standalone `useMediaQuery("(min-width: 768px)")` instead of the shared `useIsMobile()` hook (`providers/Breakpoint.tsx`). Both already resolved to the same 768px threshold -- not a live bug, but duplicated logic that could silently drift apart later. Consolidated onto the shared hook.
- **Dead safe-area padding**: the bottom-sheet drawer (`packages/ui/src/components/ui/Drawer.tsx`) already had `env(safe-area-inset-bottom)` padding wired up, but it was dead code -- that `env()` value only resolves to anything on iOS Safari when `viewport-fit=cover` is set on the viewport meta tag, which it wasn't. Added it.
- **Undiscoverable truncated location**: the location search input just clips long labels with no way to see the full value. `TextField` doesn't forward arbitrary attributes like `title` down to its underlying `<input>`, so wrapped it in a `contents` span carrying the `title` instead -- removed from the box model entirely, so it can't affect the flex layout of the search bar.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` (no new warnings) / `pnpm test` (112 passed) / `pnpm build`
- [x] Verified live at 375px width: mobile layout renders identically to before the breakpoint consolidation (bottom tab bar, bottom-sheet drawer)
- [x] Verified live at desktop width: desktop layout also renders identically (side drawer, vertical tab icons) -- the `isDesktop = !useIsMobile()` refactor is a no-op change in observable behavior at both breakpoints
- [x] Confirmed via DOM inspection: viewport meta tag now carries `viewport-fit=cover`; the wrapping `<span>`'s `title` attribute matches the full `selectedLocation.fullAddress` value exactly
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)