### PR TITLE
Re-enrich cross-source-matched events before their second-wave emission

### DIFF
--- a/apps/api/src/events/merge.rs
+++ b/apps/api/src/events/merge.rs
@@ -30,8 +30,13 @@ use crate::error::AppError;
 pub(crate) enum MergeStep {
     /// This window's Ticketmaster wave.
     Ticketmaster(Vec<EventResponse>),
-    /// PredictHQ enrichments for one calendar day (clones of already-
-    /// emitted Ticketmaster events with rank/predicted_attendance set).
+    /// PredictHQ enrichments for one calendar day: clones of the
+    /// already-emitted Ticketmaster events with rank/predicted_attendance
+    /// set. Cloned from the *pre-enrichment* snapshot this module retains
+    /// internally (`pending`, below) -- callers still need to run their own
+    /// DB enrichment/personalization steps on these, same as any other
+    /// step, despite the shared event id with an already-processed
+    /// first-wave emission.
     PredictHqEnrichments(Vec<EventResponse>),
     /// New PredictHQ-only events for one calendar day, pre-artwork-backfill.
     PredictHqNew(Vec<EventResponse>),

--- a/apps/api/src/events/stream.rs
+++ b/apps/api/src/events/stream.rs
@@ -123,11 +123,21 @@ pub async fn get_concerts_tm_stream(
                         yield to_ndjson_line(&event)?;
                     }
                 }
-                MergeStep::PredictHqEnrichments(events) => {
-                    // Already-enriched clones of already-personalized
-                    // Ticketmaster events under their original id -- no
-                    // reprocessing, just re-emit as a second-wave update.
-                    for event in events {
+                MergeStep::PredictHqEnrichments(mut events) => {
+                    // These are clones of the *pre-enrichment* Ticketmaster
+                    // events merge_events retained internally for
+                    // reconciliation (see merge.rs's `pending`) -- captured
+                    // before the MergeStep::Ticketmaster branch above ever
+                    // got to mutate its own copy with DB enrichment/
+                    // personalization. Confirmed live: without re-running
+                    // both here, a cross-source-matched event's re-emission
+                    // silently loses performer.enrichment (and any
+                    // matched_artist tag), even though it carries the same
+                    // event id as an already-enriched first-wave emission.
+                    crate::artists::attach_enrichment(&mut events, &state.db.pool).await;
+
+                    for mut event in events {
+                        apply_personalization(&mut event, &personalization_matches);
                         yield to_ndjson_line(&event)?;
                     }
                 }


### PR DESCRIPTION
## Summary
- Reported after #88 landed: the now-correctly-merged "La Luz w/ Spacemoth" card in Denver showed no artist details (bio/genres/artwork) in the event details view, only its upcoming-shows list.
- Root cause is a pre-existing gap in the reconcile pipeline, not something #86/#88 introduced — it just never fired for this specific pair until the venue-spelling fix made it actually match cross-source. `merge_events` (`merge.rs`) retains its own internal snapshot of each window's Ticketmaster events (`pending`) for later PredictHQ reconciliation, captured *before* the consumer (`stream.rs`) ever runs `attach_enrichment`/`apply_personalization` on its own copy of the same data. When PredictHQ matches, the clone re-emitted as a second-wave rank/predictedAttendance update is built from that pre-enrichment snapshot — so it silently drops `performer.enrichment` (and any personalization tag), even though it shares an event id with an already-enriched first-wave emission. The frontend reducer replaces the first with the second on a matching id, so the final stored event loses its artist details.
- Runs `attach_enrichment` + `apply_personalization` on the `PredictHqEnrichments` branch in `stream.rs`, matching the other two branches. Also corrects the stale doc comments in both files that asserted these events were already enriched.

## Test plan
- [x] `cargo test` — 118 passed
- [x] `cargo build --lib` clean
- [x] `cargo fmt --check` clean
- [x] Verified against the live local API: rebuilt and restarted the dev backend, re-fetched the real Denver `/concerts/stream` response — both emissions for the merged "La Luz w/ Spacemoth" event now carry `performer.enrichment` (previously only the first did)

🤖 Generated with [Claude Code](https://claude.com/claude-code)