### PR TITLE
Mobile: performer carousel instead of vertical stack

### DIFF
--- a/apps/web/src/EventDetails.tsx
+++ b/apps/web/src/EventDetails.tsx
@@ -24,6 +24,8 @@ import "react-social-icons/instagram"
 import type { EventResponse } from "./hooks/eventsStream"
 import { amArtistFullSchema, type Performer } from "./hooks/eventsStreamSchema"
 import { useEventsContext } from "./providers/eventsProvider"
+import { useIsMobile } from "./providers/Breakpoint"
+import { useCarouselIndex } from "./hooks/useCarouselIndex"
 import { buildArtworkUrl, normalizeBg } from "./lib/artwork"
 import { formatDate, formatTime } from "./lib/dates"
 import { ticketmasterAttractionIds } from "./lib/performers"
@@ -90,6 +92,7 @@ const EventDetails = ({
   const isMountedRef = useRef(true)
   const { selectEvents } = useEventsContext()
   const shouldReduceMotion = useReducedMotion()
+  const isMobile = useIsMobile()
 
   useEffect(() => {
     // Explicitly re-arm on setup (not just the useRef(true) initializer) --
@@ -429,24 +432,124 @@ const EventDetails = ({
         </div>
       )}
 
-      {performers?.map((performer, i) => (
-        <PerformerDetails
-          // Performer name isn't guaranteed unique on a bill (two "TBA"
-          // openers, say) -- index breaks the tie without needing a
-          // fabricated id.
-          key={performer.id ?? `${performer.name}-${i}`}
-          performer={performer}
-          state={
-            performer.name ? performerEnrichment[performer.name] : undefined
-          }
-          futureEvents={futureEventsFor(performer.id)}
-          onRetryFutureEvents={
-            performer.id
-              ? () => fetchFutureEvents(performer.id as string)
-              : undefined
-          }
+      {isMobile && performers && performers.length > 1 ? (
+        <PerformerCarousel
+          performers={performers}
+          performerEnrichment={performerEnrichment}
+          futureEventsFor={futureEventsFor}
+          fetchFutureEvents={fetchFutureEvents}
         />
-      ))}
+      ) : (
+        performers?.map((performer, i) => (
+          <PerformerDetails
+            // Performer name isn't guaranteed unique on a bill (two "TBA"
+            // openers, say) -- index breaks the tie without needing a
+            // fabricated id.
+            key={performer.id ?? `${performer.name}-${i}`}
+            performer={performer}
+            state={
+              performer.name ? performerEnrichment[performer.name] : undefined
+            }
+            futureEvents={futureEventsFor(performer.id)}
+            onRetryFutureEvents={
+              performer.id
+                ? () => fetchFutureEvents(performer.id as string)
+                : undefined
+            }
+          />
+        ))
+      )}
+    </div>
+  )
+}
+
+/** Mobile-only alternative to the plain vertical stack: a single
+ * full-width, horizontally snap-scrolling row (one performer per
+ * "page") instead of stacking every performer's full ArtistCard
+ * top-to-bottom -- a 4-5 act bill was a lot of scroll depth inside an
+ * already height-constrained sheet. Desktop keeps the vertical stack
+ * (more room, nothing to hide behind a swipe there). Only rendered when
+ * there's more than one performer -- a single-performer bill has
+ * nothing to carousel through. */
+const PerformerCarousel = ({
+  performers,
+  performerEnrichment,
+  futureEventsFor,
+  fetchFutureEvents,
+}: {
+  performers: Performer[]
+  performerEnrichment: Record<string, PerformerEnrichmentState>
+  futureEventsFor: (id: string | null | undefined) => FutureEventsState
+  fetchFutureEvents: (id: string) => void
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const { activeIndex, scrollToIndex } = useCarouselIndex(containerRef)
+
+  return (
+    <div>
+      {/* Dots sit above the track, not below it -- a below-the-fold "1 of
+          4" under a full-height ArtistCard needed scrolling past the
+          whole card just to notice the bill had more than one performer.
+          Up top, it's the first thing visible and doubles as a "this
+          swipes" cue, which plain text never was. Each dot is also a
+          jump-to-slide control, not just an indicator. */}
+      <div
+        role="tablist"
+        aria-label="Performers"
+        className="flex items-center justify-center gap-2 pb-2"
+      >
+        {performers.map((performer, i) => (
+          <button
+            key={performer.id ?? `${performer.name}-${i}`}
+            type="button"
+            role="tab"
+            aria-selected={i === activeIndex}
+            aria-label={performer.name ?? `Performer ${i + 1}`}
+            onClick={() => scrollToIndex(i)}
+            className="relative touch-manipulation p-1.5 before:absolute before:-inset-1 before:content-['']"
+          >
+            <span
+              aria-hidden
+              className={
+                i === activeIndex
+                  ? "block h-1.5 w-4 rounded-full bg-(--accent-bg) transition-all"
+                  : "block h-1.5 w-1.5 rounded-full bg-slate-600 transition-all"
+              }
+            />
+          </button>
+        ))}
+      </div>
+      <div
+        ref={containerRef}
+        role="region"
+        aria-label="Performer details"
+        tabIndex={0}
+        className="flex snap-x snap-mandatory overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {performers.map((performer, i) => (
+          <div
+            // See the vertical-stack fallback above for why index breaks
+            // the tie on performer.id.
+            key={performer.id ?? `${performer.name}-${i}`}
+            className="w-full shrink-0 snap-center"
+          >
+            <PerformerDetails
+              performer={performer}
+              state={
+                performer.name
+                  ? performerEnrichment[performer.name]
+                  : undefined
+              }
+              futureEvents={futureEventsFor(performer.id)}
+              onRetryFutureEvents={
+                performer.id
+                  ? () => fetchFutureEvents(performer.id as string)
+                  : undefined
+              }
+            />
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/hooks/useCarouselIndex.ts
+++ b/apps/web/src/hooks/useCarouselIndex.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { RefObject } from "react"
+
+/** Tracks which slide of a horizontally snap-scrolling carousel is
+ * currently active. Assumes every slide is exactly one container-width
+ * wide (e.g. `snap-x snap-mandatory` + `w-full shrink-0` children) --
+ * given that shape, the active index is just scrollLeft/clientWidth
+ * rounded to the nearest integer, which is simpler and more precise here
+ * than an IntersectionObserver (no threshold/rootMargin fuzziness to
+ * tune) -- see useTopMostVisibleInScrollContainer (listItemObserver.ts)
+ * for the more general version this doesn't need. */
+export function useCarouselIndex(
+  containerRef: RefObject<HTMLElement | null>
+) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const compute = () => {
+      rafRef.current = null
+      const { scrollLeft, clientWidth } = container
+      if (clientWidth === 0) return
+      setActiveIndex(Math.round(scrollLeft / clientWidth))
+    }
+
+    const onScroll = () => {
+      if (rafRef.current != null) return
+      rafRef.current = window.requestAnimationFrame(compute)
+    }
+
+    container.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      container.removeEventListener("scroll", onScroll)
+      if (rafRef.current != null) window.cancelAnimationFrame(rafRef.current)
+    }
+  }, [containerRef])
+
+  const scrollToIndex = useCallback(
+    (index: number) => {
+      const container = containerRef.current
+      if (!container) return
+      container.scrollTo({
+        left: index * container.clientWidth,
+        behavior: "smooth",
+      })
+    },
+    [containerRef]
+  )
+
+  return { activeIndex, scrollToIndex }
+}


### PR DESCRIPTION
## Summary

Implements UI/UX plan item #03. Stacking every performer's full `ArtistCard` top-to-bottom made a 4-5 act bill a lot of scroll depth inside the drawer's already height-constrained mobile sheet.

- On mobile, performers now render as a horizontally snap-scrolling carousel (one full-width slide per performer) instead of a vertical stack. Desktop is unaffected — more room there, nothing to hide behind a swipe.
- Swipeability is signaled by a dot row *above* the track rather than a text counter below it — a below-the-fold "1 of 4" under a full-height card needed scrolling past the whole card just to discover the bill had more than one performer. Each dot also jumps directly to that slide.
- New `useCarouselIndex.ts` hook tracks the active slide via `scrollLeft / clientWidth` — simpler and more precise than an `IntersectionObserver` given every slide is exactly one container-width wide by construction.
- Only rendered when there's more than one performer; single-act bills and desktop keep the original vertical stack untouched.

## Test plan

- [x] `tsc -b`, `eslint`, and the full `vitest` suite (119 tests) pass clean
- [x] Verified live on a real 4-performer bill (mobile viewport): dots render immediately above the first card, start on "performer 1" highlighted; scrolling/tapping dots updates the active dot and the underlying slide correctly (confirmed via `scrollLeft` math and `aria-selected` state, not just visually)
- [x] Verified desktop renders the original vertical stack for the same event, no carousel

🤖 Generated with [Claude Code](https://claude.com/claude-code)