### PR TITLE
Retry artist upsert without a colliding provider id instead of failing

### DIFF
--- a/apps/api/src/artists/db.rs
+++ b/apps/api/src/artists/db.rs
@@ -47,6 +47,18 @@ pub(super) async fn get_artist(
 /// than overwriting, since `worker.rs` never calls this for a row it
 /// already found matched (see `resolve_one`'s dispatch). Everything else
 /// (artwork, genres, similar artists) is refreshed unconditionally.
+///
+/// `apple_music_id`/`spotify_id`/`ticketmaster_attraction_id` each have
+/// their own partial unique index (`migrations/006_artists.sql`) enforcing
+/// one canonical row per real-world artist identity — deliberate, per
+/// ADR-0001. But more than one `normalized_name` can legitimately resolve
+/// to the *same* identity: e.g. a plain Ticketmaster attraction name
+/// alongside PredictHQ's event-title-as-performer-name fallback for the
+/// same real artist (confirmed live — "LCD Soundsystem" and several others
+/// hit exactly this). `attach_enrichment` looks up by `normalized_name`
+/// only, so a losing name variant still needs *a* row to ever show
+/// enrichment, even though it can't hold the identity field's unique slot
+/// itself — see `upsert_matched`'s retry-without-that-field fallback.
 pub(super) struct MatchedArtist<'a> {
     pub normalized_name: &'a str,
     pub display_name: &'a str,
@@ -63,10 +75,42 @@ pub(super) struct MatchedArtist<'a> {
     pub similar_artists: &'a [SimilarArtist],
 }
 
+/// Upserts a resolved match, retrying with an already-claimed identity
+/// field cleared if it collides with a different `normalized_name`'s row
+/// (see `MatchedArtist`'s doc comment). Bounded to at most one retry per
+/// identity field — `apple_music_id`, then `spotify_id`, then
+/// `ticketmaster_attraction_id` — so this always terminates: each retry
+/// permanently nulls the offending field out of `row` before trying again,
+/// and there are only three such fields to exhaust.
 pub(super) async fn upsert_matched(
     pool: &PgPool,
-    row: MatchedArtist<'_>,
+    mut row: MatchedArtist<'_>,
 ) -> Result<(), sqlx::Error> {
+    loop {
+        match execute_upsert_matched(pool, &row).await {
+            Ok(()) => return Ok(()),
+            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                match db_err.constraint() {
+                    Some("artists_apple_music_id_idx") if row.apple_music_id.is_some() => {
+                        row.apple_music_id = None;
+                    }
+                    Some("artists_spotify_id_idx") if row.spotify_id.is_some() => {
+                        row.spotify_id = None;
+                    }
+                    Some("artists_ticketmaster_attraction_id_idx")
+                        if row.ticketmaster_attraction_id.is_some() =>
+                    {
+                        row.ticketmaster_attraction_id = None;
+                    }
+                    _ => return Err(sqlx::Error::Database(db_err)),
+                }
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+async fn execute_upsert_matched(pool: &PgPool, row: &MatchedArtist<'_>) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
         insert into artists (


### PR DESCRIPTION
## Summary
- Investigating a "Nashville American Football has parsed performers but no enrichment" report. That specific case turned out fine on re-check (a first-discovery async-matching timing gap by design, per ADR-0001 — not a bug), but checking the worker logs while confirming that surfaced a real, separate, **permanently**-failing bug.
- The enrichment worker was repeatedly failing to persist Apple Music matches for several real artists (Caamp, LCD Soundsystem, Empire of the Sun, Joe Bonamassa, Grupo Frontera, and others) — every retry cycle, never once succeeding, hammering the Apple Music API and DB for nothing.
- Root cause: `apple_music_id`/`spotify_id`/`ticketmaster_attraction_id` each have their own partial unique index (one canonical row per real-world identity, per ADR-0001), but `upsert_matched`'s `on conflict (normalized_name)` only handles a collision on that one column. More than one `normalized_name` can legitimately resolve to the same real artist — e.g. a plain Ticketmaster attraction name alongside PredictHQ's event-title-as-performer-name fallback for the same show. Confirmed via `psql`: `caamp` and `lcdsoundsystem` had **no row at all**, because every insert attempt hard-failed against a different `normalized_name` (`caampdurandjonestheindicationsin...`, `lcdsoundsystemwfeist`) that already claimed the same `apple_music_id`. `attach_enrichment` looks up by `normalized_name` only, so the losing name variant was stuck permanently, not just delayed.
- `upsert_matched` now retries with the colliding identity field cleared (`apple_music_id`, then `spotify_id`, then `ticketmaster_attraction_id`) so the losing `normalized_name` still gets its own row — fully enriched (display name/genres/artwork/similar artists/`matched_via`), just without re-claiming an identity slot another row already holds.

## Test plan
- [x] `cargo test` — 123 passed
- [x] `cargo build --lib` clean
- [x] `cargo fmt --check` clean
- [x] Verified against the live local API + DB: rebuilt and restarted the dev backend, re-triggered the Denver search, confirmed via `psql` that `caamp`/`lcdsoundsystem` now persist (`apple_music_id` null, `matched_via` intact), and both show full enrichment (genres, etc.) in the actual `/concerts/stream` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)