### PR TITLE
Backfill title-derived performer for unmatched PredictHQ events

### DIFF
--- a/apps/api/src/events/stream.rs
+++ b/apps/api/src/events/stream.rs
@@ -200,6 +200,28 @@ pub async fn get_concerts_tm_stream(
                             }),
                     );
 
+                    // These events already survived `reconcile_predicthq_events`
+                    // (that's what makes them "new" rather than a Ticketmaster
+                    // enrichment), so it's safe to backfill `performers` from
+                    // the title now for the same ~28%-with-no-structured-
+                    // entity case `performer_search_names` covers above -- see
+                    // `predicthq::backfill_title_performer`'s doc comment for
+                    // why this must not run any earlier. Without this, an
+                    // event in that ~28% has no `performers` for the
+                    // frontend's on-demand `/artists/enrichment` fetch (and
+                    // this branch's own `attach_genres` call below) to key
+                    // off at all, even though `spawn_enrichment` above
+                    // already resolves and persists full canonical-artist
+                    // data (Spotify included) for it under the same
+                    // title-derived name -- data the frontend then has no
+                    // way to ask for.
+                    for event in events
+                        .iter_mut()
+                        .filter(|event| is_music_classified(event))
+                    {
+                        crate::predicthq::backfill_title_performer(event);
+                    }
+
                     crate::artists::attach_genres(&mut events, &state.db.pool).await;
 
                     for mut event in events {

--- a/apps/api/src/events/types.rs
+++ b/apps/api/src/events/types.rs
@@ -96,9 +96,10 @@ pub struct ArtistEnrichment {
     pub name: String,
     pub id: String,
     pub apple_music_url: Option<String>,
-    /// `None` for an artist matched via Apple Music with no Spotify
-    /// identity recorded (`try_apple_music_match` never looks Spotify up
-    /// once Apple already verified a match — see `artists::worker`), not
+    /// `None` when Spotify's own catalog search found no confident
+    /// exact-normalized-name match for this artist (both providers are
+    /// always searched concurrently, regardless of whether Apple Music
+    /// also matched — see `artists::worker::resolve_fresh`), not
     /// necessarily an artist Spotify itself has no page for.
     pub spotify_url: Option<String>,
     pub artwork: Option<ArtistArtwork>,

--- a/apps/api/src/predicthq/mod.rs
+++ b/apps/api/src/predicthq/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod source;
 
 pub(crate) use artwork::backfill_artwork;
 
-use crate::events::types::EventResponse;
+use crate::events::types::{EventResponse, Performer};
 
 /// Names to search for `event`'s performer(s), in priority order. Falls
 /// back to the event's own title when there's no structured performer
@@ -40,6 +40,37 @@ pub(crate) fn performer_search_names(event: &EventResponse) -> Vec<String> {
     }
 
     vec![event.name.clone()]
+}
+
+/// Gives `event` a single title-derived performer when it has none at all --
+/// the same ~28%-with-no-structured-entity case `performer_search_names`
+/// already falls back for, but writing the result onto `event.performers`
+/// itself (rather than just returning a search name) so callers that key
+/// off `performers` -- the frontend's on-demand `/artists/enrichment` fetch,
+/// and `crate::artists::attach_genres` -- have something to find, not just
+/// `predicthq::artwork::backfill_artwork` and `crate::artists::worker`
+/// (which already call `performer_search_names` directly). `id: None`, same
+/// as everywhere else an id-less performer is rendered -- there's no real
+/// PredictHQ entity behind this one.
+///
+/// Only ever safe to call *after* `crate::events::reconcile::reconcile_predicthq_events`
+/// has already run against this event (see `events::stream`'s
+/// `MergeStep::PredictHqNew` handling, the one caller) -- reconciliation's
+/// own performer-name confirmation step relies on `performers` still being
+/// `None` at that point to allow a venue+date-only match for a real act
+/// PredictHQ just didn't tag, and a synthetic performer here would silently
+/// demand an exact name match instead.
+pub(crate) fn backfill_title_performer(event: &mut EventResponse) {
+    if event.performers.is_none() {
+        event.performers = Some(vec![Performer {
+            name: Some(event.name.clone()),
+            id: None,
+            classifications: None,
+            external_links: None,
+            images: None,
+            genres: vec![],
+        }]);
+    }
 }
 
 #[cfg(test)]
@@ -103,5 +134,26 @@ mod tests {
             performer_search_names(&event),
             vec!["Role Model".to_string()]
         );
+    }
+
+    #[test]
+    fn backfill_title_performer_fills_in_a_synthetic_performer_when_none() {
+        let mut event = phq_event("Craig LaGrassa", None);
+        backfill_title_performer(&mut event);
+
+        let performers = event.performers.expect("expected a synthetic performer");
+        assert_eq!(performers.len(), 1);
+        assert_eq!(performers[0].name.as_deref(), Some("Craig LaGrassa"));
+        assert_eq!(performers[0].id, None);
+    }
+
+    #[test]
+    fn backfill_title_performer_leaves_real_performers_untouched() {
+        let mut event = phq_event("The Sauce w/ Jeff Beam", Some("Jeff Beam"));
+        backfill_title_performer(&mut event);
+
+        let performers = event.performers.expect("expected the real performer");
+        assert_eq!(performers.len(), 1);
+        assert_eq!(performers[0].name.as_deref(), Some("Jeff Beam"));
     }
 }

