### PR TITLE
Fix Ticketmaster/PredictHQ cross-window bucketing mismatch at UTC midnight

### DIFF
--- a/apps/api/src/ticketmaster_stream/source.rs
+++ b/apps/api/src/ticketmaster_stream/source.rs
@@ -4,6 +4,8 @@
 
 use std::collections::HashSet;
 
+use chrono::{DateTime, Utc};
+
 use super::client::{fetch_tm_page, should_fetch_next};
 use super::normalize::normalize_event;
 use super::types::PageLimit;
@@ -86,6 +88,22 @@ impl EventSource for TicketmasterSource {
 
             for raw in events {
                 let event = normalize_event(raw);
+                if !belongs_to_window(&event, window) {
+                    // Confirmed live (Denver's "Jutes with Mothica", sitting
+                    // exactly at a UTC-midnight window boundary): Ticketmaster's
+                    // API returns some boundary-exact events for BOTH adjacent
+                    // windows' queries. Without this check, whichever window's
+                    // fetch happened to run first would claim it via `seen`
+                    // below -- misaligning it from PredictHqSource's own
+                    // UTC-day bucketing of the same event (see that module's
+                    // docs) and permanently defeating cross-source
+                    // reconciliation for that pair, since they'd never be
+                    // compared within the same window's reconcile call.
+                    // Skipping here lets the *correct* window's query (the one
+                    // whose fetch this event's own UTC day actually matches)
+                    // claim it instead.
+                    continue;
+                }
                 if self.seen.insert(dedupe_key(&event)) {
                     // `dedupe_key` only catches the exact same Ticketmaster
                     // event reappearing across pagination; a second,
@@ -109,5 +127,118 @@ impl EventSource for TicketmasterSource {
         }
 
         Ok(Some(out))
+    }
+}
+
+/// Whether `event`'s own UTC calendar day matches `window`'s -- the same
+/// axis `PredictHqSource` buckets its own events by (see that module's
+/// docs), so an event failing this check belongs to (and will be correctly
+/// captured by) the adjacent window whose `calendar_day` actually matches
+/// instead.
+///
+/// `true` when `event.dates` isn't a parseable RFC3339 instant (a bare
+/// `YYYY-MM-DD` local-date-only fallback, or a timezone-less local
+/// date+time fallback -- see `normalize_event`): neither carries a UTC
+/// instant to convert, so there's no boundary-crossing ambiguity to
+/// resolve, and the existing behavior (trust whichever window's query
+/// returned it) is already correct for them.
+fn belongs_to_window(event: &EventResponse, window: &Window) -> bool {
+    match utc_calendar_day(event.dates.as_deref()) {
+        Some(day) => day == window.calendar_day,
+        None => true,
+    }
+}
+
+fn utc_calendar_day(dates: Option<&str>) -> Option<String> {
+    dates
+        .and_then(|d| DateTime::parse_from_rfc3339(d).ok())
+        .map(|dt| dt.with_timezone(&Utc).format("%Y-%m-%d").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::types::{Source, VenueResponse};
+
+    fn window(calendar_day: &str) -> Window {
+        Window {
+            start: format!("{calendar_day}T00:00:00Z"),
+            end: format!("{calendar_day}T23:59:59Z"),
+            calendar_day: calendar_day.to_string(),
+        }
+    }
+
+    fn event_with_dates(dates: Option<&str>) -> EventResponse {
+        EventResponse {
+            id: "1".to_string(),
+            name: "Event".to_string(),
+            venue: Some(VenueResponse {
+                name: Some("Venue".to_string()),
+                location: None,
+                city: None,
+                state: None,
+                state_code: None,
+                address: None,
+                postal_code: None,
+                url: None,
+                images: vec![],
+            }),
+            images: vec![],
+            dates: dates.map(str::to_string),
+            dates_pretty: None,
+            local_calendar_day: None,
+            classifications: None,
+            performers: None,
+            url: None,
+            price_ranges: None,
+            matched_artist: None,
+            matched_via: None,
+            source: Source::Ticketmaster,
+            rank: None,
+            predicted_attendance: None,
+        }
+    }
+
+    #[test]
+    fn belongs_to_window_true_when_utc_day_matches() {
+        let event = event_with_dates(Some("2026-08-14T18:00:00Z"));
+        assert!(belongs_to_window(&event, &window("2026-08-14")));
+    }
+
+    #[test]
+    fn belongs_to_window_false_when_utc_day_is_the_adjacent_day() {
+        // The confirmed-live Denver bug: an event sitting exactly at a
+        // UTC-midnight window boundary ("Jutes with Mothica", dates
+        // "2026-08-14T00:00:00Z") was returned by Ticketmaster's own API
+        // for BOTH the "2026-08-13" and "2026-08-14" window queries; without
+        // this check, the earlier window claimed it via cross-window `seen`
+        // dedup, misaligning it from PredictHqSource's "2026-08-14" bucket
+        // (UTC day of the same `dates` value) and permanently defeating
+        // cross-source reconciliation for the pair.
+        let event = event_with_dates(Some("2026-08-14T00:00:00Z"));
+        assert!(!belongs_to_window(&event, &window("2026-08-13")));
+        assert!(belongs_to_window(&event, &window("2026-08-14")));
+    }
+
+    #[test]
+    fn belongs_to_window_true_for_bare_local_date_with_no_time_component() {
+        // No instant to convert -- no boundary ambiguity to resolve, so this
+        // must not be filtered out of whichever window returned it.
+        let event = event_with_dates(Some("2026-08-14"));
+        assert!(belongs_to_window(&event, &window("2026-08-14")));
+    }
+
+    #[test]
+    fn belongs_to_window_true_for_timezone_less_local_datetime_fallback() {
+        // normalize_event's local_date+local_time fallback (no offset) --
+        // also not RFC3339-parseable, same reasoning as the bare-date case.
+        let event = event_with_dates(Some("2026-08-14T20:00:00"));
+        assert!(belongs_to_window(&event, &window("2026-08-14")));
+    }
+
+    #[test]
+    fn belongs_to_window_true_when_dates_is_absent() {
+        let event = event_with_dates(None);
+        assert!(belongs_to_window(&event, &window("2026-08-14")));
     }
 }


### PR DESCRIPTION
## Summary
- Reported after #88/#89: Denver's "JUTES - Smile You're on Tour" (Ticketmaster) and "Jutes with Mothica" (PredictHQ) still showed as two separate cards, despite matching venue name, calendar day, and overlapping performers — I confirmed the matcher itself (`same_show`) correctly returns `true` given these exact captured field values, so the miss was happening earlier in the pipeline.
- Traced it live: the show's raw UTC instant sits exactly at a window boundary (`dates: "2026-08-14T00:00:00Z"`). Ticketmaster's own API returns this event for **both** adjacent windows' queries ("2026-08-13" and "2026-08-14"), and `TicketmasterSource`'s cross-window `seen` dedup let whichever window ran first (chronologically earlier, "2026-08-13") silently claim it. `PredictHqSource` buckets the same event by UTC day of its own `dates` field, landing it under "2026-08-14" instead. Different windows means `reconcile_predicthq_events` never gets a chance to compare the two — they're simply never in the same reconcile call together.
- Adds a `belongs_to_window` filter to `TicketmasterSource` so an event is only accepted into the window whose `calendar_day` actually matches its own UTC day — aligning it onto the same axis `PredictHqSource` already uses (its own module doc already assumed Ticketmaster did this). The event's "true" window still claims it via its own query, so nothing is lost, just correctly assigned.

## Test plan
- [x] `cargo test` — 123 passed, including 5 new unit tests for `belongs_to_window` (matching day, the adjacent-boundary-day case that reproduces the live bug, bare local-date fallback, timezone-less local datetime fallback, and absent `dates`)
- [x] `cargo fmt --check` clean
- [x] Verified against the live local API: rebuilt and restarted the dev backend, re-fetched the real Denver `/concerts/stream` response — "Jutes"/"Jutes with Mothica" now collapse into a single Ticketmaster-id'd event with PredictHQ's rank attached and performer enrichment intact; re-checked the earlier "La Luz w/ Spacemoth" case is still merged correctly too (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)