### PR TITLE
Redesign the concert-stream orchestration into a seamed, testable module

### DIFF
--- a/apps/api/src/events/merge.rs
+++ b/apps/api/src/events/merge.rs
@@ -1,0 +1,471 @@
+//! The actual redesign: merges two `EventSource`s into one chronologically
+//! ordered stream, instead of the old "stream Ticketmaster fully, then dump
+//! PredictHQ at the end" shape. Fixes a real bug that shape caused: a
+//! PredictHQ-only event's calendar day could land after Ticketmaster events
+//! weeks later were already rendered in the (sorted, list-view) events
+//! drawer, jolting it.
+//!
+//! Ticketmaster's per-window sequential stream keeps driving emission
+//! exactly as before — fast time-to-first-event is preserved. Before each
+//! window emits, this opportunistically checks whether PredictHQ's single
+//! background fetch has resolved (see `predicthq::source::PredictHqSource`)
+//! and, if so, reconciles + merges it in immediately; if not, the window
+//! emits Ticketmaster-only and the day is queued for a later catch-up pass.
+//! Fully monotonic for every window processed after PredictHQ resolves;
+//! only windows already emitted before that point could still rarely see a
+//! late insert — a much narrower version of the original problem, not a
+//! new one.
+
+use futures::Stream;
+
+use super::reconcile::reconcile_predicthq_events;
+use super::source::{EventSource, Window};
+use super::types::EventResponse;
+use crate::error::AppError;
+
+/// One unit of output from `merge_events` — not yet serialized, not yet
+/// enriched/personalized/artwork-backfilled. `events::stream` (the IO
+/// layer) turns each of these into ndjson lines with the appropriate side
+/// effects; this type and `merge_events` itself have none.
+pub(crate) enum MergeStep {
+    /// This window's Ticketmaster wave.
+    Ticketmaster(Vec<EventResponse>),
+    /// PredictHQ enrichments for one calendar day (clones of already-
+    /// emitted Ticketmaster events with rank/predicted_attendance set).
+    PredictHqEnrichments(Vec<EventResponse>),
+    /// New PredictHQ-only events for one calendar day, pre-artwork-backfill.
+    PredictHqNew(Vec<EventResponse>),
+}
+
+/// Merges `tm` and `phq` across `windows` in chronological order. See the
+/// module docs for the ordering guarantee and its one accepted exception.
+pub(crate) fn merge_events<TS, PS>(
+    windows: Vec<Window>,
+    mut tm: TS,
+    mut phq: PS,
+) -> impl Stream<Item = Result<MergeStep, AppError>>
+where
+    TS: EventSource,
+    PS: EventSource,
+{
+    async_stream::try_stream! {
+        // Ticketmaster windows whose PredictHQ reconciliation is still
+        // outstanding, oldest first. Only ever non-empty while PredictHQ
+        // hasn't resolved yet -- once it has, every window drains the
+        // same pass it's pushed in (see below), so this never grows
+        // unbounded in the common case.
+        let mut pending: Vec<(Window, Vec<EventResponse>)> = Vec::new();
+
+        for window in &windows {
+            let tm_events = tm.events_for_window(window, false).await?.unwrap_or_default();
+            yield MergeStep::Ticketmaster(tm_events.clone());
+            pending.push((window.clone(), tm_events));
+
+            // Opportunistic: drain as much of the backlog as PredictHQ is
+            // ready for right now, oldest day first, stopping at the
+            // first day it isn't ready for yet. If PredictHQ just became
+            // ready, this clears the *entire* backlog in one pass before
+            // the next window's Ticketmaster fetch even starts.
+            let mut drained = 0;
+            for (day_window, day_tm_events) in &pending {
+                let Some(phq_events) = phq.events_for_window(day_window, false).await? else {
+                    break;
+                };
+                let (enrichments, new_events) =
+                    reconcile_predicthq_events(day_tm_events, phq_events);
+                if !enrichments.is_empty() {
+                    yield MergeStep::PredictHqEnrichments(enrichments);
+                }
+                if !new_events.is_empty() {
+                    yield MergeStep::PredictHqNew(new_events);
+                }
+                drained += 1;
+            }
+            pending.drain(0..drained);
+        }
+
+        // Flush: force PredictHQ to resolve for any day still pending --
+        // mirrors the old design's unconditional await after all
+        // Ticketmaster windows finished, regardless of whether the
+        // opportunistic checks above ever caught it ready.
+        for (day_window, day_tm_events) in &pending {
+            let phq_events = phq.events_for_window(day_window, true).await?.unwrap_or_default();
+            let (enrichments, new_events) = reconcile_predicthq_events(day_tm_events, phq_events);
+            if !enrichments.is_empty() {
+                yield MergeStep::PredictHqEnrichments(enrichments);
+            }
+            if !new_events.is_empty() {
+                yield MergeStep::PredictHqNew(new_events);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::events::types::{Performer, Source, VenueResponse};
+
+    fn window(day: &str) -> Window {
+        Window {
+            start: format!("{day}T00:00:00Z"),
+            end: format!("{day}T23:59:59Z"),
+            calendar_day: day.to_string(),
+        }
+    }
+
+    fn tm_event(id: &str, venue: &str, day: &str) -> EventResponse {
+        EventResponse {
+            id: id.to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some(venue.to_string()),
+                location: None,
+                city: None,
+                state: None,
+                state_code: None,
+                address: None,
+                postal_code: None,
+                url: None,
+                images: vec![],
+            }),
+            images: vec![],
+            dates: Some(format!("{day}T23:00:00Z")),
+            dates_pretty: None,
+            local_calendar_day: Some(day.to_string()),
+            classifications: None,
+            performers: None,
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+            source: Source::Ticketmaster,
+            rank: None,
+            predicted_attendance: None,
+        }
+    }
+
+    fn phq_event(id: &str, venue: &str, local_day: &str) -> EventResponse {
+        let mut e = tm_event(id, venue, local_day);
+        e.source = Source::PredictHq;
+        e.rank = Some(50);
+        e.predicted_attendance = Some(100);
+        e
+    }
+
+    fn with_performer(mut e: EventResponse, name: &str) -> EventResponse {
+        e.performers = Some(vec![Performer {
+            name: Some(name.to_string()),
+            id: None,
+            classifications: None,
+            external_links: None,
+            images: None,
+            enrichment: None,
+        }]);
+        e
+    }
+
+    /// Always synchronously ready -- serves whatever's registered for a
+    /// window's calendar day, same shape as the real `TicketmasterSource`
+    /// from the caller's point of view.
+    struct FakeTicketmasterSource {
+        by_day: HashMap<String, Vec<EventResponse>>,
+    }
+
+    impl EventSource for FakeTicketmasterSource {
+        async fn events_for_window(
+            &mut self,
+            window: &Window,
+            _must_wait: bool,
+        ) -> Result<Option<Vec<EventResponse>>, AppError> {
+            Ok(Some(
+                self.by_day
+                    .get(&window.calendar_day)
+                    .cloned()
+                    .unwrap_or_default(),
+            ))
+        }
+    }
+
+    /// Controllable readiness: not ready until the `ready_after_calls`th
+    /// invocation (or `must_wait`), then permanently ready -- mirrors the
+    /// real `PredictHqSource`'s "one background fetch, resolves once"
+    /// shape, but with a caller-controlled trigger instead of a real
+    /// `JoinHandle`.
+    struct FakePredictHqSource {
+        by_day: HashMap<String, Vec<EventResponse>>,
+        ready_after_calls: usize,
+        calls: usize,
+        ready: bool,
+    }
+
+    impl FakePredictHqSource {
+        fn always_ready(by_day: HashMap<String, Vec<EventResponse>>) -> Self {
+            Self {
+                by_day,
+                ready_after_calls: 0,
+                calls: 0,
+                ready: false,
+            }
+        }
+
+        fn ready_after(by_day: HashMap<String, Vec<EventResponse>>, calls: usize) -> Self {
+            Self {
+                by_day,
+                ready_after_calls: calls,
+                calls: 0,
+                ready: false,
+            }
+        }
+
+        fn never_ready(by_day: HashMap<String, Vec<EventResponse>>) -> Self {
+            Self {
+                by_day,
+                ready_after_calls: usize::MAX,
+                calls: 0,
+                ready: false,
+            }
+        }
+    }
+
+    impl EventSource for FakePredictHqSource {
+        async fn events_for_window(
+            &mut self,
+            window: &Window,
+            must_wait: bool,
+        ) -> Result<Option<Vec<EventResponse>>, AppError> {
+            self.calls += 1;
+            if !self.ready {
+                if must_wait || self.calls >= self.ready_after_calls {
+                    self.ready = true;
+                } else {
+                    return Ok(None);
+                }
+            }
+            Ok(Some(
+                self.by_day
+                    .get(&window.calendar_day)
+                    .cloned()
+                    .unwrap_or_default(),
+            ))
+        }
+    }
+
+    async fn run(
+        windows: Vec<Window>,
+        tm: FakeTicketmasterSource,
+        phq: FakePredictHqSource,
+    ) -> Vec<MergeStep> {
+        let stream = merge_events(windows, tm, phq);
+        futures::pin_mut!(stream);
+        let mut out = Vec::new();
+        while let Some(step) = stream.next().await {
+            out.push(step.expect("fakes never error"));
+        }
+        out
+    }
+
+    fn label(step: &MergeStep) -> &'static str {
+        match step {
+            MergeStep::Ticketmaster(_) => "tm",
+            MergeStep::PredictHqEnrichments(_) => "phq_enrich",
+            MergeStep::PredictHqNew(_) => "phq_new",
+        }
+    }
+
+    #[tokio::test]
+    async fn phq_ready_before_first_window_fully_interleaves() {
+        let windows = vec![window("2026-08-01"), window("2026-08-02")];
+        let tm = FakeTicketmasterSource {
+            by_day: HashMap::from([
+                (
+                    "2026-08-01".to_string(),
+                    vec![tm_event("tm-1", "Venue A", "2026-08-01")],
+                ),
+                (
+                    "2026-08-02".to_string(),
+                    vec![tm_event("tm-2", "Venue B", "2026-08-02")],
+                ),
+            ]),
+        };
+        // Unmatched (different venue than any TM event that day) so each
+        // day produces a PredictHqNew step, keeping the assertion simple.
+        let phq = FakePredictHqSource::always_ready(HashMap::from([
+            (
+                "2026-08-01".to_string(),
+                vec![phq_event("phq-1", "Other Venue", "2026-08-01")],
+            ),
+            (
+                "2026-08-02".to_string(),
+                vec![phq_event("phq-2", "Other Venue", "2026-08-02")],
+            ),
+        ]));
+
+        let steps = run(windows, tm, phq).await;
+        let labels: Vec<_> = steps.iter().map(label).collect();
+
+        assert_eq!(labels, ["tm", "phq_new", "tm", "phq_new"]);
+    }
+
+    #[tokio::test]
+    async fn phq_ready_mid_stream_triggers_catch_up_burst() {
+        let windows: Vec<Window> = (1..=4).map(|d| window(&format!("2026-08-0{d}"))).collect();
+        let tm = FakeTicketmasterSource {
+            by_day: (1..=4)
+                .map(|d| {
+                    let day = format!("2026-08-0{d}");
+                    (
+                        day.clone(),
+                        vec![tm_event(&format!("tm-{d}"), "Venue A", &day)],
+                    )
+                })
+                .collect(),
+        };
+        let phq_by_day: HashMap<String, Vec<EventResponse>> = (1..=4)
+            .map(|d| {
+                let day = format!("2026-08-0{d}");
+                (
+                    day.clone(),
+                    vec![phq_event(&format!("phq-{d}"), "Other Venue", &day)],
+                )
+            })
+            .collect();
+        // Call trace (see merge_events): window 1 and window 2's drain
+        // loops each make exactly one (unready) PredictHQ call for the
+        // oldest pending day -- calls #1 and #2. Window 3's drain loop
+        // makes call #3 (still asking about the oldest pending day, "08-01"),
+        // which is where readiness triggers -- so the whole backlog
+        // (days 1, 2, 3) drains in that same pass, before window 4 runs.
+        let phq = FakePredictHqSource::ready_after(phq_by_day, 3);
+
+        let steps = run(windows, tm, phq).await;
+        let labels: Vec<_> = steps.iter().map(label).collect();
+
+        assert_eq!(
+            labels,
+            [
+                "tm", "tm", "tm", "phq_new", "phq_new", "phq_new", "tm", "phq_new"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn phq_never_ready_degrades_to_ticketmaster_only() {
+        let windows = vec![window("2026-08-01"), window("2026-08-02")];
+        let tm = FakeTicketmasterSource {
+            by_day: HashMap::from([
+                (
+                    "2026-08-01".to_string(),
+                    vec![tm_event("tm-1", "Venue A", "2026-08-01")],
+                ),
+                (
+                    "2026-08-02".to_string(),
+                    vec![tm_event("tm-2", "Venue B", "2026-08-02")],
+                ),
+            ]),
+        };
+        // never_ready still answers Some(empty) once forced via must_wait
+        // during the final flush -- matching PredictHqSource::spawn(None)'s
+        // real behavior (an already-resolved, empty cache) exactly.
+        let phq = FakePredictHqSource::never_ready(HashMap::new());
+
+        let steps = run(windows, tm, phq).await;
+        let labels: Vec<_> = steps.iter().map(label).collect();
+
+        assert_eq!(labels, ["tm", "tm"]);
+    }
+
+    #[tokio::test]
+    async fn predicthq_only_event_never_precedes_its_own_windows_ticketmaster_wave() {
+        // The regression test for the bug this redesign fixes. Day 1 has
+        // a PredictHQ-only event (no matching Ticketmaster event that
+        // day at all), but PredictHQ doesn't become ready until window 2
+        // is being processed.
+        let windows = vec![window("2026-08-01"), window("2026-08-02")];
+        let tm = FakeTicketmasterSource {
+            by_day: HashMap::from([(
+                "2026-08-01".to_string(),
+                vec![tm_event("tm-1", "Venue A", "2026-08-01")],
+            )]),
+        };
+        let phq = FakePredictHqSource::ready_after(
+            HashMap::from([(
+                "2026-08-01".to_string(),
+                vec![phq_event("phq-1", "Other Venue", "2026-08-01")],
+            )]),
+            2,
+        );
+
+        let steps = run(windows, tm, phq).await;
+
+        let tm_day1_index = steps
+            .iter()
+            .position(|s| matches!(s, MergeStep::Ticketmaster(_)));
+        let phq_new_index = steps
+            .iter()
+            .position(|s| matches!(s, MergeStep::PredictHqNew(_)));
+
+        assert!(tm_day1_index.is_some());
+        assert!(phq_new_index.is_some());
+        assert!(
+            tm_day1_index < phq_new_index,
+            "day 1's PredictHQ-only event must never be yielded before day 1's Ticketmaster wave, got order {:?}",
+            steps.iter().map(label).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn utc_window_bucketing_matches_venue_local_reconcile_day() {
+        // The real evening-show-crossing-midnight case this protects: both
+        // sources' true UTC instant for this show falls on "2026-10-24"
+        // (an 8pm local show, venue in a timezone behind UTC), so a real
+        // Ticketmaster query for that UTC window is what returns this
+        // event server-side, and a real PredictHqSource's own UTC-day
+        // bucketing of its `dates` field independently lands it in the
+        // same window -- even though both sources agree the show's
+        // venue-local calendar day is "2026-10-23" (what
+        // reconcile_predicthq_events actually matches on). This test
+        // places both fake events under the window a real UTC-day
+        // resolution would produce (crucially, NOT the window matching
+        // local_calendar_day), and confirms merge_events still routes
+        // them into the same reconcile call, which then matches on their
+        // agreeing local_calendar_day despite the window/local-day split.
+        let windows = vec![window("2026-10-23"), window("2026-10-24")];
+
+        let mut tm_event = tm_event("tm-1", "State Theatre", "2026-10-24");
+        tm_event.local_calendar_day = Some("2026-10-23".to_string());
+        tm_event = with_performer(tm_event, "Guster");
+
+        let mut phq_event = phq_event("phq-1", "State Theatre", "2026-10-24");
+        phq_event.local_calendar_day = Some("2026-10-23".to_string());
+        phq_event = with_performer(phq_event, "Guster");
+
+        let tm = FakeTicketmasterSource {
+            by_day: HashMap::from([("2026-10-24".to_string(), vec![tm_event])]),
+        };
+        let phq = FakePredictHqSource::always_ready(HashMap::from([(
+            "2026-10-24".to_string(),
+            vec![phq_event],
+        )]));
+
+        let steps = run(windows, tm, phq).await;
+        let enrichment_count = steps
+            .iter()
+            .filter(|s| matches!(s, MergeStep::PredictHqEnrichments(_)))
+            .count();
+        let new_count = steps
+            .iter()
+            .filter(|s| matches!(s, MergeStep::PredictHqNew(_)))
+            .count();
+
+        assert_eq!(
+            enrichment_count, 1,
+            "expected the PredictHQ event to enrich its Ticketmaster match"
+        );
+        assert_eq!(new_count, 0, "expected no unmatched PredictHQ-only event");
+    }
+}

--- a/apps/api/src/events/mod.rs
+++ b/apps/api/src/events/mod.rs
@@ -1,13 +1,21 @@
 //! The normalized `Event` shape and the source-agnostic logic that operates
-//! on it — personalized-discovery matching and event deduplication. Neither
-//! needs any Ticketmaster-specific knowledge; the one function that does
-//! (`TmEvent -> EventResponse` mapping) stays in `ticketmaster_stream`.
+//! on it: personalized-discovery matching, event deduplication, and
+//! cross-provider stream orchestration (`merge`/`source`/`stream`) —
+//! merging Ticketmaster and PredictHQ into one chronologically ordered
+//! feed. `ticketmaster_stream`/`predicthq` stay source-specific: raw wire
+//! shapes, HTTP fetching, and (for Ticketmaster) the one place that still
+//! needs to know Ticketmaster's raw shape (`TmEvent -> EventResponse`
+//! mapping). Each satisfies the `EventSource` interface this module
+//! defines (`source::EventSource`) via its own `source` submodule.
 
 pub mod types;
 
+mod merge;
 mod reconcile;
+pub(crate) mod source;
+mod stream;
 
-pub(crate) use reconcile::reconcile_predicthq_events;
+pub(crate) use stream::get_concerts_tm_stream;
 
 use std::collections::HashMap;
 

--- a/apps/api/src/events/source.rs
+++ b/apps/api/src/events/source.rs
@@ -1,0 +1,45 @@
+//! The seam between the concert-stream merge/ordering logic (`super::merge`)
+//! and where events actually come from. Ticketmaster and PredictHQ are
+//! already two adapters for the same conceptual role — fetch concert events
+//! for a date range — so this formalizes that as a real interface rather
+//! than two bespoke shapes the orchestration has to know about directly.
+//! Lets `merge_events` be unit-tested against fake sources with
+//! controllable readiness, instead of needing live HTTP.
+
+use crate::error::AppError;
+use crate::events::types::EventResponse;
+
+/// One calendar-day query window. `calendar_day` is the UTC day of
+/// `start` — the key used to partition PredictHQ's single whole-range
+/// fetch into per-window slices (see `predicthq::source` module docs for
+/// why this must be the UTC day, not the venue-local day
+/// `EventResponse.local_calendar_day` carries).
+#[derive(Clone)]
+pub(crate) struct Window {
+    /// rfc3339, passed straight to Ticketmaster's own windowed fetch.
+    pub start: String,
+    /// rfc3339.
+    pub end: String,
+    /// `"YYYY-MM-DD"`, UTC day of `start`.
+    pub calendar_day: String,
+}
+
+/// A source of concert events for one calendar-day window at a time.
+/// Implemented by `ticketmaster_stream::source::TicketmasterSource`
+/// (always ready — does its own HTTP pagination synchronously per call)
+/// and `predicthq::source::PredictHqSource` (backed by one whole-range
+/// background fetch; not ready until that resolves, after which every
+/// window is served from an in-memory day-bucketed cache).
+pub(crate) trait EventSource {
+    /// `Ok(None)` means "not ready yet, ask again on a later window" —
+    /// only `PredictHqSource` ever returns it. When `must_wait` is
+    /// `true`, the source must block until it can answer definitively
+    /// rather than ever return `None` — used exactly once, after every
+    /// window has already been requested opportunistically, to flush any
+    /// day the source wasn't ready for during the main pass.
+    async fn events_for_window(
+        &mut self,
+        window: &Window,
+        must_wait: bool,
+    ) -> Result<Option<Vec<EventResponse>>, AppError>;
+}

--- a/apps/api/src/events/stream.rs
+++ b/apps/api/src/events/stream.rs
@@ -1,0 +1,235 @@
+//! `GET /concerts/stream` — the map's incremental ndjson feed. Drives
+//! `merge_events` (see `super::merge`) and applies the IO-bound steps
+//! (canonical-artist DB enrichment, personalization, Apple Music artwork
+//! backfill) that were always request-scoped, never part of the pure
+//! merge/ordering logic itself.
+
+use std::collections::HashMap;
+
+use axum::{
+    body::Body,
+    extract::{Query, State},
+    http::{StatusCode, header},
+    response::Response,
+};
+use axum_extra::extract::cookie::SignedCookieJar;
+use bytes::Bytes;
+use futures::StreamExt;
+use geohash::{Coord, encode};
+
+use super::merge::{MergeStep, merge_events};
+use super::source::Window;
+use super::types::EventResponse;
+use super::{apply_personalization, is_music_classified};
+use crate::artists::ArtistCandidate;
+use crate::error::AppError;
+use crate::predicthq::source::PredictHqSource;
+use crate::spotify::spotify_handlers::resolve_account_from_cookie_lenient;
+use crate::state::AppState;
+use crate::ticketmaster_stream::source::TicketmasterSource;
+use crate::ticketmaster_stream::{EventsQuery, date_windows};
+
+pub async fn get_concerts_tm_stream(
+    State(state): State<AppState>,
+    jar: SignedCookieJar,
+    Query(params): Query<EventsQuery>,
+) -> Result<Response, AppError> {
+    // Personalized discovery is best-effort: no session, no Spotify
+    // connection, or a failed fetch should silently disable it rather than
+    // break event browsing for everyone.
+    let personalization_matches = match resolve_account_from_cookie_lenient(&state, &jar).await {
+        Some(account_id) => {
+            crate::spotify::top_artists::get_personalization_matches(&state, account_id)
+                .await
+                .unwrap_or_else(|err| {
+                    tracing::warn!(
+                        error = %err,
+                        "failed to fetch personalized discovery matches, skipping"
+                    );
+                    HashMap::new()
+                })
+        }
+        None => HashMap::new(),
+    };
+
+    let geo_hash = encode(
+        Coord {
+            x: params.longitude,
+            y: params.latitude,
+        },
+        6,
+    )
+    .map_err(|e| AppError::TicketmasterApi {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: format!("failed to encode geohash: {e}"),
+    })?;
+
+    let raw_windows =
+        date_windows(&params.start, &params.end).map_err(|e| AppError::TicketmasterApi {
+            status: StatusCode::BAD_REQUEST,
+            message: e,
+        })?;
+    let windows: Vec<Window> = raw_windows
+        .into_iter()
+        .map(|(start, end)| {
+            let calendar_day = chrono::DateTime::parse_from_rfc3339(&start)
+                .map(|dt| dt.format("%Y-%m-%d").to_string())
+                .unwrap_or_default();
+            Window {
+                start,
+                end,
+                calendar_day,
+            }
+        })
+        .collect();
+
+    let tm_source = TicketmasterSource::new(
+        state.client.clone(),
+        state.ticketmaster_key.clone(),
+        geo_hash,
+        params.radius,
+    );
+
+    // Kicked off now so it runs concurrently with Ticketmaster's windowed
+    // fetch below rather than adding its own round-trip afterward.
+    let within = format!(
+        "{}mi@{},{}",
+        params.radius, params.latitude, params.longitude
+    );
+    let phq_source = PredictHqSource::spawn(
+        state.client.clone(),
+        state.predicthq_api_key.clone(),
+        within,
+        params.start.clone(),
+        params.end.clone(),
+    );
+
+    let stream: futures::stream::BoxStream<'static, Result<Bytes, AppError>> = async_stream::try_stream! {
+        let mut artist_candidates: Vec<ArtistCandidate> = Vec::new();
+        let merged = merge_events(windows, tm_source, phq_source);
+        futures::pin_mut!(merged);
+
+        while let Some(step) = merged.next().await {
+            match step? {
+                MergeStep::Ticketmaster(mut events) => {
+                    // Plain indexed reads, not a call to Apple Music/Spotify --
+                    // safe to run inline rather than detached like
+                    // `spawn_enrichment` below (see `crate::artists::lookup`).
+                    crate::artists::attach_enrichment(&mut events, &state.db.pool).await;
+                    artist_candidates.extend(candidates_from(&events));
+
+                    for mut event in events {
+                        apply_personalization(&mut event, &personalization_matches);
+                        yield to_ndjson_line(&event)?;
+                    }
+                }
+                MergeStep::PredictHqEnrichments(events) => {
+                    // Already-enriched clones of already-personalized
+                    // Ticketmaster events under their original id -- no
+                    // reprocessing, just re-emit as a second-wave update.
+                    for event in events {
+                        yield to_ndjson_line(&event)?;
+                    }
+                }
+                MergeStep::PredictHqNew(mut events) => {
+                    // Best-effort image/link backfill for the PredictHQ-only
+                    // cards (a matched event is already a Ticketmaster clone
+                    // with its own real photo/ticket URL, so it's excluded
+                    // from this via MergeStep::PredictHqEnrichments above).
+                    // Scoped to this window's events -- a real per-window
+                    // batch, not one global batch over the whole request,
+                    // so it can't dilute the ordering fix. Absent entirely
+                    // when Apple Music isn't configured or its developer
+                    // token can't be fetched right now -- same
+                    // never-block-the-feed posture as the PredictHQ fetch
+                    // itself.
+                    if let (Some(am), Some(dev_token_mgr)) =
+                        (&state.apple_music_client, &state.apple_dev_token)
+                    {
+                        match dev_token_mgr.get_token().await {
+                            Ok(token) => {
+                                crate::predicthq::backfill_artwork(
+                                    &mut events,
+                                    am,
+                                    &token,
+                                    &state.apple_artwork_cache,
+                                )
+                                .await;
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    error = %err,
+                                    "failed to fetch Apple Music developer token, skipping PredictHQ image/link backfill"
+                                );
+                            }
+                        }
+                    }
+
+                    // PredictHQ performer ids are PredictHQ entity ids, not
+                    // Ticketmaster attraction ids -- a different namespace,
+                    // so `ticketmaster_attraction_id` is always `None` here
+                    // (see `crate::predicthq::normalize`).
+                    // `performer_search_names` falls back to the event's
+                    // own title for the ~28% of PredictHQ events with no
+                    // structured performer entity at all, same as the
+                    // image backfill above.
+                    artist_candidates.extend(
+                        events
+                            .iter()
+                            .filter(|event| is_music_classified(event))
+                            .flat_map(|event| {
+                                crate::predicthq::performer_search_names(event)
+                                    .into_iter()
+                                    .map(|name| ArtistCandidate {
+                                        name,
+                                        ticketmaster_attraction_id: None,
+                                    })
+                            }),
+                    );
+
+                    crate::artists::attach_enrichment(&mut events, &state.db.pool).await;
+
+                    for mut event in events {
+                        apply_personalization(&mut event, &personalization_matches);
+                        yield to_ndjson_line(&event)?;
+                    }
+                }
+            }
+        }
+
+        crate::artists::spawn_enrichment(&state, artist_candidates);
+    }
+    .boxed();
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/x-ndjson")
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(Body::from_stream(stream))
+        .unwrap())
+}
+
+/// Every performer name on a Music-classified event, ready to feed
+/// canonical-artist enrichment (see `crate::artists::spawn_enrichment`).
+fn candidates_from(events: &[EventResponse]) -> Vec<ArtistCandidate> {
+    events
+        .iter()
+        .filter(|event| is_music_classified(event))
+        .flat_map(|event| event.performers.iter().flatten())
+        .filter_map(|performer| {
+            performer.name.clone().map(|name| ArtistCandidate {
+                name,
+                ticketmaster_attraction_id: performer.id.clone(),
+            })
+        })
+        .collect()
+}
+
+fn to_ndjson_line(event: &EventResponse) -> Result<Bytes, AppError> {
+    let mut line = serde_json::to_vec(event).map_err(|e| AppError::TicketmasterApi {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        message: e.to_string(),
+    })?;
+    line.push(b'\n');
+    Ok(Bytes::from(line))
+}

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -148,7 +148,7 @@ pub async fn build_app() -> Result<Router> {
         )
         .route(
             "/concerts/stream",
-            axum::routing::get(ticketmaster_stream::get_concerts_tm_stream),
+            axum::routing::get(events::get_concerts_tm_stream),
         )
         .route(
             "/future-events",

--- a/apps/api/src/predicthq/client.rs
+++ b/apps/api/src/predicthq/client.rs
@@ -178,7 +178,7 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn normalizes_every_real_event_without_panicking() {
-        use crate::predicthq::normalize_predicthq_event;
+        use crate::predicthq::normalize::normalize_predicthq_event;
 
         let api_key = std::env::var("PREDICTHQ_API_KEY")
             .expect("PREDICTHQ_API_KEY must be set to run this test");

--- a/apps/api/src/predicthq/mod.rs
+++ b/apps/api/src/predicthq/mod.rs
@@ -2,16 +2,18 @@
 //! (`client`/`normalize`), plus a best-effort Apple Music image/link
 //! backfill (`artwork`) for events that pass through
 //! `crate::events::reconcile_predicthq_events` unmatched — PredictHQ's own
-//! API provides neither field. Cross-source dedup and the live-stream
-//! wiring live in `ticketmaster_stream` and `crate::events`.
+//! API provides neither field. `source` is this provider's
+//! `crate::events::source::EventSource` adapter — the seam
+//! `crate::events::merge` merges against. Cross-source dedup and the
+//! live-stream wiring itself live in `crate::events` now (`reconcile`,
+//! `merge`, `stream`), not here or in `ticketmaster_stream`.
 
 mod artwork;
 mod client;
 mod normalize;
+pub(crate) mod source;
 
 pub(crate) use artwork::backfill_artwork;
-pub(crate) use client::search_concerts;
-pub(crate) use normalize::normalize_predicthq_event;
 
 use crate::events::types::EventResponse;
 

--- a/apps/api/src/predicthq/source.rs
+++ b/apps/api/src/predicthq/source.rs
@@ -1,0 +1,136 @@
+//! `PredictHqSource`: this source's `EventSource` adapter. PredictHQ is
+//! fetched once for the whole date range (not per-window — no per-day query
+//! cost added by this redesign), so this adapter's job is presenting that
+//! single fetch through the same per-window interface Ticketmaster's
+//! adapter satisfies: kick the fetch off immediately, answer `None` until
+//! it resolves, then serve every subsequent window from an in-memory
+//! day-bucketed cache built once, on first successful resolution.
+//!
+//! Bucketed by the **UTC** calendar day of each event's `dates` field
+//! (always a clean UTC rfc3339 string for PredictHQ — see
+//! `predicthq::normalize`), matching the same axis `date_windows` already
+//! uses to bucket Ticketmaster's own per-window HTTP responses. This is
+//! deliberately *not* `EventResponse.local_calendar_day` (venue-local) —
+//! that field decides whether two events *match* inside
+//! `reconcile_predicthq_events`, not which window's reconcile call an
+//! event participates in. Bucketing by the local day instead would misfile
+//! an event relative to whichever window Ticketmaster's own UTC-windowed
+//! fetch placed its true match in, for exactly the evening-show-crossing-
+//! midnight case `events::reconcile`'s
+//! `matches_via_local_calendar_day_even_when_utc_dates_disagree` regression
+//! test exists to cover.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use tokio::task::JoinHandle;
+
+use super::client::{PredictHqEvent, search_concerts};
+use super::normalize::normalize_predicthq_event;
+use crate::error::AppError;
+use crate::events::source::{EventSource, Window};
+use crate::events::types::EventResponse;
+
+pub(crate) struct PredictHqSource {
+    pending: Option<JoinHandle<Result<Vec<PredictHqEvent>, AppError>>>,
+    /// `None` until the fetch resolves; `Some` (possibly with empty
+    /// per-day buckets) from then on.
+    cache: Option<HashMap<String, Vec<EventResponse>>>,
+}
+
+impl PredictHqSource {
+    /// Spawns the one whole-range fetch now — concurrent with
+    /// Ticketmaster's windowed fetch, matching the timing
+    /// `get_concerts_tm_stream` already used before this redesign. When
+    /// `api_key` is `None`, returns a source whose cache is already
+    /// resolved to empty, so `events_for_window` always answers
+    /// `Some(vec![])` immediately — collapses "PredictHQ not configured"
+    /// and "PredictHQ resolves late with nothing" into the same code
+    /// path, no special-casing needed in `events::merge`.
+    pub(crate) fn spawn(
+        client: reqwest::Client,
+        api_key: Option<String>,
+        within: String,
+        start_gte: String,
+        start_lte: String,
+    ) -> Self {
+        match api_key {
+            Some(api_key) => {
+                let handle = tokio::spawn(async move {
+                    search_concerts(&client, &api_key, &within, &start_gte, &start_lte).await
+                });
+                Self {
+                    pending: Some(handle),
+                    cache: None,
+                }
+            }
+            None => Self {
+                pending: None,
+                cache: Some(HashMap::new()),
+            },
+        }
+    }
+
+    /// Awaits the spawned fetch (only ever called once `pending` is
+    /// confirmed either finished or being force-awaited) and builds the
+    /// day-bucketed cache. A failed/absent fetch degrades to "no
+    /// PredictHQ data this request" rather than an error — this feature
+    /// is additive and must never take down event browsing.
+    async fn resolve(&mut self) {
+        let Some(handle) = self.pending.take() else {
+            return;
+        };
+
+        let raw = match handle.await {
+            Ok(Ok(events)) => events,
+            Ok(Err(err)) => {
+                tracing::warn!(error = %err, "failed to fetch PredictHQ events, skipping");
+                Vec::new()
+            }
+            Err(join_err) => {
+                tracing::warn!(error = %join_err, "PredictHQ fetch task failed, skipping");
+                Vec::new()
+            }
+        };
+
+        let mut cache: HashMap<String, Vec<EventResponse>> = HashMap::new();
+        for event in raw.into_iter().map(normalize_predicthq_event) {
+            let day = event
+                .dates
+                .as_deref()
+                .and_then(|d| DateTime::parse_from_rfc3339(d).ok())
+                .map(|dt| dt.with_timezone(&Utc).format("%Y-%m-%d").to_string())
+                .unwrap_or_default();
+            cache.entry(day).or_default().push(event);
+        }
+
+        self.cache = Some(cache);
+    }
+}
+
+impl EventSource for PredictHqSource {
+    async fn events_for_window(
+        &mut self,
+        window: &Window,
+        must_wait: bool,
+    ) -> Result<Option<Vec<EventResponse>>, AppError> {
+        if self.cache.is_none() {
+            let ready = self
+                .pending
+                .as_ref()
+                .is_some_and(|h| must_wait || h.is_finished());
+            if !ready {
+                return Ok(None);
+            }
+            self.resolve().await;
+        }
+
+        Ok(Some(
+            self.cache
+                .as_ref()
+                .and_then(|c| c.get(&window.calendar_day))
+                .cloned()
+                .unwrap_or_default(),
+        ))
+    }
+}

--- a/apps/api/src/ticketmaster_stream/dates.rs
+++ b/apps/api/src/ticketmaster_stream/dates.rs
@@ -4,7 +4,7 @@
 
 use chrono::{DateTime, Days, NaiveDate, TimeZone, Utc};
 
-pub(super) fn date_windows(start: &str, end: &str) -> Result<Vec<(String, String)>, String> {
+pub(crate) fn date_windows(start: &str, end: &str) -> Result<Vec<(String, String)>, String> {
     let start_dt = DateTime::parse_from_rfc3339(start)
         .map_err(|e| format!("invalid start datetime: {e}"))?
         .with_timezone(&Utc);

--- a/apps/api/src/ticketmaster_stream/mod.rs
+++ b/apps/api/src/ticketmaster_stream/mod.rs
@@ -10,315 +10,41 @@
 //!   one place in this module that still needs to know Ticketmaster's raw
 //!   shape; `apply_personalization`/`dedupe_key` live in `crate::events`
 //!   since they only ever touch the normalized shape
+//! - `source`: `TicketmasterSource`, this provider's `crate::events::source::EventSource`
+//!   adapter — the seam `crate::events::merge` merges against. The live
+//!   `/concerts/stream` handler itself lives in `crate::events::stream`
+//!   now, since it's genuinely cross-provider (also depends on
+//!   `crate::predicthq`), not Ticketmaster-specific.
 //!
-//! This file wires those pieces together into two HTTP handlers —
-//! `get_concerts_tm_stream` (incremental ndjson for the map, windowed and
-//! fully paginated) and `get_events_by_attraction` (a JSON array of one
-//! attraction's upcoming shows, fully paginated) — plus `fetch_events_near`,
-//! a non-streaming, non-windowed entry point used by
+//! This file wires those pieces together into `get_events_by_attraction` (a
+//! JSON array of one attraction's upcoming shows, fully paginated) plus
+//! `fetch_events_near`, a non-streaming, non-windowed entry point used by
 //! `services::playlist_builder` to find nearby artists without paying for
 //! the map's full windowed pagination on every playlist build/update
-//! (deliberately Ticketmaster-only — see `get_concerts_tm_stream` for why
-//! PredictHQ isn't part of this path).
-//!
-//! `get_concerts_tm_stream` also reconciles PredictHQ against Ticketmaster:
-//! Ticketmaster streams progressively exactly as it always has, and once
-//! both fetches complete, PredictHQ-sourced enrichment
-//! (`rank`/`predicted_attendance` on a matching Ticketmaster event) and
-//! genuinely new PredictHQ-only events are emitted as a second wave. See
-//! `crate::events::reconcile_predicthq_events` for the matching itself.
+//! (deliberately Ticketmaster-only, same reasoning as always — PredictHQ
+//! reconciliation is only worth it for the map's live browsing view).
 
 mod client;
 mod dates;
 mod normalize;
+pub(crate) mod source;
 mod types;
 
 pub use types::*;
 
+pub(crate) use dates::date_windows;
 pub(crate) use normalize::normalize_event;
 
 use crate::error::AppError;
+use crate::events::dedupe_key;
 use crate::events::types::EventResponse;
-use crate::events::{apply_personalization, dedupe_key, reconcile_predicthq_events};
-use crate::spotify::spotify_handlers::resolve_account_from_cookie_lenient;
 use crate::state::AppState;
 use axum::{
     Json,
-    body::Body,
     extract::{Query, State},
-    http::{StatusCode, header},
-    response::Response,
 };
-use axum_extra::extract::cookie::SignedCookieJar;
-use bytes::Bytes;
 use client::{fetch_tm_attraction_page, fetch_tm_page, should_fetch_next};
-use dates::date_windows;
-use futures::{StreamExt, stream::BoxStream};
-use geohash::{Coord, encode};
-use std::collections::{HashMap, HashSet};
-
-pub async fn get_concerts_tm_stream(
-    State(state): State<AppState>,
-    jar: SignedCookieJar,
-    Query(params): Query<EventsQuery>,
-) -> Result<Response, AppError> {
-    // Personalized discovery is best-effort: no session, no Spotify
-    // connection, or a failed fetch should silently disable it rather than
-    // break event browsing for everyone.
-    let personalization_matches = match resolve_account_from_cookie_lenient(&state, &jar).await {
-        Some(account_id) => {
-            crate::spotify::top_artists::get_personalization_matches(&state, account_id)
-                .await
-                .unwrap_or_else(|err| {
-                    tracing::warn!(
-                        error = %err,
-                        "failed to fetch personalized discovery matches, skipping"
-                    );
-                    HashMap::new()
-                })
-        }
-        None => HashMap::new(),
-    };
-
-    let geo_hash = encode(
-        Coord {
-            x: params.longitude,
-            y: params.latitude,
-        },
-        6,
-    )
-    .map_err(|e| AppError::TicketmasterApi {
-        status: StatusCode::INTERNAL_SERVER_ERROR,
-        message: format!("failed to encode geohash: {e}"),
-    })?;
-
-    let windows =
-        date_windows(&params.start, &params.end).map_err(|e| AppError::TicketmasterApi {
-            status: StatusCode::BAD_REQUEST,
-            message: e,
-        })?;
-
-    let client = state.client.clone();
-    let api_key = state.ticketmaster_key.clone();
-    let radius = params.radius;
-
-    // Kicked off now so it runs concurrently with the Ticketmaster windowed
-    // fetch below rather than adding its own round-trip afterward. Absent
-    // entirely (no task spawned) when PREDICTHQ_API_KEY isn't configured —
-    // this whole feature is best-effort and must never hold up or break
-    // Ticketmaster's own results.
-    let predicthq_handle = state.predicthq_api_key.clone().map(|predicthq_key| {
-        let client = state.client.clone();
-        let within = format!("{radius}mi@{},{}", params.latitude, params.longitude);
-        let start_gte = params.start.clone();
-        let start_lte = params.end.clone();
-        tokio::spawn(async move {
-            crate::predicthq::search_concerts(
-                &client,
-                &predicthq_key,
-                &within,
-                &start_gte,
-                &start_lte,
-            )
-            .await
-        })
-    });
-
-    let stream: BoxStream<'static, Result<Bytes, AppError>> = async_stream::try_stream! {
-        let mut seen = HashSet::<String>::new();
-        let mut ticketmaster_events = Vec::<EventResponse>::new();
-
-        for (start, end) in windows {
-            let mut page = 0_u32;
-
-            loop {
-                let body = fetch_tm_page(
-                    &client,
-                    &api_key,
-                    &geo_hash,
-                    radius,
-                    &start,
-                    &end,
-                    page,
-                ).await?;
-
-                if let Some(meta) = &body.page
-                    && meta.totalElements >= 1000
-                {
-                    tracing::warn!(
-                        start = %start,
-                        end = %end,
-                        page = meta.number,
-                        page_size = meta.size,
-                        total_pages = meta.totalPages,
-                        total_elements = meta.totalElements,
-                        "ticketmaster window may exceed deep paging limit"
-                    );
-                }
-
-                let events = body
-                    .embedded
-                    .map(|embedded| embedded.events)
-                    .unwrap_or_default();
-
-                // Deduped first so a page's worth of already-discarded
-                // duplicates don't cost a wasted spot in the batched
-                // lookup below.
-                let mut page_events: Vec<EventResponse> = Vec::new();
-                for raw in events {
-                    let mut event = normalize_event(raw);
-                    apply_personalization(&mut event, &personalization_matches);
-                    if seen.insert(dedupe_key(&event)) {
-                        page_events.push(event);
-                    }
-                }
-
-                // Plain indexed reads, not a call to Apple Music/Spotify —
-                // safe to run inline rather than detached like
-                // `spawn_enrichment` below (see `crate::artists::lookup`).
-                crate::artists::attach_enrichment(&mut page_events, &state.db.pool).await;
-
-                for event in page_events {
-                    let mut line = serde_json::to_vec(&event)
-                        .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
-                    line.push(b'\n');
-                    yield Bytes::from(line);
-                    ticketmaster_events.push(event);
-                }
-
-                let Some(meta) = body.page else {
-                    break;
-                };
-
-                if !should_fetch_next(PageLimit::All, &meta) {
-                    break;
-                }
-
-                page += 1;
-            }
-        }
-
-        // Every performer name seen this request, fed to canonical artist
-        // enrichment at the very end (see below) — collected as we go
-        // rather than re-derived later, since `new_events` below is
-        // consumed by value once PredictHQ personalization is applied to
-        // it.
-        let mut artist_candidates: Vec<crate::artists::ArtistCandidate> = ticketmaster_events
-            .iter()
-            .filter(|event| crate::events::is_music_classified(event))
-            .flat_map(|event| event.performers.iter().flatten())
-            .filter_map(|performer| {
-                performer.name.clone().map(|name| crate::artists::ArtistCandidate {
-                    name,
-                    ticketmaster_attraction_id: performer.id.clone(),
-                })
-            })
-            .collect();
-
-        // Second wave: reconcile PredictHQ against everything Ticketmaster
-        // just streamed. A failed/absent fetch degrades to "no PredictHQ
-        // data this request" rather than an error — this feature is
-        // additive and must never take down event browsing.
-        let predicthq_events = match predicthq_handle {
-            Some(handle) => match handle.await {
-                Ok(Ok(raw_events)) => raw_events
-                    .into_iter()
-                    .map(crate::predicthq::normalize_predicthq_event)
-                    .collect(),
-                Ok(Err(err)) => {
-                    tracing::warn!(error = %err, "failed to fetch PredictHQ events, skipping");
-                    Vec::new()
-                }
-                Err(join_err) => {
-                    tracing::warn!(error = %join_err, "PredictHQ fetch task failed, skipping");
-                    Vec::new()
-                }
-            },
-            None => Vec::new(),
-        };
-
-        if !predicthq_events.is_empty() {
-            let (enrichments, mut new_events) =
-                reconcile_predicthq_events(&ticketmaster_events, predicthq_events);
-
-            for event in enrichments {
-                let mut line = serde_json::to_vec(&event)
-                    .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
-                line.push(b'\n');
-                yield Bytes::from(line);
-            }
-
-            // Best-effort image/link backfill for the PredictHQ-only cards
-            // (a matched event above is already a Ticketmaster clone with
-            // its own real photo/ticket URL, so it's excluded from this).
-            // Absent entirely when Apple Music isn't configured or its
-            // developer token can't be fetched right now — same
-            // never-block-the-feed posture as the PredictHQ fetch itself.
-            if let (Some(am), Some(dev_token_mgr)) =
-                (&state.apple_music_client, &state.apple_dev_token)
-            {
-                match dev_token_mgr.get_token().await {
-                    Ok(token) => {
-                        crate::predicthq::backfill_artwork(
-                            &mut new_events,
-                            am,
-                            &token,
-                            &state.apple_artwork_cache,
-                        )
-                        .await;
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            error = %err,
-                            "failed to fetch Apple Music developer token, skipping PredictHQ image/link backfill"
-                        );
-                    }
-                }
-            }
-
-            // PredictHQ performer ids are PredictHQ entity ids, not
-            // Ticketmaster attraction ids — a different namespace, so
-            // `ticketmaster_attraction_id` is always `None` here (see
-            // `crate::predicthq::normalize`). `performer_search_names`
-            // falls back to the event's own title for the ~28% of
-            // PredictHQ events with no structured performer entity at
-            // all, same as the image backfill above.
-            artist_candidates.extend(
-                new_events
-                    .iter()
-                    .filter(|event| crate::events::is_music_classified(event))
-                    .flat_map(|event| {
-                        crate::predicthq::performer_search_names(event)
-                            .into_iter()
-                            .map(|name| crate::artists::ArtistCandidate {
-                                name,
-                                ticketmaster_attraction_id: None,
-                            })
-                    }),
-            );
-
-            crate::artists::attach_enrichment(&mut new_events, &state.db.pool).await;
-
-            for mut event in new_events {
-                apply_personalization(&mut event, &personalization_matches);
-                let mut line = serde_json::to_vec(&event)
-                    .map_err(|e| -> AppError { AppError::TicketmasterApi { status: StatusCode::INTERNAL_SERVER_ERROR, message: e.to_string() } })?;
-                line.push(b'\n');
-                yield Bytes::from(line);
-            }
-        }
-
-        crate::artists::spawn_enrichment(&state, artist_candidates);
-    }
-    .boxed();
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "application/x-ndjson")
-        .header(header::CACHE_CONTROL, "no-store")
-        .body(Body::from_stream(stream))
-        .unwrap())
-}
+use std::collections::HashSet;
 
 /// `GET /future-events?id=...` — every upcoming event for one attraction,
 /// fully paginated (an artist with many announced shows shouldn't be
@@ -339,10 +65,10 @@ pub async fn get_events_by_attraction(
 }
 
 /// Fetches events within `radius` miles of `geo_hash` over `[start, end]`,
-/// normalized and deduped. Unlike `get_concerts_tm_stream`, this doesn't
-/// window by calendar day — `page_limit` alone controls how far it pages
-/// into the (single) date range, so `PageLimit::First` costs exactly one
-/// Ticketmaster request.
+/// normalized and deduped. Unlike `crate::events::get_concerts_tm_stream`,
+/// this doesn't window by calendar day — `page_limit` alone controls how
+/// far it pages into the (single) date range, so `PageLimit::First` costs
+/// exactly one Ticketmaster request.
 ///
 /// Used by `services::playlist_builder`, which calls this on a 5-minute
 /// timer (the periodic updater) and doesn't need the map stream's full

--- a/apps/api/src/ticketmaster_stream/source.rs
+++ b/apps/api/src/ticketmaster_stream/source.rs
@@ -1,0 +1,106 @@
+//! `TicketmasterSource`: this source's `EventSource` adapter. Wraps the
+//! per-window pagination loop that used to live inline in
+//! `get_concerts_tm_stream` — unchanged behavior, just given a seam.
+
+use std::collections::HashSet;
+
+use super::client::{fetch_tm_page, should_fetch_next};
+use super::normalize::normalize_event;
+use super::types::PageLimit;
+use crate::error::AppError;
+use crate::events::dedupe_key;
+use crate::events::source::{EventSource, Window};
+use crate::events::types::EventResponse;
+
+pub(crate) struct TicketmasterSource {
+    client: reqwest::Client,
+    api_key: String,
+    geo_hash: String,
+    radius: u8,
+    /// Cross-window dedupe — Ticketmaster returns the same show multiple
+    /// times across overlapping date windows with different ids. One
+    /// instance per request, same lifetime as the local `seen` this
+    /// replaces.
+    seen: HashSet<String>,
+}
+
+impl TicketmasterSource {
+    pub(crate) fn new(
+        client: reqwest::Client,
+        api_key: String,
+        geo_hash: String,
+        radius: u8,
+    ) -> Self {
+        Self {
+            client,
+            api_key,
+            geo_hash,
+            radius,
+            seen: HashSet::new(),
+        }
+    }
+}
+
+impl EventSource for TicketmasterSource {
+    /// Always synchronously ready — `must_wait` is irrelevant here, every
+    /// call fully pages through this window before returning.
+    async fn events_for_window(
+        &mut self,
+        window: &Window,
+        _must_wait: bool,
+    ) -> Result<Option<Vec<EventResponse>>, AppError> {
+        let mut page = 0_u32;
+        let mut out = Vec::new();
+
+        loop {
+            let body = fetch_tm_page(
+                &self.client,
+                &self.api_key,
+                &self.geo_hash,
+                self.radius,
+                &window.start,
+                &window.end,
+                page,
+            )
+            .await?;
+
+            if let Some(meta) = &body.page
+                && meta.totalElements >= 1000
+            {
+                tracing::warn!(
+                    start = %window.start,
+                    end = %window.end,
+                    page = meta.number,
+                    page_size = meta.size,
+                    total_pages = meta.totalPages,
+                    total_elements = meta.totalElements,
+                    "ticketmaster window may exceed deep paging limit"
+                );
+            }
+
+            let events = body
+                .embedded
+                .map(|embedded| embedded.events)
+                .unwrap_or_default();
+
+            for raw in events {
+                let event = normalize_event(raw);
+                if self.seen.insert(dedupe_key(&event)) {
+                    out.push(event);
+                }
+            }
+
+            let Some(meta) = body.page else {
+                break;
+            };
+
+            if !should_fetch_next(PageLimit::All, &meta) {
+                break;
+            }
+
+            page += 1;
+        }
+
+        Ok(Some(out))
+    }
+}


### PR DESCRIPTION
## Summary
Came out of an architecture review + grilling session on `get_concerts_tm_stream` -- a 260-line, single-function orchestration with zero test coverage even though every piece it calls (`normalize_event`, `dedupe_key`, `reconcile_predicthq_events`) is itself well-tested. While grilling the redesign, a second, concrete bug surfaced: PredictHQ-only events all emitted after Ticketmaster's *entire* chronological stream and a global artwork-backfill batch completed, so a PredictHQ-only event for tomorrow could land after Ticketmaster events three weeks out were already rendered in the (sorted, list-view) events drawer -- jolting it downward as the new item inserted above already-rendered later events.

Both problems share one fix:
- **Ticketmaster and PredictHQ are formalized behind a shared `EventSource` interface** (`events/source.rs`) -- two real adapters for the same conceptual role (fetch concert events for a date range), not a hypothetical seam.
- **`events/merge.rs`** drives Ticketmaster's per-window sequential stream exactly as before (preserving today's fast time-to-first-event -- no PredictHQ wait added to the critical path), and opportunistically checks before each window whether PredictHQ's single background fetch has resolved: if so, reconciles and interleaves it in immediately; if not, emits Ticketmaster-only and catches up in one pass once PredictHQ becomes ready. A PredictHQ-only event for day *D* can now only ever be yielded after day *D*'s Ticketmaster wave -- structurally true by construction (the merge loop's `pending` queue), not an ordering convention that could later drift.
- The orchestration itself **moves into `apps/api/src/events/`** -- its natural home now that it's genuinely cross-provider, not Ticketmaster-specific. `ticketmaster_stream/` and `predicthq/` shrink to what they actually are: two source-specific `EventSource` adapters (`source.rs` in each) plus their existing fetch/normalize/artwork primitives, reused as-is.

**One load-bearing correctness detail**: PredictHQ's single whole-range fetch is bucketed into per-window slices by the **UTC** day of each event's `dates` field -- the same axis Ticketmaster's own UTC-windowed queries already use -- not by `local_calendar_day` (which, unchanged, is still what `reconcile_predicthq_events` itself matches on). Bucketing by the wrong axis would misfile an event relative to whichever window Ticketmaster's real server-side response placed its true match in.

## Test plan
- [x] 5 new unit tests in `events/merge.rs` against fake `EventSource` implementations with controllable readiness: full interleaving when PredictHQ is ready early, a catch-up burst when it resolves mid-stream, graceful degradation to Ticketmaster-only when PredictHQ never resolves, a direct regression test proving a PredictHQ-only event can never precede its own day's Ticketmaster wave, and a test confirming the UTC-window/local-day split still reconciles correctly
- [x] `reconcile_predicthq_events`'s existing 19 tests, `dates.rs`'s 4, and every other existing test unchanged and passing -- `cargo test --lib`: 112 passed, 0 failed, 5 ignored
- [x] `cargo check --tests` / `cargo fmt` / `cargo clippy --bins --tests -- -D clippy::all` -- no new warnings
- [x] Live: real Portland, ME stream (`/concerts/stream`) -- 85 events (38 Ticketmaster, 47 PredictHQ), **zero ordering violations** (no PredictHQ-only event ever precedes its own calendar day's first Ticketmaster event), correct dedup/enrichment re-emission semantics preserved (verified the "same id, empty rank then real rank" pattern matches the old design's intentional second-wave-update behavior)
- [x] Live: the running app renders real Portland, ME results correctly, events sorted properly within each day, no console errors, no failed network requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)