--- a/apps/api/src/predicthq/normalize.rs
+++ b/apps/api/src/predicthq/normalize.rs
@@ -88,6 +88,18 @@ pub(crate) fn normalize_predicthq_event(e: PredictHqEvent) -> EventResponse {
         dates_pretty,
         local_calendar_day,
         classifications: Some(build_classifications(e.phq_labels.as_deref())),
+        // Deliberately left `None` rather than falling back to the event
+        // title here (unlike `performer_search_names`'s own title fallback,
+        // used for artwork/enrichment lookups) -- `reconcile_predicthq_events`
+        // runs on this same normalized event next, and its performer-name
+        // confirmation step treats "neither side has performer data" as
+        // permission to match on venue+date alone (the real-world case this
+        // guards: an act with no structured PredictHQ entity, still the same
+        // show as its Ticketmaster listing). A synthetic title-derived
+        // performer here would silently demand an exact name match instead,
+        // breaking that case. See `events::stream`'s `MergeStep::PredictHqNew`
+        // handling for where the title fallback is applied instead, once
+        // reconciliation has already run.
         performers,
         url: None,
         price_ranges: None,

--- a/apps/web/src/hooks/eventsStreamSchema.ts
+++ b/apps/web/src/hooks/eventsStreamSchema.ts
@@ -73,10 +73,12 @@ const amArtistSchema = z.object({
 /** `spotify_url` is on the *full* schema, not `amArtistSchema` above --
  * similar artists only ever come from Apple Music's similar-artists view
  * (see apps/api/src/artists/worker.rs module docs), so they never carry
- * one. Also asymmetric with `apple_music_url`: an artist matched via Apple
- * Music (the common case) never gets a Spotify lookup at all, so
- * `spotify_url` being absent doesn't mean Spotify has no page for them --
- * see apps/api/src/events/types.rs's `ArtistEnrichment::spotify_url` doc
+ * one. Both providers are always searched concurrently regardless of which
+ * one ends up winning identity/display fields (see
+ * apps/api/src/artists/worker.rs's `resolve_fresh`), so `spotify_url` being
+ * absent just means Spotify's own catalog search found no confident match --
+ * not that Spotify has no page for them -- see
+ * apps/api/src/events/types.rs's `ArtistEnrichment::spotify_url` doc
  * comment. */
 const amArtistFullSchema = amArtistSchema.extend({
   spotify_url: optional(z.string()),


### PR DESCRIPTION
## Summary
- ~28% of PredictHQ events have no structured performer entity, so `EventResponse.performers` stayed `None` — cutting off the frontend's on-demand `/artists/enrichment` fetch and `attach_genres`, even though `spawn_enrichment` had already resolved and persisted full Apple Music + Spotify data for the artist in the background via a title-fallback name.
- Confirmed live on Craig LaGrassa's "Old Orchard Beach" event: a fully Spotify-matched `artists` row existed, but zero `/artists/enrichment` calls ever fired and no Spotify link/genre/related artists rendered — only the artwork/listen link `predicthq::artwork::backfill_artwork` populates independently.
- Adds `predicthq::backfill_title_performer`, called only from `events::stream`'s `MergeStep::PredictHqNew` handling — i.e. only after an event has already survived `reconcile_predicthq_events`. Doing this earlier (inside `normalize_predicthq_event`) would break that reconciliation step's "neither side has performer data → match on venue+date alone" rule (the tested "Barr Brothers case"), reintroducing duplicate cards for real acts PredictHQ just didn't tag with a structured entity.
- Fixes two stale doc comments (`apps/api/src/events/types.rs`, `apps/web/src/hooks/eventsStreamSchema.ts`) claiming Spotify is never looked up once Apple Music matches an artist — untrue since both providers have been searched concurrently since e6305af.

## Test plan
- [x] `cargo build --lib` — clean
- [x] `cargo test --lib` — 128 passed (2 new), 0 failed
- [x] `cargo clippy --lib --tests` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] `tsc --noEmit` on `apps/web` — no new errors (doc-comment-only frontend change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)