### PR TITLE
Custom accent-colored map markers

### DIFF
--- a/apps/web/src/hooks/useEventLayer.ts
+++ b/apps/web/src/hooks/useEventLayer.ts
@@ -1,11 +1,44 @@
-import { useEffect, type RefObject } from "react"
+import { useEffect, useRef, type RefObject } from "react"
 import type { Map as MapboxMap } from "mapbox-gl"
 import type { GeoJSONSource } from "mapbox-gl"
 import {
   buildEventFeatureCollection,
-  eventIconImageExpression,
+  eventIconColorExpression,
+  resolveCssColor,
 } from "../lib/mapbox"
 import type { EventResponse, EventsByDate } from "./eventsStream"
+
+const MARKER_IMAGE_ID = "marker-pin"
+const MARKER_VIEWPORT = 48
+const MARKER_PIXEL_RATIO = 2
+// A simple pin-with-hole shape (24x24 viewBox) -- generic map iconography,
+// not tied to any particular icon set. Fill color here is irrelevant: it's
+// loaded as an SDF image (see ensureMarkerImage), so only the alpha shape
+// matters, and the actual color comes from the layer's icon-color paint
+// property at render time.
+const MARKER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="${MARKER_VIEWPORT}" height="${MARKER_VIEWPORT}" viewBox="0 0 24 24"><path fill="#000" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z"/></svg>`
+
+/** Registers the app's pin marker as an SDF image on `map`, if not already
+ * present. One image, tinted per-feature via icon-color, instead of a
+ * separately-baked image per marker color (see eventIconColorExpression). */
+function ensureMarkerImage(map: MapboxMap): Promise<void> {
+  if (map.hasImage(MARKER_IMAGE_ID)) return Promise.resolve()
+
+  return new Promise((resolve, reject) => {
+    const img = new Image(MARKER_VIEWPORT, MARKER_VIEWPORT)
+    img.onload = () => {
+      if (!map.hasImage(MARKER_IMAGE_ID)) {
+        map.addImage(MARKER_IMAGE_ID, img, {
+          sdf: true,
+          pixelRatio: MARKER_PIXEL_RATIO,
+        })
+      }
+      resolve()
+    }
+    img.onerror = () => reject(new Error("Failed to load marker icon"))
+    img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(MARKER_SVG)}`
+  })
+}
 
 /** Owns the "events" Mapbox source/layer end to end: its data (from
  * `eventsByDate`) and its selection-driven icon styling (from
@@ -18,6 +51,17 @@ export function useEventLayer(
   selectedEvents: EventResponse[],
   selectEvents: (events: EventResponse[]) => void
 ) {
+  // Guards the one-time addSource+addLayer setup below against a race:
+  // ensureMarkerImage is async, and this effect can re-run many times in
+  // quick succession while events stream in (see the comment on
+  // applyToMap) -- without this, several of those re-runs can all
+  // observe "no source yet" before the first one's image load resolves,
+  // and each then tries to addSource, throwing on every one after the
+  // first. Set synchronously the moment setup is claimed, before the
+  // async gap opens, so later re-runs within that gap see it and wait
+  // instead of racing.
+  const layerSetupRef = useRef<Promise<void> | null>(null)
+
   useEffect(() => {
     const markEvents = () => {
       selectEvents([])
@@ -36,7 +80,10 @@ export function useEventLayer(
       // also separately trips an internal Mapbox GL terrain-update bug
       // when done rapidly).
       const applyToMap = () => {
-        const existingSource = mapRef.current?.getSource(
+        const map = mapRef.current
+        if (!map) return
+
+        const existingSource = map.getSource(
           "event-data-source"
         ) as GeoJSONSource | undefined
 
@@ -45,54 +92,73 @@ export function useEventLayer(
           return
         }
 
-        mapRef.current?.addSource("event-data-source", {
-          type: "geojson",
-          promoteId: "id",
-          cluster: true,
-          clusterRadius: 0,
-          clusterProperties: {
-            clusterEvent: ["string", ["get", "description"]],
-            clusterVenue: ["string", ["get", "venue"]],
-          },
-          data: dataSource,
-        })
-        mapRef.current?.addLayer({
-          id: "events",
-          type: "symbol",
-          source: "event-data-source",
-          layout: {
-            "text-field": [
-              "case",
-              ["boolean", ["has", "point_count"], false],
-              [
-                "concat",
-                ["get", "point_count"],
-                " events at ",
-                ["get", "clusterVenue"],
-              ],
-              ["get", "description"],
-            ],
-            "text-variable-anchor": ["top", "bottom", "left", "right"],
-            "text-radial-offset": 0.5,
-            "text-justify": "auto",
-            "icon-image": eventIconImageExpression(selectedEvents),
-            "icon-size": 1.6,
-          },
-          paint: {
-            "icon-halo-color": "#ffffff",
-            "icon-halo-width": 1,
-            "text-color": [
-              "case",
-              ["boolean", ["feature-state", "hover"], false],
-              "#627BC1",
-              ["boolean", ["has", "point_count"], false],
-              "#373630",
-              ["get", "color"],
-            ],
-            "text-halo-color": "#ffffff",
-            "text-halo-width": 2,
-          },
-        })
+        if (!layerSetupRef.current) {
+          layerSetupRef.current = ensureMarkerImage(map).then(() => {
+            map.addSource("event-data-source", {
+              type: "geojson",
+              promoteId: "id",
+              cluster: true,
+              clusterRadius: 0,
+              clusterProperties: {
+                clusterEvent: ["string", ["get", "description"]],
+                clusterVenue: ["string", ["get", "venue"]],
+              },
+              data: dataSource,
+            })
+            map.addLayer({
+              id: "events",
+              type: "symbol",
+              source: "event-data-source",
+              layout: {
+                "text-field": [
+                  "case",
+                  ["boolean", ["has", "point_count"], false],
+                  [
+                    "concat",
+                    ["get", "point_count"],
+                    " events at ",
+                    ["get", "clusterVenue"],
+                  ],
+                  ["get", "description"],
+                ],
+                "text-variable-anchor": ["top", "bottom", "left", "right"],
+                "text-radial-offset": 0.5,
+                "text-justify": "auto",
+                "icon-image": MARKER_IMAGE_ID,
+                "icon-size": 1,
+              },
+              paint: {
+                "icon-color": eventIconColorExpression(
+                  selectedEvents,
+                  resolveCssColor("--accent-bg"),
+                  resolveCssColor("--color-blush-rose-500")
+                ),
+                "icon-halo-color": "#ffffff",
+                "icon-halo-width": 1.5,
+                "text-color": [
+                  "case",
+                  ["boolean", ["feature-state", "hover"], false],
+                  "#627BC1",
+                  ["boolean", ["has", "point_count"], false],
+                  "#373630",
+                  ["get", "color"],
+                ],
+                "text-halo-color": "#ffffff",
+                "text-halo-width": 2,
+              },
+            })
+          })
+        } else {
+          // Setup already claimed by an earlier, still-in-flight call --
+          // this run's data is newer than whatever that one saw, so apply
+          // it once setup finishes instead of trying to addSource again.
+          layerSetupRef.current.then(() => {
+            const source = map.getSource("event-data-source") as
+              | GeoJSONSource
+              | undefined
+            source?.setData(dataSource)
+          })
+        }
       }
 
       if (mapRef.current?.isStyleLoaded()) {
@@ -106,8 +172,8 @@ export function useEventLayer(
     // selectedEvents intentionally omitted: this effect calls selectEvents([])
     // itself (inside markEvents), so including selectedEvents here would
     // make the effect re-trigger the state change that re-runs it — an
-    // infinite loop. The effect below already patches icon-image via
-    // setLayoutProperty when the selection changes, so rebuilding the whole
+    // infinite loop. The effect below already patches icon-color via
+    // setPaintProperty when the selection changes, so rebuilding the whole
     // layer/source here on every click isn't needed either.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventsByDate, selectEvents])
@@ -120,10 +186,14 @@ export function useEventLayer(
     // different, untested behavior change outside this deepening's scope.
     const venueLocation = selectedEvents[0]?.venue?.location
     if (selectedEvents.length && venueLocation !== undefined) {
-      mapRef.current?.setLayoutProperty(
+      mapRef.current?.setPaintProperty(
         "events",
-        "icon-image",
-        eventIconImageExpression(selectedEvents)
+        "icon-color",
+        eventIconColorExpression(
+          selectedEvents,
+          resolveCssColor("--accent-bg"),
+          resolveCssColor("--color-blush-rose-500")
+        )
       )
     }
   }, [selectedEvents, mapRef])

--- a/apps/web/src/lib/mapbox.test.ts
+++ b/apps/web/src/lib/mapbox.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   buildEventFeatureCollection,
-  eventIconImageExpression,
+  eventIconColorExpression,
   resolveEventsByIds,
 } from "./mapbox"
 import type { EventResponse, EventsByDate } from "../hooks/eventsStream"
@@ -86,18 +86,24 @@ describe("buildEventFeatureCollection", () => {
   })
 })
 
-describe("eventIconImageExpression", () => {
+describe("eventIconColorExpression", () => {
   it("matches a selected event by id", () => {
-    const expression = eventIconImageExpression([makeEvent({ id: "e1" })])
-    // ["case", ["in", ["get", "id"], ["literal", [...ids]]], "marker-yellow", ...]
+    const expression = eventIconColorExpression(
+      [makeEvent({ id: "e1" })],
+      "red",
+      "yellow"
+    )
+    // ["case", ["in", ["get", "id"], ["literal", [...ids]]], selectedColor, ...]
     expect(expression[1]).toEqual(["in", ["get", "id"], ["literal", ["e1"]]])
-    expect(expression[2]).toBe("marker-yellow")
+    expect(expression[2]).toBe("yellow")
   })
 
   it("matches by shared venue name for cluster highlighting", () => {
-    const expression = eventIconImageExpression([
-      makeEvent({ id: "e1", venue: { name: "Shared Venue", images: [] } }),
-    ])
+    const expression = eventIconColorExpression(
+      [makeEvent({ id: "e1", venue: { name: "Shared Venue", images: [] } })],
+      "red",
+      "yellow"
+    )
     expect(expression[3]).toEqual([
       "in",
       ["get", "clusterVenue"],
@@ -105,9 +111,9 @@ describe("eventIconImageExpression", () => {
     ])
   })
 
-  it("falls back to marker-red when nothing is selected", () => {
-    const expression = eventIconImageExpression([])
-    expect(expression[expression.length - 1]).toBe("marker-red")
+  it("falls back to the default color when nothing is selected", () => {
+    const expression = eventIconColorExpression([], "red", "yellow")
+    expect(expression[expression.length - 1]).toBe("red")
     expect(expression[1]).toEqual(["in", ["get", "id"], ["literal", []]])
   })
 })

--- a/apps/web/src/lib/mapbox.ts
+++ b/apps/web/src/lib/mapbox.ts
@@ -77,31 +77,66 @@ export function buildEventFeatureCollection(
   return dataSource
 }
 
-/** The "events" layer's `icon-image` expression: yellow for the selected
- * event(s) or any marker sharing a selected venue (so a cluster containing
- * a selected show also highlights), red otherwise.
+/** The "events" layer's `icon-color` expression: `selectedColor` for the
+ * selected event(s) or any marker sharing a selected venue (so a cluster
+ * containing a selected show also highlights), `defaultColor` otherwise.
  *
  * Consolidates two expressions that had quietly drifted apart: layer
  * creation matched *any* selected id (`"in"`), while the reactive
  * selection-change update only ever matched `selectedEvents[0]`'s id
  * (`"=="`) -- so a multi-event selection (e.g. from clicking a cluster)
  * only highlighted one marker after the first update. This is the "in"
- * behavior, used everywhere now. */
-export function eventIconImageExpression(
-  selectedEvents: EventResponse[]
+ * behavior, used everywhere now.
+ *
+ * Colors are passed in rather than hardcoded so this stays a pure,
+ * DOM-free function -- see `resolveCssColor` for how the caller resolves
+ * the app's actual accent tokens at runtime. */
+export function eventIconColorExpression(
+  selectedEvents: EventResponse[],
+  defaultColor: string,
+  selectedColor: string
 ): ExpressionSpecification {
   return [
     "case",
     ["in", ["get", "id"], ["literal", selectedEvents.map((e) => e.id)]],
-    "marker-yellow",
+    selectedColor,
     [
       "in",
       ["get", "clusterVenue"],
       ["literal", selectedEvents.map((e) => e.venue?.name)],
     ],
-    "marker-yellow",
-    "marker-red",
+    selectedColor,
+    defaultColor,
   ] as unknown as ExpressionSpecification
+}
+
+/** Resolves a CSS custom property (e.g. "--accent-bg") to a plain
+ * `rgba()` string, honoring whichever of .light/.dark is currently on
+ * <html> -- Mapbox GL expressions need a real color, and these tokens are
+ * defined in OKLCH, which its color parser can't read directly.
+ *
+ * Not `getComputedStyle(el).color`: modern browsers increasingly preserve
+ * the original color syntax there (returning the oklch() string back
+ * unchanged) rather than always normalizing to rgb(), which is exactly
+ * the syntax Mapbox can't parse. Painting onto a canvas and reading the
+ * pixel back sidesteps that -- canvas `fillStyle` accepts any CSS color
+ * syntax, and `getImageData` always returns concrete 0-255 sRGB bytes
+ * regardless of how the color was originally specified. */
+export function resolveCssColor(varName: string): string {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim()
+
+  const canvas = document.createElement("canvas")
+  canvas.width = 1
+  canvas.height = 1
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return raw
+
+  ctx.fillStyle = raw
+  ctx.fillRect(0, 0, 1, 1)
+  const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data
+  return `rgba(${r}, ${g}, ${b}, ${a / 255})`
 }
 
 /** Resolves Mapbox feature ids (from a click or `getClusterChildren`) back


### PR DESCRIPTION
## Summary
Follow-up to the tablet/map fixes in #87 — implements the "custom map markers in the accent color" item flagged in the earlier UI critique as a missed signature-detail opportunity.

- Replaces Mapbox's stock `marker-red`/`marker-yellow` sprite icons with a single custom pin loaded as an SDF image, tinted at render time via the `"events"` layer's `icon-color` paint property (same technique already used for `icon-halo-color`/`text-color`).
- Unselected markers use `--accent-bg` (toasted-almond) — the same token as the Tickets/Listen CTA. Selected markers use `--color-blush-rose-500`. Both already exist in the app's token system; no new colors introduced.
- `eventIconImageExpression` → `eventIconColorExpression`: same selection-matching logic (by id or shared cluster venue), now returning colors instead of sprite ids.
- Added `resolveCssColor`, which resolves a CSS custom property to a plain `rgba()` string by painting it onto a canvas and reading the pixel back. `getComputedStyle(el).color` turned out to preserve the raw `oklch()` syntax rather than normalizing to `rgb()` in the browser I tested in, which Mapbox's color parser can't read — the canvas round-trip sidesteps that regardless of how the color was originally specified.
- Fixed a race the async image-load introduced: `useEventLayer`'s effect can re-run many times in quick succession while events stream in, and without a guard, multiple re-runs could all observe "no source yet" before the first one's `addImage` resolved, each then trying `addSource` again. `layerSetupRef` claims setup synchronously before that async gap opens.

## Test plan
- [x] `pnpm typecheck` and `pnpm test` (119 tests) pass
- [x] Verified visually: markers render as accent-colored pins with a white halo at both city-wide and zoomed-in levels; clicking a marker/cluster recolors it to the selected (blush-rose) color while others stay accent
- [x] Verified `resolveCssColor` picks up the correct `.dark`-scoped token value when the app theme is toggled (the underlying Mapbox style itself is tied to system `prefers-color-scheme`, a separate pre-existing behavior not touched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)