### PR TITLE
Fix tablet map reflow glitch, search truncation, and nav active state

### DIFF
--- a/apps/web/src/Search.tsx
+++ b/apps/web/src/Search.tsx
@@ -148,7 +148,8 @@ const Search = () => {
             name="search"
             value={selectedLocation ? selectedLocation.fullAddress : searchTerm}
             placeholder="Search for a city"
-            className="block w-full grow border-r-1 border-gray-300 p-0 text-base text-gray-900 outline-none placeholder:text-gray-400 focus:outline-none [&>input]:border-none"
+            className="block w-full grow border-r-1 border-gray-300 p-0 outline-none focus:outline-none [&>input]:border-none"
+            inputClassName="truncate text-base text-gray-900 placeholder:text-gray-400"
             onChange={(e) => updateSearchTerm(e)}
             onKeyDown={handleKeyDown}
             onFocus={() => places.length > 1 && setIsSuggestionsOpen(true)}

--- a/apps/web/src/hooks/useResizeFix.ts
+++ b/apps/web/src/hooks/useResizeFix.ts
@@ -1,32 +1,47 @@
 import { useEffect, type RefObject } from "react"
 import type { Map as MapboxMap } from "mapbox-gl"
 
-/** Debounced `resize()` call whenever `container` changes size.
+// ~1 frame at 60fps. Not requestAnimationFrame: rAF is paused entirely
+// while the document is hidden/backgrounded, which would silently stop
+// the map from ever resizing in that state; a short timeout keeps firing
+// regardless and is close enough to frame-rate for this purpose.
+const RESIZE_THROTTLE_MS = 16
+
+/** Throttled `resize()` call whenever `container` changes size.
  *
- * Not a call-on-every-tick observer: Mapbox recalculates its internal
- * camera transform on each `resize()` call, and the drawer's open/close
- * transition fires this observer continuously as its reserved width
- * animates (~150ms). Resizing the GL canvas that often before it settles
- * produces a visible zoom/scale glitch. Waiting for the container to go
- * quiet avoids it — the canvas just stretches via CSS in the meantime,
- * which is cheap and doesn't touch the camera. */
+ * Not a debounce: waiting for the container to go quiet (e.g. ~200ms after
+ * the drawer's width animation stops changing) leaves the GL canvas -- a
+ * fixed pixel size set by mapbox-gl itself, which does not track its
+ * container's CSS size on its own -- stale for the length of the wait. On
+ * a container that's *shrinking* that's merely invisible overflow, but on
+ * one that's *growing* (e.g. the drawer collapsing) it's a visible dead
+ * gap between the stale canvas and the container's now-larger edge.
+ *
+ * Throttling instead keeps `resize()` within about one frame of the
+ * container's true size throughout the animation, not just at the end --
+ * so there's never a gap (or a stretched canvas, from an earlier attempt
+ * at this fix that forced the canvas to CSS-stretch to its container in
+ * the meantime) large enough to notice. Still coalesced to at most once
+ * per interval (not once per ResizeObserver entry) so a burst of
+ * synchronous layout changes triggers one `resize()`, not many. */
 export function useResizeFix(
   mapRef: RefObject<MapboxMap | null>,
   container: RefObject<HTMLDivElement | null>
 ) {
   useEffect(() => {
-    let settleTimeout: ReturnType<typeof setTimeout> | null = null
+    let throttleId: ReturnType<typeof setTimeout> | null = null
     const resizeObserver = new ResizeObserver(() => {
-      if (settleTimeout) clearTimeout(settleTimeout)
-      settleTimeout = setTimeout(() => {
+      if (throttleId !== null) return
+      throttleId = setTimeout(() => {
+        throttleId = null
         mapRef.current?.resize()
-      }, 200)
+      }, RESIZE_THROTTLE_MS)
     })
     if (container.current) {
       resizeObserver.observe(container.current)
     }
     return () => {
-      if (settleTimeout) clearTimeout(settleTimeout)
+      if (throttleId !== null) clearTimeout(throttleId)
       resizeObserver.disconnect()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/components/ui/Tabs.tsx
+++ b/packages/ui/src/components/ui/Tabs.tsx
@@ -63,26 +63,11 @@ export function TabList<T extends object>(props: TabListProps<T>) {
 
 const tabProps = tv({
   extend: focusRing,
-  // `isolate` scopes the SelectionIndicator's mix-blend-difference below to
-  // just this tab's own stacking context. Without it, the blend composites
-  // against whatever's behind the tab in the page's shared stacking context
-  // instead of just this tab's own icon/label — on a dark background that
-  // reads as a solid-black circle with the icon and label blended away
-  // entirely, rather than the intended inverted-color pill.
-  //
-  // `selected:text-white` forces the icon/label to a known, fixed color
-  // before the blend runs. The indicator's own background is always white
-  // and, blended against the transparent space around the icon/label, always
-  // composites out to white too — so the indicator itself never varies by
-  // theme. Left to inherit the normal (theme-dependent) text color, the
-  // difference-blend is far weaker in light mode: OKLCH's perceptually-even
-  // lightness scale isn't linear in sRGB, so light mode's dark text (~35/255)
-  // blends to a washed-out light gray (~220/255) against the white pill,
-  // while dark mode's light text (~250/255) happens to blend to strong
-  // near-black — the same trick, but only reliably readable in one theme.
-  // Pinning to white first makes every theme diff from the same value dark
-  // mode already gets for free: near-maximum, near-black marks on the pill.
-  base: "group relative isolate flex items-center cursor-default rounded-full px-3 py-1.5 text-sm font-medium transition selected:text-white forced-color-adjust-none [-webkit-tap-highlight-color:transparent]",
+  // `isolate` keeps the SelectionIndicator (a -z-10 sibling) from painting
+  // below page content outside this tab -- it's a solid accent pill sitting
+  // behind the icon/label, not a blend trick, so it needs its own stacking
+  // context to stay contained rather than any special compositing.
+  base: "group relative isolate flex items-center cursor-default rounded-full px-3 py-1.5 text-sm font-medium transition selected:text-(--text-on-accent) forced-color-adjust-none [-webkit-tap-highlight-color:transparent]",
   variants: {
     isDisabled: {
       true: "text-neutral-200 dark:text-neutral-600 forced-colors:text-[GrayText] selected:text-white dark:selected:text-neutral-500 forced-colors:selected:text-[HighlightText] selected:bg-neutral-200 dark:selected:bg-neutral-600 forced-colors:selected:bg-[GrayText]",
@@ -101,7 +86,7 @@ export function Tab(props: TabProps) {
       {composeRenderProps(props.children, (children) => (
         <>
           {children}
-          <SelectionIndicator className="absolute top-0 left-0 z-10 h-full w-full rounded-full bg-white mix-blend-difference group-disabled:-z-1 group-disabled:bg-neutral-400 group-disabled:mix-blend-normal motion-safe:transition-[translate,width,height] group-disabled:dark:bg-neutral-600" />
+          <SelectionIndicator className="absolute top-0 left-0 -z-10 h-full w-full rounded-full bg-(--accent-bg) group-disabled:bg-neutral-200 motion-safe:transition-[translate,width,height] dark:group-disabled:bg-neutral-600" />
         </>
       ))}
     </RACTab>


### PR DESCRIPTION
## Summary
- **Map reflow glitch (tablet/drawer collapse)**: `useResizeFix` debounced `mapRef.resize()` by 200ms after the container stopped changing, on the assumption that the Mapbox canvas visually stretches via CSS in the meantime. It doesn't — mapbox-gl sets the canvas as fixed inline pixel dimensions, so a *growing* container (e.g. the drawer collapsing, or a viewport resize) left a real dead gap next to a stale, too-small canvas for up to 200ms. Swapped the debounce for a ~16ms throttle so `resize()` stays within about a frame of the container's true size throughout, instead of only settling at the end.
- **Search input truncation**: the location field's truncation/typography classes were passed via `TextField`'s `className`, which styles the wrapper `<div>`, not the actual `<input>` — `inputClassName` is the prop that reaches it. Long addresses were hard-clipping mid-word ("Portland, Maine, Unit") instead of showing an ellipsis.
- **Nav active state**: the desktop rail's selected-tab indicator relied on a `mix-blend-difference` white-pill trick to auto-invert whatever's underneath. It's clever but reads as a vague monochrome smudge, unrelated to the app's actual accent color used everywhere else (the Tickets/Listen CTA, links). Replaced it with a solid `--accent-bg` pill + `--text-on-accent` text — same tokens already used elsewhere, so the active state is now unambiguous and on-brand. This is a shared component, so it also fixes the Spotify/Apple Music sub-tabs' selected state.

## Test plan
- [x] Verified via the running dev server: map fills its container with no gap or lingering distortion after a tablet-width resize, in both directions (shrink and grow)
- [x] Verified the search input now shows a proper ellipsis at 375px width instead of a hard clip
- [x] Verified the nav rail's active pill renders correctly and slides/recolors correctly across Explore/Spotify/Apple Music, and the Spotify sub-tabs (My Playlists/Create)
- [ ] No automated tests added — these are visual/layout fixes; existing test suites (`events.test.ts` etc.) are unaffected and untouched by this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)