### PR TITLE
Mobile drawer: draggable overlay with peek/half/full snap points

### DIFF
--- a/apps/web/src/AppWrapper.tsx
+++ b/apps/web/src/AppWrapper.tsx
@@ -1,7 +1,5 @@
 import { lazy, Suspense } from "react"
-import { DrawerWrapper } from "./Drawer/DrawerWrapper"
 import { Search } from "./Search"
-import { useIsMobile } from "./providers/Breakpoint"
 import { AppHeader } from "./Header"
 
 const MapWrapper = lazy(() =>
@@ -18,7 +16,6 @@ const AppWrapper = () => {
         <Suspense fallback={null}>
           <MapWrapper />
         </Suspense>
-        {useIsMobile() && <DrawerWrapper />}
       </div>
     </div>
   )

--- a/apps/web/src/Drawer/DrawerWrapper.tsx
+++ b/apps/web/src/Drawer/DrawerWrapper.tsx
@@ -14,8 +14,18 @@ import { VenueDetails } from "../VenueDetails"
 import { EventsDrawer, EventsDrawerHeader } from "./EventsDrawer"
 import { useTopMostVisibleInScrollContainer } from "../hooks/listItemObserver"
 import type { Key } from "react-aria-components/Tabs"
-import { useDrawerProvider } from "@/providers/drawerProvider"
+import { useDrawerProvider, type DrawerSnapPoint } from "@/providers/drawerProvider"
 import { groupEvents } from "../lib/groupEvents"
+
+// Matches AppHeader's h-16 (apps/web/src/Header.tsx) -- kept as a constant
+// here rather than measured, since the header's own height never changes.
+const HEADER_HEIGHT_PX = 64
+const SNAP_FRACTIONS: Record<DrawerSnapPoint, number> = {
+  peek: 0.15,
+  half: 0.5,
+  full: 0.88,
+}
+const SNAP_ORDER: DrawerSnapPoint[] = ["peek", "half", "full"]
 
 const PlaylistsDrawerBody = lazy(() =>
   import("./PlaylistsDrawer").then((m) => ({ default: m.PlaylistsDrawerBody }))
@@ -89,8 +99,10 @@ const DestinationIcon = ({
 
 const DrawerWrapper = () => {
   const { eventsByDate, selectedEvents, isStreaming } = useEventsContext()
-  const { isDrawerOpen, setIsDrawerOpen } = useDrawerProvider()
+  const { isDrawerOpen, setIsDrawerOpen, snapPoint, setSnapPoint } =
+    useDrawerProvider()
   const shouldReduceMotion = useReducedMotion()
+  const isDesktop = !useIsMobile()
 
   const [activeTab, setActiveTab] = useState<Key>("explore")
   const eventsScrollRef = useRef<HTMLDivElement>(null)
@@ -98,6 +110,13 @@ const DrawerWrapper = () => {
     eventsScrollRef,
     { offsetTop: 0 }
   )
+
+  const entries = Object.entries(eventsByDate).sort()
+  // A single group means selectedEvents is either one event, or several
+  // showtimes of the *same* event (selected via a GroupedEventCard) — both
+  // go to EventDetails. More than one group means genuinely distinct events
+  // (e.g. a venue-marker click), which go to VenueDetails.
+  const selectedGroups = groupEvents(selectedEvents)
 
   const handleDestinationTab = useCallback(
     (tab: Key) => {
@@ -116,13 +135,16 @@ const DrawerWrapper = () => {
     // Syncs drawer visibility/active tab to event selection, which is owned
     // by a different provider (eventsProvider) — not derivable at render
     // time without lifting that state up or touching every selectEvents()
-    // call site (map marker clicks, drawer list clicks, etc.).
+    // call site (map marker clicks, drawer list clicks, etc.). Mobile also
+    // jumps to "full" so the just-selected event/venue is actually readable
+    // rather than left at whatever height the sheet happened to be at.
     if (selectedEvents.length) {
       setIsDrawerOpen(true)
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setActiveTab("explore")
+      if (!isDesktop) setSnapPoint("full")
     }
-  }, [selectedEvents, setIsDrawerOpen])
+  }, [selectedEvents, setIsDrawerOpen, isDesktop, setSnapPoint])
 
   // Switches to the Explore tab when a new search starts (e.g. the caller
   // is on the Spotify/Apple Music tab, then moves the map or changes the
@@ -135,23 +157,52 @@ const DrawerWrapper = () => {
   // dozens of times over the course of a single search -- switching tabs
   // on every one of those would be exactly the kind of repeated,
   // twitchy interruption this behavior is meant to avoid, not cause.
+  //
+  // Mobile also drives the sheet's height off the same transition: peek
+  // the moment a search starts (keep the map visible while results are
+  // still uncertain), then rise to half once streaming finishes with
+  // results and nothing's selected (selection, handled above, wins if
+  // both land in the same commit).
   const wasStreamingRef = useRef(isStreaming)
   useEffect(() => {
-    const searchJustStarted = isStreaming && !wasStreamingRef.current
+    const wasStreaming = wasStreamingRef.current
     wasStreamingRef.current = isStreaming
-    if (searchJustStarted) {
+    if (isStreaming && !wasStreaming) {
       handleDestinationTab("explore")
+      if (!isDesktop) setSnapPoint("peek")
+    } else if (!isStreaming && wasStreaming) {
+      if (!isDesktop && entries.length > 0 && selectedGroups.length === 0) {
+        setSnapPoint("half")
+      }
     }
-  }, [isStreaming, handleDestinationTab])
+  }, [
+    isStreaming,
+    handleDestinationTab,
+    isDesktop,
+    setSnapPoint,
+    entries.length,
+    selectedGroups.length,
+  ])
 
-  const isDesktop = !useIsMobile()
+  // Mirrors Breakpoint.tsx's own resize-listener pattern rather than a
+  // ResizeObserver -- this only needs the window's own size, not any
+  // particular element's.
+  const [viewportHeight, setViewportHeight] = useState(
+    () => window.innerHeight
+  )
+  useEffect(() => {
+    const onResize = () => setViewportHeight(window.innerHeight)
+    window.addEventListener("resize", onResize)
+    return () => window.removeEventListener("resize", onResize)
+  }, [])
 
-  const entries = Object.entries(eventsByDate).sort()
-  // A single group means selectedEvents is either one event, or several
-  // showtimes of the *same* event (selected via a GroupedEventCard) — both
-  // go to EventDetails. More than one group means genuinely distinct events
-  // (e.g. a venue-marker click), which go to VenueDetails.
-  const selectedGroups = groupEvents(selectedEvents)
+  // Pixel snap points for the mobile bottom sheet, ascending
+  // [peek, half, full]. Desktop never reads these.
+  const sheetContainerHeightPx = viewportHeight - HEADER_HEIGHT_PX
+  const snapPointsPx = SNAP_ORDER.map((point) =>
+    Math.round(sheetContainerHeightPx * SNAP_FRACTIONS[point])
+  )
+  const activeSnapIndex = SNAP_ORDER.indexOf(snapPoint)
 
   // Kept in lockstep with the DrawerContent slide transition in the shared
   // Drawer component, so the reserved layout width and the visible slide
@@ -165,9 +216,16 @@ const DrawerWrapper = () => {
   const drawerContent = (
     <DrawerContent
       isOpen={isDrawerOpen}
-      closeDrawer={() => setIsDrawerOpen(false)}
-      notch={false}
+      closeDrawer={
+        isDesktop ? () => setIsDrawerOpen(false) : () => setSnapPoint("peek")
+      }
+      notch={!isDesktop}
       side={isDesktop ? "left" : "bottom"}
+      snapPointsPx={isDesktop ? undefined : snapPointsPx}
+      activeSnapIndex={isDesktop ? undefined : activeSnapIndex}
+      onSnapChange={
+        isDesktop ? undefined : (i: number) => setSnapPoint(SNAP_ORDER[i])
+      }
       className={
         isDesktop
           ? "z-10 flex h-full w-[26rem] flex-col overflow-hidden"
@@ -188,7 +246,7 @@ const DrawerWrapper = () => {
       {!isDesktop && (
         <TabList
           aria-label="Content sections"
-          className="my-1 flex shrink-0 items-center justify-center gap-1 border-b border-black/10 px-2 dark:border-white/10"
+          className="mt-4 mb-1 flex shrink-0 items-center justify-center gap-1 border-b border-black/10 px-2 dark:border-white/10"
         >
           {destinationTabs.map(({ id, label }) => (
             <Tab
@@ -252,7 +310,14 @@ const DrawerWrapper = () => {
   return (
     <Tabs
       orientation={isDesktop ? "vertical" : "horizontal"}
-      className="h-[60vh] shrink-0 md:h-full"
+      // Desktop: unchanged, a normal flex sidebar item. Mobile: an
+      // absolutely-positioned overlay (see MapWrapper.tsx, which now
+      // renders this inside the map's own relative container) sized to
+      // the "full" snap height -- DrawerContent's drag/spring then
+      // translates within that fixed box rather than the box itself
+      // resizing per snap point.
+      className={isDesktop ? "h-full shrink-0" : "absolute inset-x-0 bottom-0"}
+      style={isDesktop ? undefined : { height: snapPointsPx[2] }}
       selectedKey={activeTab}
       onSelectionChange={(t) => handleDestinationTab(t)}
     >

--- a/apps/web/src/MapWrapper.tsx
+++ b/apps/web/src/MapWrapper.tsx
@@ -11,16 +11,19 @@ import { useResizeFix } from "./hooks/useResizeFix"
 import { useMapCamera } from "./hooks/useMapCamera"
 import { useEventLayer } from "./hooks/useEventLayer"
 import { useClusterSelection } from "./hooks/useClusterSelection"
+import { useCollapseDrawerOnMapTap } from "./hooks/useCollapseDrawerOnMapTap"
 import { locationFromFeature } from "./lib/mapbox"
 import { DrawerWrapper } from "./Drawer/DrawerWrapper"
 import { SearchThisAreaButton } from "./SearchThisAreaButton"
 import { useIsMobile } from "./providers/Breakpoint"
+import { useDrawerProvider } from "./providers/drawerProvider"
 import "mapbox-gl/dist/mapbox-gl.css"
 import "./App.css"
 
 const MapWrapper = () => {
   const { selectedCoordinates, setSelectedLocation } = useSearchProvider()
   const { mapView, isRestoredMapView } = useMapViewProvider()
+  const { setSnapPoint } = useDrawerProvider()
   const navigateToLocation = useNavigateToLocation()
   const [rendered, setRendered] = useState(false)
   useEffect(() => {
@@ -123,6 +126,12 @@ const MapWrapper = () => {
   useEventLayer(mapRef, visibleEventsByDate, selectedEvents, selectEvents)
   useClusterSelection(mapRef, visibleEventsByDate, selectEvents)
 
+  const handleCollapseDrawer = useCallback(
+    () => setSnapPoint("peek"),
+    [setSnapPoint]
+  )
+  useCollapseDrawerOnMapTap(mapRef, useIsMobile(), handleCollapseDrawer)
+
   useEffect(() => {
     // Only flies when there's a selected event with a venue location --
     // matches useEventLayer's icon-highlight guard, since both come from
@@ -154,13 +163,14 @@ const MapWrapper = () => {
     <>
       <div className="relative flex min-h-0 flex-1">
         {!useIsMobile() && <DrawerWrapper />}
-        <div className="relative h-full w-full">
+        <div className="relative h-full w-full overflow-hidden">
           <div
             ref={mapContainer}
             id="map-container"
             className="h-full w-full"
           />
           <SearchThisAreaButton onSearchThisArea={handleSearchThisArea} />
+          {useIsMobile() && <DrawerWrapper />}
         </div>
       </div>
     </>

--- a/apps/web/src/hooks/useClusterSelection.ts
+++ b/apps/web/src/hooks/useClusterSelection.ts
@@ -19,7 +19,15 @@ export function useClusterSelection(
     map.addInteraction("event-click-interaction", {
       type: "click",
       target: { layerId: "events" },
-      handler: ({ feature }: InteractionEvent) => {
+      handler: (interactionEvent: InteractionEvent) => {
+        // Stops this click from also reaching the untargeted map-tap
+        // interaction that collapses the drawer to peek
+        // (useCollapseDrawerOnMapTap) -- interactions are a stack, not
+        // automatically mutually exclusive by target, so without this a
+        // marker/cluster tap would select the event *and* collapse the
+        // sheet in the same gesture.
+        interactionEvent.preventDefault()
+        const { feature } = interactionEvent
         const [event] = resolveEventsByIds(eventsByDate, [feature?.id])
         if (event) {
           selectEvents([event])

--- a/apps/web/src/hooks/useCollapseDrawerOnMapTap.ts
+++ b/apps/web/src/hooks/useCollapseDrawerOnMapTap.ts
@@ -1,0 +1,30 @@
+import { useEffect, type RefObject } from "react"
+import type { Map as MapboxMap } from "mapbox-gl"
+
+/** Collapses the mobile bottom sheet to "peek" when the user taps open map
+ * area (not a marker/cluster). An untargeted `click` interaction -- unlike
+ * useClusterSelection's/useMapInstance's own targeted ones, this has no
+ * `target`, so it would also fire on a marker/cluster tap (interactions
+ * are a stack, not automatically mutually exclusive by target) if those
+ * handlers didn't already call `event.preventDefault()` to stop it from
+ * reaching this one. `enabled` is expected to be `isMobile` -- desktop's
+ * sidebar has no snap points to collapse. */
+export function useCollapseDrawerOnMapTap(
+  mapRef: RefObject<MapboxMap | null>,
+  enabled: boolean,
+  onCollapse: () => void
+) {
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !enabled) return
+
+    map.addInteraction("map-tap-collapse-drawer", {
+      type: "click",
+      handler: () => onCollapse(),
+    })
+
+    return () => {
+      map.removeInteraction("map-tap-collapse-drawer")
+    }
+  }, [mapRef, enabled, onCollapse])
+}

--- a/apps/web/src/hooks/useMapInstance.ts
+++ b/apps/web/src/hooks/useMapInstance.ts
@@ -84,7 +84,14 @@ export function useMapInstance(
     mapRef.current?.addInteraction("map-click", {
       type: "click",
       target: { layerId: "events" },
-      handler: () => {
+      handler: (event) => {
+        // A click that hit a feature on this layer is handled here (and
+        // by useClusterSelection's own targeted interaction) -- stop it
+        // from also reaching the untargeted map-tap-collapses-drawer
+        // interaction (useCollapseDrawerOnMapTap), which would otherwise
+        // also fire on the same click since interactions are a stack,
+        // not automatically mutually exclusive by target.
+        event.preventDefault()
         if (selectedFeature) {
           mapRef.current?.setFeatureState(selectedFeature, { selected: false })
           setSelectedFeature(null)

--- a/apps/web/src/providers/drawerProvider.tsx
+++ b/apps/web/src/providers/drawerProvider.tsx
@@ -1,9 +1,17 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useState, useContext, createContext } from "react"
 
+/** Mobile-only bottom-sheet height. Desktop's sidebar has no notion of
+ * this -- it only ever reads isDrawerOpen. "peek" is the practical floor:
+ * there's no true "closed" state on mobile (no close button renders
+ * there), so peek stands in for it. */
+export type DrawerSnapPoint = "peek" | "half" | "full"
+
 type DrawerProviderState = {
   isDrawerOpen: boolean
   setIsDrawerOpen: (isOpen: boolean) => void
+  snapPoint: DrawerSnapPoint
+  setSnapPoint: (point: DrawerSnapPoint) => void
 }
 
 type DrawerProviderProps = {
@@ -16,12 +24,15 @@ export const DrawerProviderContext = createContext<
 
 export function DrawerProvider({ children }: DrawerProviderProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState<boolean>(true)
+  const [snapPoint, setSnapPoint] = useState<DrawerSnapPoint>("peek")
 
   return (
     <DrawerProviderContext
       value={{
         isDrawerOpen,
         setIsDrawerOpen,
+        snapPoint,
+        setSnapPoint,
       }}
     >
       {children}

--- a/packages/ui/src/components/ui/Drawer.tsx
+++ b/packages/ui/src/components/ui/Drawer.tsx
@@ -2,11 +2,13 @@
 
 import {
   AnimatePresence,
+  animate,
   motion,
   useDragControls,
+  useMotionValue,
   useReducedMotion,
 } from "motion/react"
-import { use, Children, cloneElement } from "react"
+import { use, Children, cloneElement, useEffect, useRef } from "react"
 import type { Ref } from "react"
 import type {
   DialogProps,
@@ -51,7 +53,27 @@ interface DrawerContentProps
   side?: "top" | "bottom" | "left" | "right"
   notch?: boolean
   closeDrawer: () => void
+  /** Ascending pixel heights for a draggable multi-snap bottom sheet
+   * (e.g. [peekPx, halfPx, fullPx]) -- side="bottom" only. Omit for the
+   * regular binary open/close sheet every other caller uses; when
+   * omitted, drag/animate behavior is byte-identical to before this
+   * feature existed. */
+  snapPointsPx?: number[]
+  /** Index into snapPointsPx for the currently-settled snap. */
+  activeSnapIndex?: number
+  /** Fired when a drag gesture resolves to a snap index (possibly
+   * unchanged from activeSnapIndex -- the sheet still re-settles to the
+   * exact target pixel position either way). */
+  onSnapChange?: (index: number) => void
 }
+
+// Matches the bounce feel already established by dragTransition below,
+// expressed as a real spring transition (not dragTransition, which only
+// governs live elastic recoil *during* a drag, not this post-release
+// settle) -- used both by the settle effect and directly in onDragEnd.
+const SNAP_SPRING = { type: "spring", stiffness: 600, damping: 20 } as const
+const FLING_VELOCITY_THRESHOLD = 500 // px/s
+const VELOCITY_PROJECTION_SECONDS = 0.15
 
 const DrawerContent = ({
   side = "bottom",
@@ -60,6 +82,9 @@ const DrawerContent = ({
   closeDrawer = () => {},
   children,
   className,
+  snapPointsPx,
+  activeSnapIndex,
+  onSnapChange,
   ...props
 }: DrawerContentProps) => {
   const state = use(OverlayTriggerStateContext)!
@@ -69,6 +94,150 @@ const DrawerContent = ({
     x: side === "left" ? "-100%" : side === "right" ? "100%" : 0,
     y: side === "top" ? "-100%" : side === "bottom" ? "100%" : 0,
   }
+
+  const isMultiSnapBottom =
+    side === "bottom" &&
+    !!snapPointsPx &&
+    snapPointsPx.length > 1 &&
+    activeSnapIndex !== undefined
+
+  // Downward-translate targets, one per snap point -- the smallest height
+  // (peek) is the *largest* y (most pushed down); the tallest (full) is
+  // always y=0. Only meaningful when isMultiSnapBottom, but computed
+  // unconditionally since hooks below need a stable reference either way.
+  const snapYs = (snapPointsPx ?? []).map(
+    (h) => (snapPointsPx ?? [])[(snapPointsPx ?? []).length - 1] - h
+  )
+
+  // Controlled motion value: bound to the element via `style` below so a
+  // live drag gesture and this settle effect / onDragEnd's imperative
+  // animate() both read and write the exact same value, with no jump
+  // between "being dragged" and "being programmatically animated".
+  const ySpring = useMotionValue(
+    isMultiSnapBottom ? snapYs[activeSnapIndex!] : 0
+  )
+
+  // Settles ySpring whenever activeSnapIndex changes from *outside* a drag
+  // (e.g. DrawerWrapper's auto-transition effects calling setSnapPoint).
+  // The drag-driven case settles immediately inside onDragEnd itself,
+  // below -- this effect is what covers the non-drag path. Skips the
+  // spring (jumps instantly) when only snapPointsPx changed -- e.g. a
+  // viewport resize -- so that alone never produces a visible bounce.
+  const prevSnapPointsPxRef = useRef(snapPointsPx)
+  useEffect(() => {
+    if (!isMultiSnapBottom || activeSnapIndex === undefined) return
+    const onlyPointsChanged = prevSnapPointsPxRef.current !== snapPointsPx
+    prevSnapPointsPxRef.current = snapPointsPx
+    const controls = animate(
+      ySpring,
+      snapYs[activeSnapIndex],
+      shouldReduceMotion || onlyPointsChanged ? { duration: 0 } : SNAP_SPRING
+    )
+    return () => controls.stop()
+    // snapYs is derived fresh from snapPointsPx every render (new array
+    // identity each time) -- depending on snapPointsPx itself is the
+    // correct, stable trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMultiSnapBottom, activeSnapIndex, snapPointsPx, shouldReduceMotion])
+
+  const handleBinaryDragEnd = (
+    _: React.MouseEvent<HTMLDivElement>,
+    {
+      offset,
+      velocity,
+    }: {
+      offset: { x: number; y: number }
+      velocity: { x: number; y: number }
+    }
+  ) => {
+    if (
+      side === "bottom" &&
+      (velocity.y > 150 || offset.y > screen.height * 0.25)
+    ) {
+      closeDrawer()
+    }
+    if (
+      side === "top" &&
+      (velocity.y < -150 || offset.y < screen.height * 0.25)
+    ) {
+      state.close()
+    }
+    if (side === "left" && velocity.x < -150) {
+      closeDrawer()
+    }
+    if (side === "right" && velocity.x > 150) {
+      state.close()
+    }
+  }
+
+  // Velocity-weighted nearest-snap resolution. Projects the release point
+  // forward by its velocity before picking the nearest snap (so a fast
+  // drag that hasn't visually reached the next point yet still commits to
+  // it), then separately checks a pure position-only read: if that agrees
+  // with the projected pick (i.e. "stayed put") but the release was a fast
+  // flick, forces one step in the fling's direction anyway -- otherwise a
+  // quick short flick near a boundary would resolve to doing nothing,
+  // which reads as broken/unresponsive.
+  const handleMultiSnapDragEnd = (
+    _: React.MouseEvent<HTMLDivElement>,
+    {
+      velocity,
+    }: {
+      offset: { x: number; y: number }
+      velocity: { x: number; y: number }
+    }
+  ) => {
+    if (!snapPointsPx || activeSnapIndex === undefined || !onSnapChange) {
+      return
+    }
+
+    const current = ySpring.get()
+    const projected = current + velocity.y * VELOCITY_PROJECTION_SECONDS
+    const clamped = Math.min(Math.max(projected, 0), snapYs[0])
+
+    let nearestToProjected = 0
+    let nearestToProjectedDist = Infinity
+    let nearestToCurrent = 0
+    let nearestToCurrentDist = Infinity
+    snapYs.forEach((y, i) => {
+      const projectedDist = Math.abs(y - clamped)
+      if (projectedDist < nearestToProjectedDist) {
+        nearestToProjectedDist = projectedDist
+        nearestToProjected = i
+      }
+      const currentDist = Math.abs(y - current)
+      if (currentDist < nearestToCurrentDist) {
+        nearestToCurrentDist = currentDist
+        nearestToCurrent = i
+      }
+    })
+
+    let resolvedIndex = nearestToProjected
+    if (
+      nearestToProjected === nearestToCurrent &&
+      Math.abs(velocity.y) > FLING_VELOCITY_THRESHOLD
+    ) {
+      // y decreases toward "full" -- a fast upward drag (negative
+      // velocity.y) advances the index; downward retreats it.
+      const direction = velocity.y < 0 ? 1 : -1
+      resolvedIndex = Math.min(
+        Math.max(nearestToCurrent + direction, 0),
+        snapYs.length - 1
+      )
+    }
+
+    // Settle immediately regardless of whether the index actually
+    // changed -- a released drag rarely lands exactly on the target
+    // pixel, so this is what guarantees the sheet always ends up exactly
+    // at a real snap position rather than wherever the gesture let go.
+    animate(
+      ySpring,
+      snapYs[resolvedIndex],
+      shouldReduceMotion ? { duration: 0 } : SNAP_SPRING
+    )
+    onSnapChange(resolvedIndex)
+  }
+
   return (
     <AnimatePresence>
       {(props?.isOpen || state?.isOpen) && (
@@ -101,58 +270,49 @@ const DrawerContent = ({
               ].join(" "),
             className
           )}
-          animate={{ x: 0, y: 0, opacity: 1 }}
-          initial={shouldReduceMotion ? { opacity: 0 } : { ...offscreen, opacity: 1 }}
-          exit={shouldReduceMotion ? { opacity: 0 } : { ...offscreen, opacity: 1 }}
+          style={isMultiSnapBottom ? { y: ySpring } : undefined}
+          animate={
+            isMultiSnapBottom ? { x: 0, opacity: 1 } : { x: 0, y: 0, opacity: 1 }
+          }
+          initial={
+            shouldReduceMotion
+              ? { opacity: 0 }
+              : isMultiSnapBottom
+                ? { x: 0, opacity: 1 }
+                : { ...offscreen, opacity: 1 }
+          }
+          exit={
+            shouldReduceMotion
+              ? { opacity: 0 }
+              : isMultiSnapBottom
+                ? { x: 0, opacity: 1 }
+                : { ...offscreen, opacity: 1 }
+          }
           drag={side === "left" || side === "right" ? "x" : "y"}
           whileDrag={{ cursor: "grabbing" }}
-          dragConstraints={{
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-          }}
+          dragConstraints={
+            isMultiSnapBottom
+              ? { top: 0, bottom: snapYs[0], left: 0, right: 0 }
+              : { top: 0, bottom: 0, left: 0, right: 0 }
+          }
           dragControls={dragControls}
           dragTransition={{
             bounceStiffness: 600,
             bounceDamping: 20,
           }}
+          dragMomentum={!isMultiSnapBottom}
           transition={{ duration: 0.15, ease: "easeInOut" }}
-          onDragEnd={(
-            _: React.MouseEvent<HTMLDivElement>,
-            {
-              offset,
-              velocity,
-            }: {
-              offset: { x: number; y: number }
-              velocity: { x: number; y: number }
-            }
-          ) => {
-            if (
-              side === "bottom" &&
-              (velocity.y > 150 || offset.y > screen.height * 0.25)
-            ) {
-              closeDrawer()
-            }
-            if (
-              side === "top" &&
-              (velocity.y < -150 || offset.y < screen.height * 0.25)
-            ) {
-              state.close()
-            }
-            if (side === "left" && velocity.x < -150) {
-              closeDrawer()
-            }
-            if (side === "right" && velocity.x > 150) {
-              state.close()
-            }
-          }}
-          dragElastic={{
-            top: side === "top" ? 1 : 0,
-            bottom: side === "bottom" ? 1 : 0,
-            left: side === "left" ? 1 : 0,
-            right: side === "right" ? 1 : 0,
-          }}
+          onDragEnd={isMultiSnapBottom ? handleMultiSnapDragEnd : handleBinaryDragEnd}
+          dragElastic={
+            isMultiSnapBottom
+              ? { top: 0.2, bottom: 0.2, left: 0, right: 0 }
+              : {
+                  top: side === "top" ? 1 : 0,
+                  bottom: side === "bottom" ? 1 : 0,
+                  left: side === "left" ? 1 : 0,
+                  right: side === "right" ? 1 : 0,
+                }
+          }
           dragListener={false}
         >
           <Dialog


### PR DESCRIPTION
## Summary

Implements UI/UX plan item #02 (adjustable-height mobile sheet), with an architectural fix identified while scoping it: the mobile drawer and map were laid out as flex-column siblings, not an overlay — the drawer occupied a fixed `h-[60vh]` box below the map, squeezing the map into whatever space was left. That's fine for desktop's fixed-width sidebar, but wrong for a *variable-height* sheet, which would otherwise resize the map's own box on every height change instead of floating over it.

- **Overlay conversion**: mobile drawer moves from a flex sibling into an `absolute`-positioned overlay inside the map's own `relative` container (`AppWrapper.tsx`/`MapWrapper.tsx`). Desktop's sidebar render is untouched.
- **Multi-snap dragging**: `DrawerContent` (`packages/ui/.../Drawer.tsx`) gets new opt-in `snapPointsPx`/`activeSnapIndex`/`onSnapChange` props, gated behind a bottom-sheet-only check so every other consumer — including desktop's `side="left"` sidebar — is byte-identical to before. Uses a controlled Framer Motion value with a velocity-weighted nearest-snap resolution (plus a fling guarantee for fast short flicks) so the sheet springs to the nearest of three points (peek/half/full) on release.
- **Auto-transitions**: `DrawerWrapper.tsx` extends the existing event-selection/streaming effects, mobile-only, so the sheet moves to peek when a search starts, half once results land, and full when an event/venue is selected.
- **Tap-to-collapse**: new `useCollapseDrawerOnMapTap.ts` hook collapses the sheet to peek when tapping open map area. Required adding `event.preventDefault()` to the existing marker-click handlers (`useClusterSelection.ts`, `useMapInstance.ts`) so a marker tap doesn't also trigger the collapse — Mapbox GL JS's interactions are a stack, not automatically mutually exclusive by target.

## Test plan

- [x] `tsc -b`, `eslint`, and the full `vitest` suite (119 tests) pass clean
- [x] Verified live (mobile viewport): map is full-bleed with markers visible behind the sheet; dragging resolves to exact computed peek/half/full pixel targets; tapping open map area collapses an expanded sheet to peek
- [x] Verified live (desktop): sidebar width/position/no-notch/no-transform all pixel-identical to before this change
- [ ] **Needs a real device/manual check**: tapping an actual marker while the sheet is expanded should select the event *without* also collapsing it (the `preventDefault()` fix) — Mapbox's WebGL hit-testing didn't respond to synthetic pointer/mouse events in automated testing, so this specific interaction wasn't mechanically verifiable

🤖 Generated with [Claude Code](https://claude.com/claude-code)